### PR TITLE
Integrate Microsoft Agent Framework RC as first-class provider

### DIFF
--- a/agent_gantry/adapters/tool_spec/providers.py
+++ b/agent_gantry/adapters/tool_spec/providers.py
@@ -2,12 +2,13 @@
 Provider-specific tool specification adapters.
 
 Implementations for OpenAI (Chat Completions & Responses API), Anthropic,
-Gemini, Mistral, and Groq.
+Gemini, Mistral, Groq, and Microsoft Agent Framework.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 from typing import TYPE_CHECKING, Any
 
 from agent_gantry.adapters.tool_spec.base import ToolCallPayload
@@ -483,19 +484,18 @@ class GroqAdapter(OpenAIAdapter):
         return "groq"
 
 
-class AgentFrameworkAdapter:
+_logger = logging.getLogger(__name__)
+
+
+class AgentFrameworkAdapter(OpenAIAdapter):
     """
     Tool specification adapter for Microsoft Agent Framework (RC+).
 
     Microsoft Agent Framework uses OpenAI-compatible function calling format
-    for its tool schemas. Agents accept plain Python callables as tools, but
-    the underlying schema exchange with LLM providers follows the OpenAI
-    function calling convention.
+    for its tool schemas, so this inherits from ``OpenAIAdapter`` and adds:
 
-    This adapter provides:
-    - Schema conversion matching AF's internal expectations
-    - Tool call payload parsing from AF's function invocation results
-    - Result formatting compatible with AF's tool result protocol
+    - Optional ``include_metadata`` support for Gantry provenance info
+    - Simplified AF internal payload format (``{"name": ..., "arguments": ...}``)
 
     For direct tool wrapping (Python callables), use the higher-level
     ``agent_gantry.integrations.agent_framework_bridge`` module instead.
@@ -513,25 +513,10 @@ class AgentFrameworkAdapter:
         """
         Convert ToolDefinition to Microsoft Agent Framework tool schema.
 
-        AF uses OpenAI-style function schemas internally. The schema includes
-        an additional ``metadata`` key for Gantry-specific provenance info
-        that AF ignores but is useful for round-tripping.
-
-        Args:
-            tool: The tool definition to convert
-            **options: Additional options (e.g., include_metadata=True)
-
-        Returns:
-            Agent Framework compatible tool schema
+        Delegates to OpenAIAdapter for the base schema and optionally appends
+        Gantry-specific metadata for provenance tracking.
         """
-        schema: dict[str, Any] = {
-            "type": "function",
-            "function": {
-                "name": tool.name,
-                "description": tool.description,
-                "parameters": tool.parameters_schema,
-            },
-        }
+        schema = super().to_provider_schema(tool, **options)
         if options.get("include_metadata", False):
             schema["function"]["metadata"] = {
                 "namespace": tool.namespace,
@@ -547,38 +532,29 @@ class AgentFrameworkAdapter:
         """
         Parse a Microsoft Agent Framework tool call payload.
 
-        AF emits tool calls in OpenAI-compatible format:
-        {
-            "id": "call_xxx",
-            "type": "function",
-            "function": {
-                "name": "tool_name",
-                "arguments": "{\"arg\": \"value\"}"
-            }
-        }
-
-        Also supports the simplified format used by AF's internal dispatch:
-        {
-            "name": "tool_name",
-            "arguments": {"arg": "value"}
-        }
+        Handles both the standard OpenAI-style format (via super()) and the
+        simplified format used by AF's internal dispatch:
+        ``{"name": "tool_name", "arguments": {"arg": "value"}}``
         """
-        # Handle full OpenAI-style format
+        # Standard OpenAI format — delegate to parent
         if "function" in payload:
-            tool_call_id = payload.get("id")
-            function_data = payload["function"]
-            tool_name = function_data.get("name", "")
-            arguments = function_data.get("arguments", {})
-        else:
-            # Simplified AF internal format
-            tool_call_id = payload.get("id") or payload.get("call_id")
-            tool_name = payload.get("name", "")
-            arguments = payload.get("arguments", {})
+            return super().from_provider_payload(payload)
+
+        # Simplified AF internal format
+        tool_call_id = payload.get("id") or payload.get("call_id")
+        tool_name = payload.get("name", "")
+        arguments = payload.get("arguments", {})
 
         if isinstance(arguments, str):
             try:
                 arguments = json.loads(arguments)
             except json.JSONDecodeError:
+                _logger.warning(
+                    "AgentFrameworkAdapter: malformed JSON in tool arguments "
+                    "for '%s', defaulting to empty dict: %s",
+                    tool_name,
+                    arguments[:200] if isinstance(arguments, str) else arguments,
+                )
                 arguments = {}
 
         return ToolCallPayload(
@@ -587,34 +563,3 @@ class AgentFrameworkAdapter:
             arguments=arguments,
             raw_payload=payload,
         )
-
-    def to_tool_call(
-        self,
-        payload: ToolCallPayload,
-        timeout_ms: int = 30000,
-        retry_count: int = 0,
-    ) -> ToolCall:
-        return ToolCall(
-            tool_name=payload.tool_name,
-            arguments=payload.arguments,
-            timeout_ms=timeout_ms,
-            retry_count=retry_count,
-            trace_id=payload.tool_call_id,
-        )
-
-    def format_tool_result(
-        self,
-        tool_name: str,
-        result: Any,
-        tool_call_id: str | None = None,
-    ) -> dict[str, Any]:
-        """Format result for Microsoft Agent Framework tool response."""
-        content = result if isinstance(result, str) else json.dumps(result)
-        response: dict[str, Any] = {
-            "role": "tool",
-            "content": content,
-            "name": tool_name,
-        }
-        if tool_call_id:
-            response["tool_call_id"] = tool_call_id
-        return response

--- a/agent_gantry/adapters/tool_spec/providers.py
+++ b/agent_gantry/adapters/tool_spec/providers.py
@@ -481,3 +481,140 @@ class GroqAdapter(OpenAIAdapter):
     @property
     def dialect_name(self) -> str:
         return "groq"
+
+
+class AgentFrameworkAdapter:
+    """
+    Tool specification adapter for Microsoft Agent Framework (RC+).
+
+    Microsoft Agent Framework uses OpenAI-compatible function calling format
+    for its tool schemas. Agents accept plain Python callables as tools, but
+    the underlying schema exchange with LLM providers follows the OpenAI
+    function calling convention.
+
+    This adapter provides:
+    - Schema conversion matching AF's internal expectations
+    - Tool call payload parsing from AF's function invocation results
+    - Result formatting compatible with AF's tool result protocol
+
+    For direct tool wrapping (Python callables), use the higher-level
+    ``agent_gantry.integrations.agent_framework_bridge`` module instead.
+    """
+
+    @property
+    def dialect_name(self) -> str:
+        return "agent_framework"
+
+    def to_provider_schema(
+        self,
+        tool: ToolDefinition,
+        **options: Any,
+    ) -> dict[str, Any]:
+        """
+        Convert ToolDefinition to Microsoft Agent Framework tool schema.
+
+        AF uses OpenAI-style function schemas internally. The schema includes
+        an additional ``metadata`` key for Gantry-specific provenance info
+        that AF ignores but is useful for round-tripping.
+
+        Args:
+            tool: The tool definition to convert
+            **options: Additional options (e.g., include_metadata=True)
+
+        Returns:
+            Agent Framework compatible tool schema
+        """
+        schema: dict[str, Any] = {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.parameters_schema,
+            },
+        }
+        if options.get("include_metadata", False):
+            schema["function"]["metadata"] = {
+                "namespace": tool.namespace,
+                "version": tool.version,
+                "source": tool.source.value if hasattr(tool.source, "value") else str(tool.source),
+            }
+        return schema
+
+    def from_provider_payload(
+        self,
+        payload: dict[str, Any],
+    ) -> ToolCallPayload:
+        """
+        Parse a Microsoft Agent Framework tool call payload.
+
+        AF emits tool calls in OpenAI-compatible format:
+        {
+            "id": "call_xxx",
+            "type": "function",
+            "function": {
+                "name": "tool_name",
+                "arguments": "{\"arg\": \"value\"}"
+            }
+        }
+
+        Also supports the simplified format used by AF's internal dispatch:
+        {
+            "name": "tool_name",
+            "arguments": {"arg": "value"}
+        }
+        """
+        # Handle full OpenAI-style format
+        if "function" in payload:
+            tool_call_id = payload.get("id")
+            function_data = payload["function"]
+            tool_name = function_data.get("name", "")
+            arguments = function_data.get("arguments", {})
+        else:
+            # Simplified AF internal format
+            tool_call_id = payload.get("id") or payload.get("call_id")
+            tool_name = payload.get("name", "")
+            arguments = payload.get("arguments", {})
+
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                arguments = {}
+
+        return ToolCallPayload(
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            arguments=arguments,
+            raw_payload=payload,
+        )
+
+    def to_tool_call(
+        self,
+        payload: ToolCallPayload,
+        timeout_ms: int = 30000,
+        retry_count: int = 0,
+    ) -> ToolCall:
+        return ToolCall(
+            tool_name=payload.tool_name,
+            arguments=payload.arguments,
+            timeout_ms=timeout_ms,
+            retry_count=retry_count,
+            trace_id=payload.tool_call_id,
+        )
+
+    def format_tool_result(
+        self,
+        tool_name: str,
+        result: Any,
+        tool_call_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Format result for Microsoft Agent Framework tool response."""
+        content = result if isinstance(result, str) else json.dumps(result)
+        response: dict[str, Any] = {
+            "role": "tool",
+            "content": content,
+            "name": tool_name,
+        }
+        if tool_call_id:
+            response["tool_call_id"] = tool_call_id
+        return response

--- a/agent_gantry/adapters/tool_spec/registry.py
+++ b/agent_gantry/adapters/tool_spec/registry.py
@@ -54,6 +54,7 @@ class DialectRegistry:
         """Register all built-in adapters."""
         # Import here to avoid circular imports
         from agent_gantry.adapters.tool_spec.providers import (
+            AgentFrameworkAdapter,
             AnthropicAdapter,
             GeminiAdapter,
             GroqAdapter,
@@ -68,6 +69,7 @@ class DialectRegistry:
         self.register(GeminiAdapter())
         self.register(MistralAdapter())
         self.register(GroqAdapter())
+        self.register(AgentFrameworkAdapter())
 
     def register(self, adapter: ToolSpecAdapter) -> None:
         """

--- a/agent_gantry/integrations/__init__.py
+++ b/agent_gantry/integrations/__init__.py
@@ -1,9 +1,11 @@
 """
 Framework integrations for Agent-Gantry.
 
-Integrations with LangChain, AutoGen, LlamaIndex, CrewAI, etc.
+Integrations with LangChain, AutoGen, LlamaIndex, CrewAI,
+Microsoft Agent Framework, etc.
 """
 
+from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
 from agent_gantry.integrations.framework_adapters import fetch_framework_tools
 from agent_gantry.integrations.semantic_tools import (
     SemanticToolsDecorator,
@@ -12,6 +14,7 @@ from agent_gantry.integrations.semantic_tools import (
 )
 
 __all__: list[str] = [
+    "GantryToolBridge",
     "SemanticToolSelector",
     "SemanticToolsDecorator",
     "with_semantic_tools",

--- a/agent_gantry/integrations/agent_framework_bridge.py
+++ b/agent_gantry/integrations/agent_framework_bridge.py
@@ -32,8 +32,8 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
 import functools
+import inspect
 import json
 import logging
 from typing import TYPE_CHECKING, Annotated, Any
@@ -91,38 +91,23 @@ def _build_callable_for_tool(
         # No-arg tool
         async def wrapper() -> str:
             return await _execute()
-    elif len(properties) == 1:
-        param_name = next(iter(properties))
-        param_info = properties[param_name]
-        param_desc = param_info.get("description", f"Parameter: {param_name}")
-
-        # Use **kwargs so callers can pass keyword args by the real param name
-        async def wrapper(**kwargs: Any) -> str:
-            return await _execute(**kwargs)
-
-        import inspect
-
-        new_params = [
-            inspect.Parameter(
-                param_name,
-                inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                annotation=Annotated[
-                    _json_type_to_python(param_info.get("type", "string")),
-                    Field(description=param_desc),
-                ],
-                default=inspect.Parameter.empty
-                if param_name in required_params
-                else param_info.get("default"),
-            ),
-            inspect.Parameter("kwargs", inspect.Parameter.VAR_KEYWORD),
-        ]
-        wrapper.__signature__ = inspect.Signature(parameters=new_params)  # type: ignore[attr-defined]
     else:
-        # Multi-arg tool: build a generic **kwargs wrapper with proper signature
-        async def wrapper(**kwargs: Any) -> str:
-            return await _execute(**kwargs)
+        # Tool with one or more arguments: support both positional and keyword args
+        param_names = list(properties.keys())
 
-        import inspect
+        async def wrapper(*args: Any, **kwargs: Any) -> str:
+            # Map positional arguments to parameter names based on JSON schema order
+            if args:
+                if len(args) > len(param_names):
+                    raise TypeError(
+                        f"{tool_name}() takes at most {len(param_names)} positional "
+                        f"arguments but {len(args)} were given"
+                    )
+                for idx, value in enumerate(args):
+                    p_name = param_names[idx]
+                    if p_name not in kwargs:
+                        kwargs[p_name] = value
+            return await _execute(**kwargs)
 
         new_params = []
         for p_name, p_info in properties.items():
@@ -165,6 +150,11 @@ def _json_type_to_python(json_type: str) -> type:
         "object": dict,
     }
     return mapping.get(json_type, str)
+
+
+def _cache_key(tool_def: ToolDefinition) -> str:
+    """Build a namespace-qualified cache key for a tool definition."""
+    return f"{tool_def.namespace}:{tool_def.name}"
 
 
 class GantryToolBridge:
@@ -220,6 +210,7 @@ class GantryToolBridge:
         limit: int = 5,
         score_threshold: float | None = None,
         cache: bool = True,
+        **query_kwargs: Any,
     ) -> list[Any]:
         """
         Retrieve semantically relevant tools as AF-compatible callables.
@@ -235,6 +226,11 @@ class GantryToolBridge:
             score_threshold: Override the bridge's default score threshold.
             cache: Whether to reuse previously wrapped callables for the same
                    tool (avoids re-creating wrappers). Default: True.
+            **query_kwargs: Additional keyword arguments passed through to
+                ``ToolQuery`` (e.g. ``namespaces``, ``required_capabilities``,
+                ``sources``, ``exclude_deprecated``, ``enable_reranking``) and
+                to ``ConversationContext`` (e.g. ``user_capabilities``,
+                ``conversation_summary``, ``recent_messages``).
 
         Returns:
             List of async callables suitable for AF agent ``tools=[...]``.
@@ -243,23 +239,31 @@ class GantryToolBridge:
 
         threshold = score_threshold if score_threshold is not None else self._score_threshold
 
+        # Separate context-level kwargs from query-level kwargs
+        context_fields = set(ConversationContext.model_fields.keys()) - {"query"}
+        context_kwargs = {k: v for k, v in query_kwargs.items() if k in context_fields}
+        tool_query_fields = set(ToolQuery.model_fields.keys()) - {"context", "limit", "score_threshold"}
+        tq_kwargs = {k: v for k, v in query_kwargs.items() if k in tool_query_fields}
+
         result = await self._gantry.retrieve(
             ToolQuery(
-                context=ConversationContext(query=query),
+                context=ConversationContext(query=query, **context_kwargs),
                 limit=limit,
                 score_threshold=threshold,
+                **tq_kwargs,
             )
         )
 
         tools = []
         for scored_tool in result.tools:
             tool_def = scored_tool.tool
-            if cache and tool_def.name in self._tool_cache:
-                tools.append(self._tool_cache[tool_def.name])
+            key = _cache_key(tool_def)
+            if cache and key in self._tool_cache:
+                tools.append(self._tool_cache[key])
             else:
                 wrapper = _build_callable_for_tool(tool_def, self._gantry)
                 if cache:
-                    self._tool_cache[tool_def.name] = wrapper
+                    self._tool_cache[key] = wrapper
                 tools.append(wrapper)
 
         logger.debug(
@@ -289,11 +293,12 @@ class GantryToolBridge:
         """
         tools = []
         for tool_def in tool_definitions:
-            if tool_def.name in self._tool_cache:
-                tools.append(self._tool_cache[tool_def.name])
+            key = _cache_key(tool_def)
+            if key in self._tool_cache:
+                tools.append(self._tool_cache[key])
             else:
                 wrapper = _build_callable_for_tool(tool_def, self._gantry)
-                self._tool_cache[tool_def.name] = wrapper
+                self._tool_cache[key] = wrapper
                 tools.append(wrapper)
         return tools
 
@@ -307,10 +312,11 @@ class GantryToolBridge:
         Returns:
             An async callable suitable for AF agent ``tools=[...]``.
         """
-        if tool_def.name in self._tool_cache:
-            return self._tool_cache[tool_def.name]
+        key = _cache_key(tool_def)
+        if key in self._tool_cache:
+            return self._tool_cache[key]
         wrapper = _build_callable_for_tool(tool_def, self._gantry)
-        self._tool_cache[tool_def.name] = wrapper
+        self._tool_cache[key] = wrapper
         return wrapper
 
     def clear_cache(self) -> None:
@@ -323,6 +329,8 @@ class GantryToolBridge:
         *,
         limit: int = 5,
         score_threshold: float | None = None,
+        cache: bool = True,
+        **query_kwargs: Any,
     ) -> list[tuple[Any, float]]:
         """
         Retrieve tools with their relevance scores for observability.
@@ -334,6 +342,10 @@ class GantryToolBridge:
             query: The user query to match tools against.
             limit: Maximum number of tools to return.
             score_threshold: Override the bridge's default score threshold.
+            cache: Whether to reuse previously wrapped callables for the same
+                   tool (avoids re-creating wrappers). Default: True.
+            **query_kwargs: Additional keyword arguments passed through to
+                ``ToolQuery`` and ``ConversationContext``.
 
         Returns:
             List of (callable, score) tuples.
@@ -342,18 +354,30 @@ class GantryToolBridge:
 
         threshold = score_threshold if score_threshold is not None else self._score_threshold
 
+        context_fields = set(ConversationContext.model_fields.keys()) - {"query"}
+        context_kwargs = {k: v for k, v in query_kwargs.items() if k in context_fields}
+        tool_query_fields = set(ToolQuery.model_fields.keys()) - {"context", "limit", "score_threshold"}
+        tq_kwargs = {k: v for k, v in query_kwargs.items() if k in tool_query_fields}
+
         result = await self._gantry.retrieve(
             ToolQuery(
-                context=ConversationContext(query=query),
+                context=ConversationContext(query=query, **context_kwargs),
                 limit=limit,
                 score_threshold=threshold,
+                **tq_kwargs,
             )
         )
 
         tools_with_scores = []
         for scored_tool in result.tools:
             tool_def = scored_tool.tool
-            wrapper = _build_callable_for_tool(tool_def, self._gantry)
+            key = _cache_key(tool_def)
+            if cache and key in self._tool_cache:
+                wrapper = self._tool_cache[key]
+            else:
+                wrapper = _build_callable_for_tool(tool_def, self._gantry)
+                if cache:
+                    self._tool_cache[key] = wrapper
             tools_with_scores.append((wrapper, scored_tool.final_score))
 
         return tools_with_scores

--- a/agent_gantry/integrations/agent_framework_bridge.py
+++ b/agent_gantry/integrations/agent_framework_bridge.py
@@ -1,0 +1,359 @@
+"""
+Microsoft Agent Framework bridge for Agent-Gantry.
+
+Provides seamless integration between Agent-Gantry's semantic tool routing
+and Microsoft Agent Framework (RC+) agents. The bridge converts Gantry
+tool definitions into Python callables that AF agents can invoke directly,
+enabling dynamic tool selection that reduces token usage in multi-agent systems.
+
+Key classes:
+    - ``GantryToolBridge``: Main bridge that wraps Gantry tools for AF agents.
+
+Usage:
+    from agent_gantry import AgentGantry
+    from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+
+    @gantry.register
+    def get_weather(city: str) -> str:
+        '''Get current weather for a city.'''
+        return f"Weather in {city}: Sunny, 22C"
+
+    await gantry.sync()
+
+    bridge = GantryToolBridge(gantry)
+    tools = await bridge.get_tools("What's the weather?", limit=3)
+
+    # Pass directly to any AF agent:
+    agent = client.as_agent(name="Assistant", instructions="...", tools=tools)
+    result = await agent.run("What's the weather in London?")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import json
+import logging
+from typing import TYPE_CHECKING, Annotated, Any
+
+from pydantic import Field
+
+from agent_gantry.schema.execution import ToolCall
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+    from agent_gantry.schema.tool import ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+
+def _build_callable_for_tool(
+    tool_def: ToolDefinition,
+    gantry: AgentGantry,
+) -> Any:
+    """
+    Build a Python callable wrapping a Gantry tool for Microsoft Agent Framework.
+
+    The callable is created with proper type annotations (using ``Annotated``
+    and Pydantic ``Field``) so that AF can auto-generate the correct function
+    schema for the LLM. This avoids sending raw JSON schemas and lets AF's
+    native function-tool infrastructure handle serialisation.
+
+    Args:
+        tool_def: The Gantry ToolDefinition to wrap.
+        gantry: The AgentGantry instance for execution.
+
+    Returns:
+        An async callable suitable for passing to AF agent ``tools=[...]``.
+    """
+    tool_name = tool_def.name
+    tool_desc = tool_def.description
+    params_schema = tool_def.parameters_schema
+
+    # Extract parameter info from the JSON Schema
+    properties = params_schema.get("properties", {})
+    required_params = set(params_schema.get("required", []))
+
+    async def _execute(**kwargs: Any) -> str:
+        result = await gantry.execute(
+            ToolCall(tool_name=tool_name, arguments=kwargs)
+        )
+        if result.status.value == "success":
+            val = result.result
+            return val if isinstance(val, str) else json.dumps(val)
+        return json.dumps({"error": result.error or "Tool execution failed"})
+
+    # Build the wrapper with proper annotations for AF
+    # AF inspects __name__, __doc__, and __annotations__ to generate schemas
+    if len(properties) == 0:
+        # No-arg tool
+        async def wrapper() -> str:
+            return await _execute()
+    elif len(properties) == 1:
+        param_name = next(iter(properties))
+        param_info = properties[param_name]
+        param_desc = param_info.get("description", f"Parameter: {param_name}")
+
+        # Use **kwargs so callers can pass keyword args by the real param name
+        async def wrapper(**kwargs: Any) -> str:
+            return await _execute(**kwargs)
+
+        import inspect
+
+        new_params = [
+            inspect.Parameter(
+                param_name,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=Annotated[
+                    _json_type_to_python(param_info.get("type", "string")),
+                    Field(description=param_desc),
+                ],
+                default=inspect.Parameter.empty
+                if param_name in required_params
+                else param_info.get("default"),
+            ),
+            inspect.Parameter("kwargs", inspect.Parameter.VAR_KEYWORD),
+        ]
+        wrapper.__signature__ = inspect.Signature(parameters=new_params)  # type: ignore[attr-defined]
+    else:
+        # Multi-arg tool: build a generic **kwargs wrapper with proper signature
+        async def wrapper(**kwargs: Any) -> str:
+            return await _execute(**kwargs)
+
+        import inspect
+
+        new_params = []
+        for p_name, p_info in properties.items():
+            p_desc = p_info.get("description", f"Parameter: {p_name}")
+            p_type = _json_type_to_python(p_info.get("type", "string"))
+            default = (
+                inspect.Parameter.empty
+                if p_name in required_params
+                else p_info.get("default")
+            )
+            new_params.append(
+                inspect.Parameter(
+                    p_name,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=Annotated[p_type, Field(description=p_desc)],
+                    default=default,
+                )
+            )
+        new_params.append(
+            inspect.Parameter("kwargs", inspect.Parameter.VAR_KEYWORD)
+        )
+        wrapper.__signature__ = inspect.Signature(parameters=new_params)  # type: ignore[attr-defined]
+
+    wrapper.__name__ = tool_name
+    wrapper.__qualname__ = tool_name
+    wrapper.__doc__ = tool_desc
+    functools.update_wrapper(wrapper, wrapper)
+
+    return wrapper
+
+
+def _json_type_to_python(json_type: str) -> type:
+    """Map JSON Schema type strings to Python types."""
+    mapping: dict[str, type] = {
+        "string": str,
+        "integer": int,
+        "number": float,
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }
+    return mapping.get(json_type, str)
+
+
+class GantryToolBridge:
+    """
+    Bridge between Agent-Gantry and Microsoft Agent Framework.
+
+    Retrieves semantically relevant tools from Gantry and wraps them as
+    Python callables that AF agents can use directly. This is the primary
+    integration point for production multi-agent systems where token savings
+    from semantic routing are critical.
+
+    The bridge supports two usage patterns:
+
+    1. **Query-time retrieval** (recommended for token savings):
+       Retrieve only the relevant tools for each query, minimising the
+       tool definitions sent to the LLM.
+
+       .. code-block:: python
+
+           bridge = GantryToolBridge(gantry)
+           tools = await bridge.get_tools("book a flight", limit=3)
+           agent = client.as_agent(tools=tools, ...)
+
+    2. **Pre-built tool set**:
+       Build tools once from specific Gantry tool definitions for agents
+       that need a fixed tool set.
+
+       .. code-block:: python
+
+           bridge = GantryToolBridge(gantry)
+           tools = bridge.wrap_tools(my_tool_definitions)
+           agent = client.as_agent(tools=tools, ...)
+
+    Args:
+        gantry: The AgentGantry instance providing tool retrieval and execution.
+        score_threshold: Minimum relevance score for tool selection (default: 0.3).
+    """
+
+    def __init__(
+        self,
+        gantry: AgentGantry,
+        *,
+        score_threshold: float = 0.3,
+    ) -> None:
+        self._gantry = gantry
+        self._score_threshold = score_threshold
+        self._tool_cache: dict[str, Any] = {}
+
+    async def get_tools(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        score_threshold: float | None = None,
+        cache: bool = True,
+    ) -> list[Any]:
+        """
+        Retrieve semantically relevant tools as AF-compatible callables.
+
+        This is the primary method for dynamic tool selection. It queries
+        Gantry's semantic router, selects the top-k tools, and wraps each
+        as a Python async callable with proper type annotations that
+        Microsoft Agent Framework can introspect.
+
+        Args:
+            query: The user query or task description to match tools against.
+            limit: Maximum number of tools to return (default: 5).
+            score_threshold: Override the bridge's default score threshold.
+            cache: Whether to reuse previously wrapped callables for the same
+                   tool (avoids re-creating wrappers). Default: True.
+
+        Returns:
+            List of async callables suitable for AF agent ``tools=[...]``.
+        """
+        from agent_gantry.schema.query import ConversationContext, ToolQuery
+
+        threshold = score_threshold if score_threshold is not None else self._score_threshold
+
+        result = await self._gantry.retrieve(
+            ToolQuery(
+                context=ConversationContext(query=query),
+                limit=limit,
+                score_threshold=threshold,
+            )
+        )
+
+        tools = []
+        for scored_tool in result.tools:
+            tool_def = scored_tool.tool
+            if cache and tool_def.name in self._tool_cache:
+                tools.append(self._tool_cache[tool_def.name])
+            else:
+                wrapper = _build_callable_for_tool(tool_def, self._gantry)
+                if cache:
+                    self._tool_cache[tool_def.name] = wrapper
+                tools.append(wrapper)
+
+        logger.debug(
+            "GantryToolBridge: selected %d/%d tools for query '%s' (threshold=%.2f)",
+            len(tools),
+            result.candidate_count,
+            query[:50],
+            threshold,
+        )
+        return tools
+
+    def wrap_tools(
+        self,
+        tool_definitions: list[ToolDefinition],
+    ) -> list[Any]:
+        """
+        Wrap specific Gantry tool definitions as AF-compatible callables.
+
+        Use this when you already have the tool definitions and want to
+        create the callable wrappers without going through semantic retrieval.
+
+        Args:
+            tool_definitions: List of ToolDefinition objects to wrap.
+
+        Returns:
+            List of async callables suitable for AF agent ``tools=[...]``.
+        """
+        tools = []
+        for tool_def in tool_definitions:
+            if tool_def.name in self._tool_cache:
+                tools.append(self._tool_cache[tool_def.name])
+            else:
+                wrapper = _build_callable_for_tool(tool_def, self._gantry)
+                self._tool_cache[tool_def.name] = wrapper
+                tools.append(wrapper)
+        return tools
+
+    def wrap_single(self, tool_def: ToolDefinition) -> Any:
+        """
+        Wrap a single Gantry tool definition as an AF-compatible callable.
+
+        Args:
+            tool_def: The ToolDefinition to wrap.
+
+        Returns:
+            An async callable suitable for AF agent ``tools=[...]``.
+        """
+        if tool_def.name in self._tool_cache:
+            return self._tool_cache[tool_def.name]
+        wrapper = _build_callable_for_tool(tool_def, self._gantry)
+        self._tool_cache[tool_def.name] = wrapper
+        return wrapper
+
+    def clear_cache(self) -> None:
+        """Clear the cached tool wrappers."""
+        self._tool_cache.clear()
+
+    async def get_tools_with_scores(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        score_threshold: float | None = None,
+    ) -> list[tuple[Any, float]]:
+        """
+        Retrieve tools with their relevance scores for observability.
+
+        Same as ``get_tools`` but also returns the semantic relevance score
+        for each tool, useful for debugging and monitoring token savings.
+
+        Args:
+            query: The user query to match tools against.
+            limit: Maximum number of tools to return.
+            score_threshold: Override the bridge's default score threshold.
+
+        Returns:
+            List of (callable, score) tuples.
+        """
+        from agent_gantry.schema.query import ConversationContext, ToolQuery
+
+        threshold = score_threshold if score_threshold is not None else self._score_threshold
+
+        result = await self._gantry.retrieve(
+            ToolQuery(
+                context=ConversationContext(query=query),
+                limit=limit,
+                score_threshold=threshold,
+            )
+        )
+
+        tools_with_scores = []
+        for scored_tool in result.tools:
+            tool_def = scored_tool.tool
+            wrapper = _build_callable_for_tool(tool_def, self._gantry)
+            tools_with_scores.append((wrapper, scored_tool.final_score))
+
+        return tools_with_scores

--- a/agent_gantry/integrations/agent_framework_bridge.py
+++ b/agent_gantry/integrations/agent_framework_bridge.py
@@ -32,7 +32,6 @@ Usage:
 
 from __future__ import annotations
 
-import functools
 import inspect
 import json
 import logging
@@ -44,6 +43,7 @@ from agent_gantry.schema.execution import ToolCall
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
+    from agent_gantry.schema.query import RetrievalResult
     from agent_gantry.schema.tool import ToolDefinition
 
 logger = logging.getLogger(__name__)
@@ -126,15 +126,11 @@ def _build_callable_for_tool(
                     default=default,
                 )
             )
-        new_params.append(
-            inspect.Parameter("kwargs", inspect.Parameter.VAR_KEYWORD)
-        )
         wrapper.__signature__ = inspect.Signature(parameters=new_params)  # type: ignore[attr-defined]
 
     wrapper.__name__ = tool_name
     wrapper.__qualname__ = tool_name
     wrapper.__doc__ = tool_desc
-    functools.update_wrapper(wrapper, wrapper)
 
     return wrapper
 
@@ -203,6 +199,48 @@ class GantryToolBridge:
         self._score_threshold = score_threshold
         self._tool_cache: dict[str, Any] = {}
 
+    async def _retrieve(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        score_threshold: float | None = None,
+        **query_kwargs: Any,
+    ) -> RetrievalResult:
+        """Shared retrieval logic for get_tools and get_tools_with_scores."""
+        from agent_gantry.schema.query import ConversationContext, ToolQuery
+
+        threshold = score_threshold if score_threshold is not None else self._score_threshold
+
+        # Separate context-level kwargs from query-level kwargs
+        context_fields = set(ConversationContext.model_fields.keys()) - {"query"}
+        context_kwargs = {k: v for k, v in query_kwargs.items() if k in context_fields}
+        tool_query_fields = set(ToolQuery.model_fields.keys()) - {"context", "limit", "score_threshold"}
+        tq_kwargs = {k: v for k, v in query_kwargs.items() if k in tool_query_fields}
+
+        return await self._gantry.retrieve(
+            ToolQuery(
+                context=ConversationContext(query=query, **context_kwargs),
+                limit=limit,
+                score_threshold=threshold,
+                **tq_kwargs,
+            )
+        )
+
+    def _get_or_build(
+        self,
+        tool_def: ToolDefinition,
+        cache: bool,
+    ) -> Any:
+        """Look up a cached wrapper or build a new one."""
+        key = _cache_key(tool_def)
+        if cache and key in self._tool_cache:
+            return self._tool_cache[key]
+        wrapper = _build_callable_for_tool(tool_def, self._gantry)
+        if cache:
+            self._tool_cache[key] = wrapper
+        return wrapper
+
     async def get_tools(
         self,
         query: str,
@@ -235,49 +273,25 @@ class GantryToolBridge:
         Returns:
             List of async callables suitable for AF agent ``tools=[...]``.
         """
-        from agent_gantry.schema.query import ConversationContext, ToolQuery
-
-        threshold = score_threshold if score_threshold is not None else self._score_threshold
-
-        # Separate context-level kwargs from query-level kwargs
-        context_fields = set(ConversationContext.model_fields.keys()) - {"query"}
-        context_kwargs = {k: v for k, v in query_kwargs.items() if k in context_fields}
-        tool_query_fields = set(ToolQuery.model_fields.keys()) - {"context", "limit", "score_threshold"}
-        tq_kwargs = {k: v for k, v in query_kwargs.items() if k in tool_query_fields}
-
-        result = await self._gantry.retrieve(
-            ToolQuery(
-                context=ConversationContext(query=query, **context_kwargs),
-                limit=limit,
-                score_threshold=threshold,
-                **tq_kwargs,
-            )
+        result = await self._retrieve(
+            query, limit=limit, score_threshold=score_threshold, **query_kwargs
         )
 
-        tools = []
-        for scored_tool in result.tools:
-            tool_def = scored_tool.tool
-            key = _cache_key(tool_def)
-            if cache and key in self._tool_cache:
-                tools.append(self._tool_cache[key])
-            else:
-                wrapper = _build_callable_for_tool(tool_def, self._gantry)
-                if cache:
-                    self._tool_cache[key] = wrapper
-                tools.append(wrapper)
+        tools = [self._get_or_build(st.tool, cache) for st in result.tools]
 
         logger.debug(
-            "GantryToolBridge: selected %d/%d tools for query '%s' (threshold=%.2f)",
+            "GantryToolBridge: selected %d/%d tools for query '%s'",
             len(tools),
             result.candidate_count,
             query[:50],
-            threshold,
         )
         return tools
 
     def wrap_tools(
         self,
         tool_definitions: list[ToolDefinition],
+        *,
+        cache: bool = True,
     ) -> list[Any]:
         """
         Wrap specific Gantry tool definitions as AF-compatible callables.
@@ -287,20 +301,12 @@ class GantryToolBridge:
 
         Args:
             tool_definitions: List of ToolDefinition objects to wrap.
+            cache: Whether to cache/reuse wrappers (default: True).
 
         Returns:
             List of async callables suitable for AF agent ``tools=[...]``.
         """
-        tools = []
-        for tool_def in tool_definitions:
-            key = _cache_key(tool_def)
-            if key in self._tool_cache:
-                tools.append(self._tool_cache[key])
-            else:
-                wrapper = _build_callable_for_tool(tool_def, self._gantry)
-                self._tool_cache[key] = wrapper
-                tools.append(wrapper)
-        return tools
+        return [self._get_or_build(td, cache) for td in tool_definitions]
 
     def wrap_single(self, tool_def: ToolDefinition) -> Any:
         """
@@ -312,12 +318,7 @@ class GantryToolBridge:
         Returns:
             An async callable suitable for AF agent ``tools=[...]``.
         """
-        key = _cache_key(tool_def)
-        if key in self._tool_cache:
-            return self._tool_cache[key]
-        wrapper = _build_callable_for_tool(tool_def, self._gantry)
-        self._tool_cache[key] = wrapper
-        return wrapper
+        return self._get_or_build(tool_def, cache=True)
 
     def clear_cache(self) -> None:
         """Clear the cached tool wrappers."""
@@ -350,34 +351,11 @@ class GantryToolBridge:
         Returns:
             List of (callable, score) tuples.
         """
-        from agent_gantry.schema.query import ConversationContext, ToolQuery
-
-        threshold = score_threshold if score_threshold is not None else self._score_threshold
-
-        context_fields = set(ConversationContext.model_fields.keys()) - {"query"}
-        context_kwargs = {k: v for k, v in query_kwargs.items() if k in context_fields}
-        tool_query_fields = set(ToolQuery.model_fields.keys()) - {"context", "limit", "score_threshold"}
-        tq_kwargs = {k: v for k, v in query_kwargs.items() if k in tool_query_fields}
-
-        result = await self._gantry.retrieve(
-            ToolQuery(
-                context=ConversationContext(query=query, **context_kwargs),
-                limit=limit,
-                score_threshold=threshold,
-                **tq_kwargs,
-            )
+        result = await self._retrieve(
+            query, limit=limit, score_threshold=score_threshold, **query_kwargs
         )
 
-        tools_with_scores = []
-        for scored_tool in result.tools:
-            tool_def = scored_tool.tool
-            key = _cache_key(tool_def)
-            if cache and key in self._tool_cache:
-                wrapper = self._tool_cache[key]
-            else:
-                wrapper = _build_callable_for_tool(tool_def, self._gantry)
-                if cache:
-                    self._tool_cache[key] = wrapper
-            tools_with_scores.append((wrapper, scored_tool.final_score))
-
-        return tools_with_scores
+        return [
+            (self._get_or_build(st.tool, cache), st.final_score)
+            for st in result.tools
+        ]

--- a/agent_gantry/integrations/framework_adapters.py
+++ b/agent_gantry/integrations/framework_adapters.py
@@ -3,7 +3,7 @@ Thin, dependency-free adapters for popular agent frameworks.
 
 These helpers translate Agent-Gantry retrieval results into the schema shapes
 expected by common frameworks (LangGraph, Semantic Kernel, CrewAI, Google ADK,
-and Strands) while preserving dynamic top-k surfacing.
+Strands, and Microsoft Agent Framework) while preserving dynamic top-k surfacing.
 """
 
 from __future__ import annotations
@@ -13,7 +13,14 @@ from typing import Any, Literal
 from agent_gantry.core.gantry import AgentGantry
 from agent_gantry.schema.query import ConversationContext, ToolQuery
 
-FrameworkName = Literal["langgraph", "semantic-kernel", "crew_ai", "google_adk", "strands"]
+FrameworkName = Literal[
+    "langgraph",
+    "semantic-kernel",
+    "crew_ai",
+    "google_adk",
+    "strands",
+    "agent_framework",
+]
 
 _SUPPORTED_FRAMEWORKS: set[FrameworkName] = {
     "langgraph",
@@ -21,6 +28,7 @@ _SUPPORTED_FRAMEWORKS: set[FrameworkName] = {
     "crew_ai",
     "google_adk",
     "strands",
+    "agent_framework",
 }
 
 
@@ -40,6 +48,11 @@ async def fetch_framework_tools(
     frameworks accept OpenAI-style tool/function schemas, so that shape is
     returned; the framework parameter is validated to fail fast and reserved
     for future per-framework tweaks.
+
+    For Microsoft Agent Framework, use the ``agent_framework`` dialect which
+    produces OpenAI-compatible schemas that AF's tool infrastructure expects.
+    For higher-level integration (wrapping tools as Python callables for AF
+    agents), see ``agent_gantry.integrations.agent_framework_bridge``.
     """
     if framework not in _SUPPORTED_FRAMEWORKS:
         raise ValueError(f"Unsupported framework: {framework}")
@@ -51,6 +64,9 @@ async def fetch_framework_tools(
             score_threshold=score_threshold,
         )
     )
+
+    if framework == "agent_framework":
+        return result.to_dialect("agent_framework")
 
     # LangGraph, Semantic Kernel, CrewAI, Google ADK, and Strands all accept
     # OpenAI-style tool/function schemas today, so default to that shape.

--- a/agent_gantry/schema/tool.py
+++ b/agent_gantry/schema/tool.py
@@ -24,6 +24,7 @@ class SchemaDialect(str, Enum):
     GEMINI = "gemini"
     MISTRAL = "mistral"
     GROQ = "groq"
+    AGENT_FRAMEWORK = "agent_framework"
     AUTO = "auto"
 
 

--- a/examples/agent_frameworks/agent_framework_example.py
+++ b/examples/agent_frameworks/agent_framework_example.py
@@ -47,40 +47,14 @@ async def main() -> str:
     #    This is where token savings happen: instead of sending ALL tools to the
     #    LLM, Gantry's semantic router selects only the relevant subset.
     user_query = "What plan is user abc123 on?"
-    tools = await gantry.retrieve_tools(user_query, limit=1, score_threshold=0.1)
+    tools = await bridge.get_tools(user_query, limit=2)
 
-    # 3) Wrap Gantry tools for Microsoft Agent Framework
-    def make_tool_wrapper(tool_name: str, gantry_instance: AgentGantry):
-        """Factory function to properly bind tool name to wrapper."""
-
-        async def tool_wrapper(
-            user_id: Annotated[str, Field(description="The user ID to look up.")],
-        ) -> str:
-            result = await gantry_instance.execute(
-                ToolCall(tool_name=tool_name, arguments={"user_id": user_id})
-            )
-            return str(result.result) if result.status == "success" else str(result.error)
-
-        # Set wrapper metadata for better debuggability and framework compatibility.
-        tool_wrapper.__name__ = tool_name
-        tool_wrapper.__doc__ = (
-            f"Tool wrapper for Agent-Gantry tool '{tool_name}'. "
-            "Invokes the underlying tool with a user_id argument."
-        )
-        return tool_wrapper
-
-    agent_tools = []
-    for schema in tools:
-        name = schema["function"]["name"]
-
-        if name == "get_user_profile":
-            agent_tools.append(make_tool_wrapper(name, gantry))
-
-    # 4) Create and run the Agent Framework ChatAgent
-    chat_agent = ChatAgent(
-        chat_client=OpenAIChatClient(model_id="gpt-4o"),
-        instructions=("You are a support assistant. Use the tools to fetch customer data."),
-        tools=agent_tools,
+    # 4) Create and run the Agent Framework agent with semantically selected tools
+    client = OpenAIResponsesClient()
+    agent = client.as_agent(
+        name="SupportAgent",
+        instructions="You are a support assistant. Use the tools to fetch customer data.",
+        tools=tools,
     )
 
     print("--- Running Microsoft Agent Framework with Agent-Gantry ---")

--- a/examples/agent_frameworks/agent_framework_example.py
+++ b/examples/agent_frameworks/agent_framework_example.py
@@ -1,13 +1,20 @@
-import asyncio
-from typing import Annotated
+"""
+Microsoft Agent Framework (RC+) integration example.
 
-from agent_framework import ChatAgent
-from agent_framework.openai import OpenAIChatClient
+Demonstrates how Agent-Gantry's semantic routing reduces token usage in
+multi-agent systems by surfacing only the relevant tools per query.
+
+Uses GantryToolBridge for seamless wrapping of Gantry tools as AF-compatible
+Python callables, compatible with any AF chat client (OpenAI, Azure, Anthropic, etc.).
+"""
+
+import asyncio
+
+from agent_framework.openai import OpenAIResponsesClient
 from dotenv import load_dotenv
-from pydantic import Field
 
 from agent_gantry import AgentGantry
-from agent_gantry.schema.execution import ToolCall
+from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
 
 load_dotenv()
 
@@ -18,52 +25,42 @@ async def main() -> str:
 
     @gantry.register
     def get_user_profile(user_id: str) -> dict[str, str]:
-        """Fetch a user's profile from the CRM."""
+        """Fetch a user's profile from the CRM system including plan and region."""
         return {"user_id": user_id, "plan": "pro", "region": "us-east"}
+
+    @gantry.register
+    def get_billing_info(user_id: str) -> dict[str, str]:
+        """Retrieve billing information for a customer account."""
+        return {"user_id": user_id, "balance": "$0.00", "next_invoice": "2026-04-01"}
+
+    @gantry.register
+    def search_knowledge_base(query: str) -> str:
+        """Search the internal knowledge base for support articles."""
+        return f"Found 3 articles matching '{query}'"
 
     await gantry.sync()
 
-    # 2) Retrieve relevant tools for this query (lower threshold for SimpleEmbedder demos)
+    # 2) Create the bridge - this is the key integration point
+    bridge = GantryToolBridge(gantry, score_threshold=0.1)
+
+    # 3) Retrieve only relevant tools for this specific query
+    #    This is where token savings happen: instead of sending ALL tools to the
+    #    LLM, Gantry's semantic router selects only the relevant subset.
     user_query = "What plan is user abc123 on?"
-    tools = await gantry.retrieve_tools(user_query, limit=1, score_threshold=0.1)
+    tools = await bridge.get_tools(user_query, limit=2)
 
-    # 3) Wrap Gantry tools for Microsoft Agent Framework
-    def make_tool_wrapper(tool_name: str, gantry_instance: AgentGantry):
-        """Factory function to properly bind tool name to wrapper."""
-        async def tool_wrapper(
-            user_id: Annotated[str, Field(description="The user ID to look up.")]
-        ) -> str:
-            result = await gantry_instance.execute(
-                ToolCall(tool_name=tool_name, arguments={"user_id": user_id})
-            )
-            return str(result.result) if result.status == "success" else str(result.error)
-
-        # Set wrapper metadata for better debuggability and framework compatibility.
-        tool_wrapper.__name__ = tool_name
-        tool_wrapper.__doc__ = (
-            f"Tool wrapper for Agent-Gantry tool '{tool_name}'. "
-            "Invokes the underlying tool with a user_id argument."
-        )
-        return tool_wrapper
-
-    agent_tools = []
-    for schema in tools:
-        name = schema["function"]["name"]
-
-        if name == "get_user_profile":
-            agent_tools.append(make_tool_wrapper(name, gantry))
-
-    # 4) Create and run the Agent Framework ChatAgent
-    chat_agent = ChatAgent(
-        chat_client=OpenAIChatClient(model_id="gpt-4o"),
-        instructions=(
-            "You are a support assistant. Use the tools to fetch customer data."
-        ),
-        tools=agent_tools,
+    # 4) Create and run the Agent Framework agent with semantically selected tools
+    client = OpenAIResponsesClient()
+    agent = client.as_agent(
+        name="SupportAgent",
+        instructions="You are a support assistant. Use the tools to fetch customer data.",
+        tools=tools,
     )
 
     print("--- Running Microsoft Agent Framework with Agent-Gantry ---")
-    response = await chat_agent.run(user_query)
+    print(f"Selected {len(tools)} tools (from {3} registered) for: '{user_query}'")
+
+    response = await agent.run(user_query)
     print(f"\nAgent Response: {response}")
     return str(response)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
     "python-dotenv>=1.0.0",
 ]
 agent-frameworks = [
-    "agent-framework>=1.0.0b251120",
+    "agent-framework>=1.0.0rc1",
     "autogen-agentchat>=0.7.5",
     "autogen-ext[openai]>=0.7.5",
     "crewai>=1.6.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
     "python-dotenv>=1.0.0",
 ]
 agent-frameworks = [
-    "agent-framework>=1.0.0rc1",
+    "agent-framework>=1.0.0rc1,<2.0.0",
     "autogen-agentchat>=0.7.5",
     "autogen-ext[openai]>=0.7.5",
     "crewai>=1.6.1",

--- a/tests/test_agent_framework_integration.py
+++ b/tests/test_agent_framework_integration.py
@@ -1,0 +1,560 @@
+"""
+Tests for Microsoft Agent Framework integration.
+
+Covers the AgentFrameworkAdapter (tool spec), the GantryToolBridge,
+the framework_adapters entry, and the updated example.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent_gantry.adapters.tool_spec import DialectRegistry, ToolCallPayload, get_adapter
+from agent_gantry.adapters.tool_spec.providers import AgentFrameworkAdapter
+from agent_gantry.schema.tool import SchemaDialect, ToolDefinition
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_tool() -> ToolDefinition:
+    """Create a sample tool definition for testing."""
+    return ToolDefinition(
+        name="get_weather",
+        description="Get the current weather for a specified city.",
+        parameters_schema={
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "The city name to get weather for",
+                },
+                "unit": {
+                    "type": "string",
+                    "enum": ["celsius", "fahrenheit"],
+                    "description": "Temperature unit",
+                },
+            },
+            "required": ["city"],
+        },
+        tags=["weather", "api"],
+    )
+
+
+@pytest.fixture
+def single_param_tool() -> ToolDefinition:
+    return ToolDefinition(
+        name="lookup_user",
+        description="Look up a user by their unique identifier.",
+        parameters_schema={
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string",
+                    "description": "The user ID to look up",
+                },
+            },
+            "required": ["user_id"],
+        },
+    )
+
+
+@pytest.fixture
+def no_param_tool() -> ToolDefinition:
+    return ToolDefinition(
+        name="get_system_status",
+        description="Retrieve the current system health status.",
+        parameters_schema={
+            "type": "object",
+            "properties": {},
+        },
+    )
+
+
+@pytest.fixture
+def adapter() -> AgentFrameworkAdapter:
+    return AgentFrameworkAdapter()
+
+
+# ---------------------------------------------------------------------------
+# AgentFrameworkAdapter — schema conversion
+# ---------------------------------------------------------------------------
+
+
+class TestAgentFrameworkAdapter:
+    """Tests for the Microsoft Agent Framework tool spec adapter."""
+
+    def test_dialect_name(self, adapter: AgentFrameworkAdapter) -> None:
+        assert adapter.dialect_name == "agent_framework"
+
+    def test_to_provider_schema_basic(
+        self, adapter: AgentFrameworkAdapter, sample_tool: ToolDefinition
+    ) -> None:
+        schema = adapter.to_provider_schema(sample_tool)
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "get_weather"
+        assert schema["function"]["description"] == sample_tool.description
+        assert schema["function"]["parameters"] == sample_tool.parameters_schema
+        assert "metadata" not in schema["function"]
+
+    def test_to_provider_schema_with_metadata(
+        self, adapter: AgentFrameworkAdapter, sample_tool: ToolDefinition
+    ) -> None:
+        schema = adapter.to_provider_schema(sample_tool, include_metadata=True)
+        assert "metadata" in schema["function"]
+        meta = schema["function"]["metadata"]
+        assert meta["namespace"] == "default"
+        assert meta["version"] == "1.0.0"
+        assert meta["source"] == "python_function"
+
+    def test_from_provider_payload_openai_style(
+        self, adapter: AgentFrameworkAdapter
+    ) -> None:
+        payload = adapter.from_provider_payload(
+            {
+                "id": "call_abc",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"city": "London"}',
+                },
+            }
+        )
+        assert payload.tool_name == "get_weather"
+        assert payload.tool_call_id == "call_abc"
+        assert payload.arguments == {"city": "London"}
+
+    def test_from_provider_payload_simplified(
+        self, adapter: AgentFrameworkAdapter
+    ) -> None:
+        payload = adapter.from_provider_payload(
+            {
+                "name": "get_weather",
+                "arguments": {"city": "London"},
+                "call_id": "call_xyz",
+            }
+        )
+        assert payload.tool_name == "get_weather"
+        assert payload.tool_call_id == "call_xyz"
+        assert payload.arguments == {"city": "London"}
+
+    def test_from_provider_payload_invalid_json_args(
+        self, adapter: AgentFrameworkAdapter
+    ) -> None:
+        payload = adapter.from_provider_payload(
+            {
+                "name": "test",
+                "arguments": "not valid json{",
+            }
+        )
+        assert payload.arguments == {}
+
+    def test_to_tool_call(self, adapter: AgentFrameworkAdapter) -> None:
+        payload = ToolCallPayload(
+            tool_name="get_weather",
+            tool_call_id="call_123",
+            arguments={"city": "Paris"},
+        )
+        call = adapter.to_tool_call(payload, timeout_ms=5000, retry_count=2)
+        assert call.tool_name == "get_weather"
+        assert call.arguments == {"city": "Paris"}
+        assert call.timeout_ms == 5000
+        assert call.retry_count == 2
+        assert call.trace_id == "call_123"
+
+    def test_format_tool_result_string(
+        self, adapter: AgentFrameworkAdapter
+    ) -> None:
+        result = adapter.format_tool_result("get_weather", "Sunny, 22C", "call_1")
+        assert result["role"] == "tool"
+        assert result["content"] == "Sunny, 22C"
+        assert result["name"] == "get_weather"
+        assert result["tool_call_id"] == "call_1"
+
+    def test_format_tool_result_dict(
+        self, adapter: AgentFrameworkAdapter
+    ) -> None:
+        result = adapter.format_tool_result(
+            "get_weather", {"temp": 22, "unit": "C"}, None
+        )
+        assert result["role"] == "tool"
+        assert json.loads(result["content"]) == {"temp": 22, "unit": "C"}
+        assert "tool_call_id" not in result
+
+    def test_format_tool_result_no_call_id(
+        self, adapter: AgentFrameworkAdapter
+    ) -> None:
+        result = adapter.format_tool_result("test", "ok")
+        assert "tool_call_id" not in result
+
+
+# ---------------------------------------------------------------------------
+# Dialect Registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestDialectRegistryIntegration:
+    """Verify AgentFrameworkAdapter is registered in the default registry."""
+
+    def test_agent_framework_registered(self) -> None:
+        # Reset singleton to ensure fresh registration
+        DialectRegistry._instance = None
+        registry = DialectRegistry.default()
+        assert registry.has("agent_framework")
+
+    def test_get_adapter_by_name(self) -> None:
+        DialectRegistry._instance = None
+        adapter = get_adapter("agent_framework")
+        assert adapter.dialect_name == "agent_framework"
+
+    def test_list_dialects_includes_agent_framework(self) -> None:
+        DialectRegistry._instance = None
+        dialects = DialectRegistry.default().list_dialects()
+        assert "agent_framework" in dialects
+
+
+# ---------------------------------------------------------------------------
+# SchemaDialect enum
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaDialectEnum:
+    def test_agent_framework_dialect_exists(self) -> None:
+        assert SchemaDialect.AGENT_FRAMEWORK.value == "agent_framework"
+
+    def test_tool_definition_to_dialect(self, sample_tool: ToolDefinition) -> None:
+        schema = sample_tool.to_dialect("agent_framework")
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "get_weather"
+
+
+# ---------------------------------------------------------------------------
+# GantryToolBridge
+# ---------------------------------------------------------------------------
+
+
+class TestGantryToolBridge:
+    """Tests for the GantryToolBridge."""
+
+    @pytest.mark.asyncio
+    async def test_bridge_get_tools_returns_callables(self) -> None:
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+        gantry = AgentGantry()
+
+        @gantry.register
+        def get_user_profile(user_id: str) -> dict[str, str]:
+            """Fetch a user's profile from the CRM system."""
+            return {"user_id": user_id, "plan": "pro"}
+
+        await gantry.sync()
+
+        bridge = GantryToolBridge(gantry, score_threshold=0.0)
+        tools = await bridge.get_tools("user profile", limit=5, score_threshold=0.0)
+
+        assert len(tools) >= 1
+        tool = tools[0]
+        assert callable(tool)
+        assert tool.__name__ == "get_user_profile"
+        assert "profile" in (tool.__doc__ or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_bridge_tool_execution(self) -> None:
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+        gantry = AgentGantry()
+
+        @gantry.register
+        def get_user_profile(user_id: str) -> dict[str, str]:
+            """Fetch a user's profile from the CRM system."""
+            return {"user_id": user_id, "plan": "pro"}
+
+        await gantry.sync()
+
+        bridge = GantryToolBridge(gantry, score_threshold=0.0)
+        tools = await bridge.get_tools("user profile", limit=5, score_threshold=0.0)
+
+        # Execute the wrapped tool
+        result = await tools[0](user_id="abc123")
+        parsed = json.loads(result)
+        assert parsed["user_id"] == "abc123"
+        assert parsed["plan"] == "pro"
+
+    @pytest.mark.asyncio
+    async def test_bridge_multi_param_tool(self) -> None:
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+        gantry = AgentGantry()
+
+        @gantry.register
+        def search_products(query: str, category: str) -> str:
+            """Search for products by query and category in the catalog."""
+            return f"Found 5 products matching '{query}' in '{category}'"
+
+        await gantry.sync()
+
+        bridge = GantryToolBridge(gantry, score_threshold=0.0)
+        tools = await bridge.get_tools("search products", limit=5, score_threshold=0.0)
+
+        assert len(tools) >= 1
+        tool = tools[0]
+        assert tool.__name__ == "search_products"
+
+        # Check the wrapper has proper parameter annotations
+        sig = inspect.signature(tool)
+        param_names = [p for p in sig.parameters if p != "kwargs"]
+        assert "query" in param_names
+        assert "category" in param_names
+
+    @pytest.mark.asyncio
+    async def test_bridge_no_param_tool(self) -> None:
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+        gantry = AgentGantry()
+
+        @gantry.register
+        def get_system_status() -> str:
+            """Retrieve the current system health status information."""
+            return "all systems operational"
+
+        await gantry.sync()
+
+        bridge = GantryToolBridge(gantry, score_threshold=0.0)
+        tools = await bridge.get_tools("system status", limit=5, score_threshold=0.0)
+
+        assert len(tools) >= 1
+        result = await tools[0]()
+        assert "operational" in result
+
+    @pytest.mark.asyncio
+    async def test_bridge_caching(self) -> None:
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+        gantry = AgentGantry()
+
+        @gantry.register
+        def get_user_profile(user_id: str) -> dict[str, str]:
+            """Fetch a user's profile from the CRM system."""
+            return {"user_id": user_id, "plan": "pro"}
+
+        await gantry.sync()
+
+        bridge = GantryToolBridge(gantry, score_threshold=0.0)
+        tools1 = await bridge.get_tools("user profile", limit=5, score_threshold=0.0)
+        tools2 = await bridge.get_tools("user profile", limit=5, score_threshold=0.0)
+
+        # Same callable object should be returned due to caching
+        assert tools1[0] is tools2[0]
+
+    @pytest.mark.asyncio
+    async def test_bridge_clear_cache(self) -> None:
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+        gantry = AgentGantry()
+
+        @gantry.register
+        def get_user_profile(user_id: str) -> dict[str, str]:
+            """Fetch a user's profile from the CRM system."""
+            return {"user_id": user_id, "plan": "pro"}
+
+        await gantry.sync()
+
+        bridge = GantryToolBridge(gantry, score_threshold=0.0)
+        tools1 = await bridge.get_tools("user profile", limit=5, score_threshold=0.0)
+        bridge.clear_cache()
+        tools2 = await bridge.get_tools("user profile", limit=5, score_threshold=0.0)
+
+        # Different callable objects after cache clear
+        assert tools1[0] is not tools2[0]
+
+    @pytest.mark.asyncio
+    async def test_bridge_wrap_tools_directly(self) -> None:
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+        gantry = AgentGantry()
+
+        @gantry.register
+        def get_user_profile(user_id: str) -> dict[str, str]:
+            """Fetch a user's profile from the CRM system."""
+            return {"user_id": user_id, "plan": "pro"}
+
+        await gantry.sync()
+
+        bridge = GantryToolBridge(gantry)
+        tool_defs = gantry.export_tools()
+        wrapped = bridge.wrap_tools(tool_defs)
+
+        assert len(wrapped) == 1
+        assert wrapped[0].__name__ == "get_user_profile"
+
+    @pytest.mark.asyncio
+    async def test_bridge_wrap_single(self) -> None:
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+        gantry = AgentGantry()
+
+        @gantry.register
+        def get_user_profile(user_id: str) -> dict[str, str]:
+            """Fetch a user's profile from the CRM system."""
+            return {"user_id": user_id, "plan": "pro"}
+
+        await gantry.sync()
+
+        bridge = GantryToolBridge(gantry)
+        tool_def = gantry.export_tools()[0]
+        wrapped = bridge.wrap_single(tool_def)
+
+        assert callable(wrapped)
+        assert wrapped.__name__ == "get_user_profile"
+
+    @pytest.mark.asyncio
+    async def test_bridge_get_tools_with_scores(self) -> None:
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+        gantry = AgentGantry()
+
+        @gantry.register
+        def get_user_profile(user_id: str) -> dict[str, str]:
+            """Fetch a user's profile from the CRM system."""
+            return {"user_id": user_id, "plan": "pro"}
+
+        await gantry.sync()
+
+        bridge = GantryToolBridge(gantry, score_threshold=0.0)
+        results = await bridge.get_tools_with_scores(
+            "user profile", limit=5, score_threshold=0.0
+        )
+
+        assert len(results) >= 1
+        tool, score = results[0]
+        assert callable(tool)
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Framework adapters entry
+# ---------------------------------------------------------------------------
+
+
+class TestFrameworkAdaptersEntry:
+    """Verify agent_framework is a supported framework in fetch_framework_tools."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_framework_tools_agent_framework(self) -> None:
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.framework_adapters import fetch_framework_tools
+
+        gantry = AgentGantry()
+
+        @gantry.register
+        def get_user_profile(user_id: str) -> dict[str, str]:
+            """Fetch a user's profile from the CRM system."""
+            return {"user_id": user_id, "plan": "pro"}
+
+        await gantry.sync()
+
+        tools = await fetch_framework_tools(
+            gantry,
+            "user profile",
+            framework="agent_framework",
+            limit=5,
+            score_threshold=0.0,
+        )
+
+        assert len(tools) >= 1
+        assert tools[0]["type"] == "function"
+        assert tools[0]["function"]["name"] == "get_user_profile"
+
+    @pytest.mark.asyncio
+    async def test_unsupported_framework_raises(self) -> None:
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.framework_adapters import fetch_framework_tools
+
+        gantry = AgentGantry()
+        with pytest.raises(ValueError, match="Unsupported framework"):
+            await fetch_framework_tools(
+                gantry, "test", framework="nonexistent"  # type: ignore[arg-type]
+            )
+
+
+# ---------------------------------------------------------------------------
+# Updated example test (with fakes)
+# ---------------------------------------------------------------------------
+
+
+class _Result:
+    def __init__(self, result: Any):
+        self.status = SimpleNamespace(value="success")
+        self.result = result
+        self.error = None
+
+
+@pytest.mark.asyncio
+async def test_agent_framework_example_runs_with_fakes(monkeypatch: Any) -> None:
+    """Test the updated AF example using fakes for external dependencies."""
+    import sys
+    from types import ModuleType
+
+    # Stub the agent_framework package so the example can import without it installed
+    af_mod = ModuleType("agent_framework")
+    af_openai_mod = ModuleType("agent_framework.openai")
+
+    class StubOpenAIResponsesClient:
+        pass
+
+    af_openai_mod.OpenAIResponsesClient = StubOpenAIResponsesClient  # type: ignore[attr-defined]
+    af_mod.openai = af_openai_mod  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "agent_framework", af_mod)
+    monkeypatch.setitem(sys.modules, "agent_framework.openai", af_openai_mod)
+
+    # Force re-import of the example module
+    mod_name = "examples.agent_frameworks.agent_framework_example"
+    if mod_name in sys.modules:
+        del sys.modules[mod_name]
+
+    from examples.agent_frameworks import agent_framework_example as mod
+
+    captured_tools: list[Any] = []
+
+    class FakeOpenAIResponsesClient:
+        def __init__(self, *_, **__):
+            pass
+
+        def as_agent(self, *, name, instructions, tools):
+            return FakeAgent(tools=tools)
+
+    class FakeAgent:
+        def __init__(self, *, tools):
+            self.tools = tools
+            captured_tools.extend(tools)
+
+        async def run(self, query: str) -> str:
+            if not self.tools:
+                return "no tools"
+            # Call the first tool to verify wiring works
+            return await self.tools[0](user_id="abc123")
+
+    monkeypatch.setattr(mod, "OpenAIResponsesClient", FakeOpenAIResponsesClient)
+
+    resp = await mod.main()
+    assert captured_tools, "tool wrapping was not performed"
+    assert "pro" in str(resp)

--- a/tests/test_agent_framework_integration.py
+++ b/tests/test_agent_framework_integration.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import inspect
 import json
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -496,65 +495,138 @@ class TestFrameworkAdaptersEntry:
 
 
 # ---------------------------------------------------------------------------
-# Updated example test (with fakes)
+# Additional edge-case tests requested by reviewers
 # ---------------------------------------------------------------------------
 
 
-class _Result:
-    def __init__(self, result: Any):
-        self.status = SimpleNamespace(value="success")
-        self.result = result
-        self.error = None
+class TestGantryToolBridgeEdgeCases:
+    """Edge-case and regression tests for the GantryToolBridge."""
 
+    @pytest.mark.asyncio
+    async def test_positional_args_single_param(self) -> None:
+        """Calling a single-param wrapper positionally should work."""
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
 
-@pytest.mark.asyncio
-async def test_agent_framework_example_runs_with_fakes(monkeypatch: Any) -> None:
-    """Test the updated AF example using fakes for external dependencies."""
-    import sys
-    from types import ModuleType
+        gantry = AgentGantry()
 
-    # Stub the agent_framework package so the example can import without it installed
-    af_mod = ModuleType("agent_framework")
-    af_openai_mod = ModuleType("agent_framework.openai")
+        @gantry.register
+        def get_user_profile(user_id: str) -> dict[str, str]:
+            """Fetch a user's profile from the CRM system."""
+            return {"user_id": user_id, "plan": "pro"}
 
-    class StubOpenAIResponsesClient:
-        pass
+        await gantry.sync()
 
-    af_openai_mod.OpenAIResponsesClient = StubOpenAIResponsesClient  # type: ignore[attr-defined]
-    af_mod.openai = af_openai_mod  # type: ignore[attr-defined]
+        bridge = GantryToolBridge(gantry, score_threshold=0.0)
+        tools = await bridge.get_tools("user profile", limit=5, score_threshold=0.0)
 
-    monkeypatch.setitem(sys.modules, "agent_framework", af_mod)
-    monkeypatch.setitem(sys.modules, "agent_framework.openai", af_openai_mod)
+        # Positional call
+        result = await tools[0]("abc123")
+        parsed = json.loads(result)
+        assert parsed["user_id"] == "abc123"
 
-    # Force re-import of the example module
-    mod_name = "examples.agent_frameworks.agent_framework_example"
-    if mod_name in sys.modules:
-        del sys.modules[mod_name]
+    @pytest.mark.asyncio
+    async def test_positional_args_multi_param(self) -> None:
+        """Calling a multi-param wrapper positionally should map by order."""
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
 
-    from examples.agent_frameworks import agent_framework_example as mod
+        gantry = AgentGantry()
 
-    captured_tools: list[Any] = []
+        @gantry.register
+        def search_products(query: str, category: str) -> str:
+            """Search for products by query and category in the catalog."""
+            return f"Found 5 products matching '{query}' in '{category}'"
 
-    class FakeOpenAIResponsesClient:
-        def __init__(self, *_, **__):
-            pass
+        await gantry.sync()
 
-        def as_agent(self, *, name, instructions, tools):
-            return FakeAgent(tools=tools)
+        bridge = GantryToolBridge(gantry, score_threshold=0.0)
+        tools = await bridge.get_tools("search products", limit=5, score_threshold=0.0)
 
-    class FakeAgent:
-        def __init__(self, *, tools):
-            self.tools = tools
-            captured_tools.extend(tools)
+        result = await tools[0]("shoes", "footwear")
+        assert "shoes" in result
+        assert "footwear" in result
 
-        async def run(self, query: str) -> str:
-            if not self.tools:
-                return "no tools"
-            # Call the first tool to verify wiring works
-            return await self.tools[0](user_id="abc123")
+    @pytest.mark.asyncio
+    async def test_positional_args_too_many_raises(self) -> None:
+        """Passing more positional args than parameters should raise TypeError."""
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
 
-    monkeypatch.setattr(mod, "OpenAIResponsesClient", FakeOpenAIResponsesClient)
+        gantry = AgentGantry()
 
-    resp = await mod.main()
-    assert captured_tools, "tool wrapping was not performed"
-    assert "pro" in str(resp)
+        @gantry.register
+        def get_user_profile(user_id: str) -> dict[str, str]:
+            """Fetch a user's profile from the CRM system."""
+            return {"user_id": user_id, "plan": "pro"}
+
+        await gantry.sync()
+
+        bridge = GantryToolBridge(gantry, score_threshold=0.0)
+        tools = await bridge.get_tools("user profile", limit=5, score_threshold=0.0)
+
+        with pytest.raises(TypeError, match="takes at most 1"):
+            await tools[0]("abc", "extra_arg")
+
+    @pytest.mark.asyncio
+    async def test_no_var_keyword_in_signature(self) -> None:
+        """Wrapper signatures should not expose **kwargs to AF introspection."""
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+        gantry = AgentGantry()
+
+        @gantry.register
+        def get_user_profile(user_id: str) -> dict[str, str]:
+            """Fetch a user's profile from the CRM system."""
+            return {"user_id": user_id, "plan": "pro"}
+
+        await gantry.sync()
+
+        bridge = GantryToolBridge(gantry, score_threshold=0.0)
+        tools = await bridge.get_tools("user profile", limit=5, score_threshold=0.0)
+
+        sig = inspect.signature(tools[0])
+        var_keyword_params = [
+            p for p in sig.parameters.values()
+            if p.kind == inspect.Parameter.VAR_KEYWORD
+        ]
+        assert len(var_keyword_params) == 0, (
+            "Wrapper should not expose **kwargs in its signature"
+        )
+
+    @pytest.mark.asyncio
+    async def test_wrap_tools_cache_bypass(self) -> None:
+        """wrap_tools with cache=False should create fresh wrappers."""
+        from agent_gantry import AgentGantry
+        from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+        gantry = AgentGantry()
+
+        @gantry.register
+        def get_user_profile(user_id: str) -> dict[str, str]:
+            """Fetch a user's profile from the CRM system."""
+            return {"user_id": user_id, "plan": "pro"}
+
+        await gantry.sync()
+
+        bridge = GantryToolBridge(gantry)
+        tool_defs = gantry.export_tools()
+        wrapped1 = bridge.wrap_tools(tool_defs, cache=True)
+        wrapped2 = bridge.wrap_tools(tool_defs, cache=False)
+
+        # With cache=False, should get a new wrapper object
+        assert wrapped1[0] is not wrapped2[0]
+
+    def test_adapter_logs_warning_on_malformed_json(self, caplog: Any) -> None:
+        """AgentFrameworkAdapter should log a warning for malformed arguments."""
+        import logging as _logging
+
+        adapter = AgentFrameworkAdapter()
+        with caplog.at_level(_logging.WARNING):
+            payload = adapter.from_provider_payload(
+                {"name": "test", "arguments": "not valid json{"}
+            )
+        assert payload.arguments == {}
+        assert payload.tool_name == "test"
+        assert "malformed JSON" in caplog.text

--- a/tests/test_examples_agent_frameworks.py
+++ b/tests/test_examples_agent_frameworks.py
@@ -73,21 +73,23 @@ async def test_google_adk_example_runs_with_fakes(monkeypatch):
     from types import ModuleType
 
     # Stub google.adk modules so the example can import without them installed
+    # Always override with stub modules to avoid mutating real installed packages
     for mod_name in [
         "google", "google.adk", "google.adk.agents", "google.adk.runners",
         "google.adk.sessions", "google.adk.tools", "google.genai",
         "google.genai.types",
     ]:
-        if mod_name not in sys.modules:
-            monkeypatch.setitem(sys.modules, mod_name, ModuleType(mod_name))
+        stub_module = ModuleType(mod_name)
+        monkeypatch.setitem(sys.modules, mod_name, stub_module)
 
     google_mod = sys.modules["google"]
     adk_mod = sys.modules["google.adk"]
-    google_mod.adk = adk_mod  # type: ignore[attr-defined]
-    adk_mod.agents = sys.modules["google.adk.agents"]  # type: ignore[attr-defined]
-    adk_mod.runners = sys.modules["google.adk.runners"]  # type: ignore[attr-defined]
-    adk_mod.sessions = sys.modules["google.adk.sessions"]  # type: ignore[attr-defined]
-    adk_mod.tools = sys.modules["google.adk.tools"]  # type: ignore[attr-defined]
+    # Use monkeypatch.setattr for attribute injection to guarantee cleanup
+    monkeypatch.setattr(google_mod, "adk", adk_mod, raising=False)  # type: ignore[attr-defined]
+    monkeypatch.setattr(adk_mod, "agents", sys.modules["google.adk.agents"], raising=False)  # type: ignore[attr-defined]
+    monkeypatch.setattr(adk_mod, "runners", sys.modules["google.adk.runners"], raising=False)  # type: ignore[attr-defined]
+    monkeypatch.setattr(adk_mod, "sessions", sys.modules["google.adk.sessions"], raising=False)  # type: ignore[attr-defined]
+    monkeypatch.setattr(adk_mod, "tools", sys.modules["google.adk.tools"], raising=False)  # type: ignore[attr-defined]
 
     # Provide stub classes the example expects to import
     class StubAgent:
@@ -105,13 +107,13 @@ async def test_google_adk_example_runs_with_fakes(monkeypatch):
         def __init__(self, *args, **kwargs):
             pass
 
-    sys.modules["google.adk.agents"].Agent = StubAgent  # type: ignore[attr-defined]
-    sys.modules["google.adk.runners"].Runner = StubRunner  # type: ignore[attr-defined]
-    sys.modules["google.adk.sessions"].InMemorySessionService = StubInMemorySessionService  # type: ignore[attr-defined]
-    sys.modules["google.adk.tools"].FunctionTool = StubFunctionTool  # type: ignore[attr-defined]
-    sys.modules["google.genai"].types = sys.modules["google.genai.types"]  # type: ignore[attr-defined]
-    sys.modules["google.genai.types"].Content = StubContent  # type: ignore[attr-defined]
-    sys.modules["google.genai.types"].Part = StubPart  # type: ignore[attr-defined]
+    monkeypatch.setattr(sys.modules["google.adk.agents"], "Agent", StubAgent, raising=False)  # type: ignore[attr-defined]
+    monkeypatch.setattr(sys.modules["google.adk.runners"], "Runner", StubRunner, raising=False)  # type: ignore[attr-defined]
+    monkeypatch.setattr(sys.modules["google.adk.sessions"], "InMemorySessionService", StubInMemorySessionService, raising=False)  # type: ignore[attr-defined]
+    monkeypatch.setattr(sys.modules["google.adk.tools"], "FunctionTool", StubFunctionTool, raising=False)  # type: ignore[attr-defined]
+    monkeypatch.setattr(sys.modules["google.genai"], "types", sys.modules["google.genai.types"], raising=False)  # type: ignore[attr-defined]
+    monkeypatch.setattr(sys.modules["google.genai.types"], "Content", StubContent, raising=False)  # type: ignore[attr-defined]
+    monkeypatch.setattr(sys.modules["google.genai.types"], "Part", StubPart, raising=False)  # type: ignore[attr-defined]
 
     # Force reimport
     example_mod_name = "examples.agent_frameworks.google_adk_example"

--- a/tests/test_examples_agent_frameworks.py
+++ b/tests/test_examples_agent_frameworks.py
@@ -17,33 +17,50 @@ class _Result:
 
 @pytest.mark.asyncio
 async def test_agent_framework_example_runs_with_fakes(monkeypatch):
+    import sys
+    from types import ModuleType
+
+    # Stub the agent_framework package so the example can import without it installed
+    af_mod = ModuleType("agent_framework")
+    af_openai_mod = ModuleType("agent_framework.openai")
+
+    class StubOpenAIResponsesClient:
+        pass
+
+    af_openai_mod.OpenAIResponsesClient = StubOpenAIResponsesClient
+    af_mod.openai = af_openai_mod
+
+    monkeypatch.setitem(sys.modules, "agent_framework", af_mod)
+    monkeypatch.setitem(sys.modules, "agent_framework.openai", af_openai_mod)
+
+    # Force re-import of the example module
+    mod_name = "examples.agent_frameworks.agent_framework_example"
+    if mod_name in sys.modules:
+        del sys.modules[mod_name]
+
     from examples.agent_frameworks import agent_framework_example as mod
 
     captured_tools: list[Any] = []
 
-    class FakeOpenAIChatClient:
+    class FakeOpenAIResponsesClient:
         def __init__(self, *_, **__):
             pass
 
-    class FakeChatAgent:
-        def __init__(self, *, chat_client, instructions, tools):
-            self.chat_client = chat_client
-            self.instructions = instructions
+        def as_agent(self, *, name, instructions, tools):
+            return FakeAgent(tools=tools)
+
+    class FakeAgent:
+        def __init__(self, *, tools):
             self.tools = tools
             captured_tools.extend(tools)
 
         async def run(self, query: str) -> str:
-            # call the first tool to ensure wiring works
             if not self.tools:
                 return "no tools"
-            return await self.tools[0]("abc123")
+            # Call the first tool to verify wiring works
+            return await self.tools[0](user_id="abc123")
 
-    async def fake_execute(self, tool_call):
-        return _Result({"user_id": tool_call.arguments["user_id"], "plan": "pro"})
-
-    monkeypatch.setattr(mod, "OpenAIChatClient", FakeOpenAIChatClient)
-    monkeypatch.setattr(mod, "ChatAgent", FakeChatAgent)
-    monkeypatch.setattr(mod.AgentGantry, "execute", fake_execute, raising=False)
+    monkeypatch.setattr(mod, "OpenAIResponsesClient", FakeOpenAIResponsesClient)
 
     resp = await mod.main()
     assert captured_tools, "tool wrapping was not performed"
@@ -52,6 +69,55 @@ async def test_agent_framework_example_runs_with_fakes(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_google_adk_example_runs_with_fakes(monkeypatch):
+    import sys
+    from types import ModuleType
+
+    # Stub google.adk modules so the example can import without them installed
+    for mod_name in [
+        "google", "google.adk", "google.adk.agents", "google.adk.runners",
+        "google.adk.sessions", "google.adk.tools", "google.genai",
+        "google.genai.types",
+    ]:
+        if mod_name not in sys.modules:
+            monkeypatch.setitem(sys.modules, mod_name, ModuleType(mod_name))
+
+    google_mod = sys.modules["google"]
+    adk_mod = sys.modules["google.adk"]
+    google_mod.adk = adk_mod  # type: ignore[attr-defined]
+    adk_mod.agents = sys.modules["google.adk.agents"]  # type: ignore[attr-defined]
+    adk_mod.runners = sys.modules["google.adk.runners"]  # type: ignore[attr-defined]
+    adk_mod.sessions = sys.modules["google.adk.sessions"]  # type: ignore[attr-defined]
+    adk_mod.tools = sys.modules["google.adk.tools"]  # type: ignore[attr-defined]
+
+    # Provide stub classes the example expects to import
+    class StubAgent:
+        pass
+    class StubRunner:
+        pass
+    class StubInMemorySessionService:
+        pass
+    class StubFunctionTool:
+        pass
+    class StubContent:
+        def __init__(self, *args, **kwargs):
+            pass
+    class StubPart:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    sys.modules["google.adk.agents"].Agent = StubAgent  # type: ignore[attr-defined]
+    sys.modules["google.adk.runners"].Runner = StubRunner  # type: ignore[attr-defined]
+    sys.modules["google.adk.sessions"].InMemorySessionService = StubInMemorySessionService  # type: ignore[attr-defined]
+    sys.modules["google.adk.tools"].FunctionTool = StubFunctionTool  # type: ignore[attr-defined]
+    sys.modules["google.genai"].types = sys.modules["google.genai.types"]  # type: ignore[attr-defined]
+    sys.modules["google.genai.types"].Content = StubContent  # type: ignore[attr-defined]
+    sys.modules["google.genai.types"].Part = StubPart  # type: ignore[attr-defined]
+
+    # Force reimport
+    example_mod_name = "examples.agent_frameworks.google_adk_example"
+    if example_mod_name in sys.modules:
+        del sys.modules[example_mod_name]
+
     from examples.agent_frameworks import google_adk_example as mod
 
     class FakeFunctionTool:


### PR DESCRIPTION
- Update agent-framework dependency from beta to RC (>=1.0.0rc1)
- Add AgentFrameworkAdapter to tool_spec providers with full bidirectional
  schema conversion (OpenAI-compatible + simplified AF format)
- Register agent_framework dialect in DialectRegistry
- Add AGENT_FRAMEWORK to SchemaDialect enum
- Add agent_framework to framework_adapters.py supported frameworks
- Create GantryToolBridge in integrations/agent_framework_bridge.py:
  - Wraps Gantry tools as AF-compatible Python callables with proper
    type annotations (Annotated + Field) for AF's function introspection
  - Supports query-time semantic retrieval (key for token savings)
  - Tool caching, direct wrapping, and score observability
  - Handles 0-arg, single-arg, and multi-arg tools
- Update example to use RC API (client.as_agent pattern with
  OpenAIResponsesClient instead of legacy ChatAgent)
- Add 27 comprehensive tests covering adapter, bridge, registry,
  dialect, framework entry, and example integration
- Fix existing test_examples_agent_frameworks.py to stub external
  dependencies properly

https://claude.ai/code/session_013boWmXKNXz7GVGgdaGpj18