### PR TITLE
🧪 [Test MCP registry pending queue encapsulation and clearing]

### DIFF
--- a/tests/test_dynamic_mcp_selection.py
+++ b/tests/test_dynamic_mcp_selection.py
@@ -174,11 +174,30 @@ class TestMCPRegistry:
         self, registry: MCPRegistry, sample_server: MCPServerDefinition
     ) -> None:
         """Test pending servers management."""
+        # Test sequential appends
         registry.add_pending(sample_server)
-        pending = registry.get_pending()
-        assert len(pending) == 1
-        assert pending[0].name == "filesystem"
 
+        server2 = MCPServerDefinition(
+            name="database",
+            command=["mcp-database"],
+            description="Database tools"
+        )
+        registry.add_pending(server2)
+
+        pending = registry.get_pending()
+        assert len(pending) == 2
+        assert pending[0].name == "filesystem"
+        assert pending[1].name == "database"
+
+        # Test defensive copying (encapsulation)
+        # Modifying the returned list should not affect the internal queue
+        pending.clear()
+        assert len(pending) == 0
+
+        internal_pending = registry.get_pending()
+        assert len(internal_pending) == 2
+
+        # Test explicit clearing
         registry.clear_pending()
         assert len(registry.get_pending()) == 0
 


### PR DESCRIPTION
🎯 **What:** Added tests for MCPRegistry's pending queue management.
📊 **Coverage:** Added assertions to verify sequential server appends, defensive list copying (encapsulation) to prevent accidental mutation of the internal queue, and proper explicit clearing behavior.
✨ **Result:** Increased codebase reliability by ensuring \`get_pending()\` and \`clear_pending()\` behave correctly with isolated data structures, catching potential bugs where the internal list might be externally modified.

---
*PR created automatically by Jules for task [5148199831380896091](https://jules.google.com/task/5148199831380896091) started by @CodeHalwell*