### PR TITLE
🎨 Palette: Improve external link accessibility for screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - External links accessibility
+**Learning:** Automatically appended visual indicators (like `↗`) for external links are read aloud by screen readers confusingly (e.g., "link text arrow up right").
+**Action:** Always add `aria-hidden="true"` to the decorative external link icon and append visually hidden text (using `.sr-only` class) to explicitly announce "(opens in a new tab)" to screen reader users.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -229,10 +229,16 @@
         if (!link.querySelector('.external-icon')) {
           const icon = document.createElement('span');
           icon.className = 'external-icon';
+          icon.setAttribute('aria-hidden', 'true');
           icon.innerHTML = ' ↗';
           icon.style.fontSize = '0.8em';
           icon.style.opacity = '0.6';
           link.appendChild(icon);
+
+          const srText = document.createElement('span');
+          srText.className = 'sr-only';
+          srText.textContent = ' (opens in a new tab)';
+          link.appendChild(srText);
         }
       }
     });


### PR DESCRIPTION
💡 **What**: Added `aria-hidden="true"` to the decorative external link icon (`↗`) and appended a visually hidden span containing the text "(opens in a new tab)".

🎯 **Why**: Screen readers were reading the visual indicator out loud (e.g., "link text arrow up right"), causing confusion. This change ensures that screen reader users are explicitly informed that the link opens a new tab without hearing the confusing symbol name.

♿ **Accessibility**: Improved context for screen reader users on external links and prevented non-essential decorative characters from cluttering audio feedback.

---
*PR created automatically by Jules for task [10951717550356891417](https://jules.google.com/task/10951717550356891417) started by @CodeHalwell*