### PR TITLE
🎨 Palette: Improve accessibility for external links and icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-15 - [External Link & Decorative Icon Accessibility]
+**Learning:** Decorative icons placed next to external links (or inside interactive buttons) shouldn't be read out by screen readers as it creates a redundant or confusing user experience. Additionally, when a link opens in a new tab (`target="_blank"`), the visual UI alone might not be enough context for a screen reader user.
+**Action:** Always add `aria-hidden="true"` to purely decorative SVGs/icons. When linking to an external resource in a new tab, use a visually hidden text block like `<span class="sr-only"> (opens in a new tab)</span>` immediately after the link text to inform assistive technologies.

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -36,7 +36,7 @@
   <header class="site-header">
     <div class="header-content">
       <a href="{{ '/' | relative_url }}" class="site-logo">
-        <svg class="logo-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="logo-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M12 2L2 7L12 12L22 7L12 2Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
           <path d="M2 17L12 22L22 17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
           <path d="M2 12L12 17L22 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -57,14 +57,14 @@
       <!-- Header Actions -->
       <div class="header-actions">
         <a href="https://github.com/CodeHalwell/Agent-Gantry" class="github-link" target="_blank" rel="noopener noreferrer">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" style="margin-right: 8px;">
+          <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" style="margin-right: 8px;">
             <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
           </svg>
-          GitHub
+          GitHub<span class="sr-only"> (opens in a new tab)</span>
         </a>
 
         <button class="mobile-menu-toggle" aria-label="Toggle navigation menu" aria-expanded="false">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <line x1="3" y1="12" x2="21" y2="12"></line>
             <line x1="3" y1="6" x2="21" y2="6"></line>
             <line x1="3" y1="18" x2="21" y2="18"></line>


### PR DESCRIPTION
💡 **What:** 
- Added `aria-hidden="true"` to purely decorative SVGs (GitHub icon, site logo, mobile menu toggle).
- Appended a visually hidden `<span> (opens in a new tab)</span>` to the GitHub external link.
- Created `.Jules/palette.md` to record the critical UX/a11y learnings regarding external link accessibility patterns.

🎯 **Why:** 
- Decorative icons placed next to external links (or inside interactive buttons) shouldn't be read out by screen readers as it creates a redundant or confusing user experience. 
- Additionally, when a link opens in a new tab (`target="_blank"`), the visual UI alone might not be enough context for a screen reader user. This change explicitly communicates the behavior.

📸 **Before/After:** 
- Visuals remain identical for sighted users, as purely semantic and visually-hidden classes are utilized.

♿ **Accessibility:** 
- Screen reader users will now be appropriately informed when a link shifts focus to a new tab.
- Screen readers will skip redundant announcements of decorative icons.

---
*PR created automatically by Jules for task [9939006465840352046](https://jules.google.com/task/9939006465840352046) started by @CodeHalwell*