### PR TITLE
🎨 Palette: Add accessibility improvements to external links

### DIFF
--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -2,33 +2,35 @@
  * Agent-Gantry Documentation - Navigation & Interactivity
  */
 
-(function() {
-  'use strict';
+(function () {
+  "use strict";
 
   // ==================== Mobile Menu Toggle ====================
 
   function initMobileMenu() {
-    const toggleButton = document.querySelector('.mobile-menu-toggle');
-    const sidebar = document.querySelector('.sidebar');
+    const toggleButton = document.querySelector(".mobile-menu-toggle");
+    const sidebar = document.querySelector(".sidebar");
 
     if (toggleButton && sidebar) {
-      toggleButton.addEventListener('click', function() {
-        sidebar.classList.toggle('open');
+      toggleButton.addEventListener("click", function () {
+        sidebar.classList.toggle("open");
 
         // Update aria-expanded for accessibility
-        const isExpanded = sidebar.classList.contains('open');
-        toggleButton.setAttribute('aria-expanded', isExpanded);
+        const isExpanded = sidebar.classList.contains("open");
+        toggleButton.setAttribute("aria-expanded", isExpanded);
       });
 
       // Close sidebar when clicking outside on mobile
-      document.addEventListener('click', function(event) {
+      document.addEventListener("click", function (event) {
         const isMobile = window.innerWidth <= 768;
-        if (isMobile &&
-            !sidebar.contains(event.target) &&
-            !toggleButton.contains(event.target) &&
-            sidebar.classList.contains('open')) {
-          sidebar.classList.remove('open');
-          toggleButton.setAttribute('aria-expanded', 'false');
+        if (
+          isMobile &&
+          !sidebar.contains(event.target) &&
+          !toggleButton.contains(event.target) &&
+          sidebar.classList.contains("open")
+        ) {
+          sidebar.classList.remove("open");
+          toggleButton.setAttribute("aria-expanded", "false");
         }
       });
     }
@@ -38,25 +40,25 @@
 
   function highlightActiveNav() {
     const currentPath = window.location.pathname;
-    const navLinks = document.querySelectorAll('.nav-link');
+    const navLinks = document.querySelectorAll(".nav-link");
 
-    navLinks.forEach(link => {
+    navLinks.forEach((link) => {
       const linkPath = new URL(link.href).pathname;
 
       // Exact match or starts with for sub-pages
-      if (currentPath === linkPath || currentPath.startsWith(linkPath + '/')) {
-        link.classList.add('active');
+      if (currentPath === linkPath || currentPath.startsWith(linkPath + "/")) {
+        link.classList.add("active");
 
         // Expand parent section if in submenu
-        const parentMenu = link.closest('.nav-submenu');
+        const parentMenu = link.closest(".nav-submenu");
         if (parentMenu) {
-          const parentSection = parentMenu.closest('.nav-section');
+          const parentSection = parentMenu.closest(".nav-section");
           if (parentSection) {
-            parentSection.classList.add('expanded');
+            parentSection.classList.add("expanded");
           }
         }
       } else {
-        link.classList.remove('active');
+        link.classList.remove("active");
       }
     });
   }
@@ -64,12 +66,12 @@
   // ==================== Smooth Scroll with Offset ====================
 
   function initSmoothScroll() {
-    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-      anchor.addEventListener('click', function(e) {
-        const href = this.getAttribute('href');
+    document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+      anchor.addEventListener("click", function (e) {
+        const href = this.getAttribute("href");
 
         // Skip if href is just '#'
-        if (href === '#') return;
+        if (href === "#") return;
 
         const target = document.querySelector(href);
         if (target) {
@@ -77,15 +79,16 @@
 
           const headerOffset = 80; // Account for fixed header
           const elementPosition = target.getBoundingClientRect().top;
-          const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+          const offsetPosition =
+            elementPosition + window.pageYOffset - headerOffset;
 
           window.scrollTo({
             top: offsetPosition,
-            behavior: 'smooth'
+            behavior: "smooth",
           });
 
           // Update URL without triggering scroll
-          history.pushState(null, '', href);
+          history.pushState(null, "", href);
         }
       });
     });
@@ -94,31 +97,31 @@
   // ==================== Table of Contents Generator ====================
 
   function generateTableOfContents() {
-    const content = document.querySelector('.content-wrapper');
-    const tocContainer = document.querySelector('.table-of-contents');
+    const content = document.querySelector(".content-wrapper");
+    const tocContainer = document.querySelector(".table-of-contents");
 
     if (!content || !tocContainer) return;
 
-    const headings = content.querySelectorAll('h2, h3, h4');
+    const headings = content.querySelectorAll("h2, h3, h4");
     if (headings.length === 0) return;
 
-    const tocList = document.createElement('ul');
-    tocList.className = 'toc-list';
+    const tocList = document.createElement("ul");
+    tocList.className = "toc-list";
 
     headings.forEach((heading, index) => {
       // Add ID if not present
       if (!heading.id) {
-        heading.id = 'heading-' + index;
+        heading.id = "heading-" + index;
       }
 
       const level = parseInt(heading.tagName.substring(1));
-      const listItem = document.createElement('li');
-      listItem.className = 'toc-item toc-level-' + level;
+      const listItem = document.createElement("li");
+      listItem.className = "toc-item toc-level-" + level;
 
-      const link = document.createElement('a');
-      link.href = '#' + heading.id;
+      const link = document.createElement("a");
+      link.href = "#" + heading.id;
       link.textContent = heading.textContent;
-      link.className = 'toc-link';
+      link.className = "toc-link";
 
       listItem.appendChild(link);
       tocList.appendChild(listItem);
@@ -130,41 +133,41 @@
   // ==================== Code Copy Buttons ====================
 
   function initCodeCopyButtons() {
-    const codeBlocks = document.querySelectorAll('pre code');
+    const codeBlocks = document.querySelectorAll("pre code");
 
-    codeBlocks.forEach(block => {
+    codeBlocks.forEach((block) => {
       const pre = block.parentElement;
 
       // Wrap pre in a container if not already wrapped
-      if (!pre.parentElement.classList.contains('code-block-wrapper')) {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'code-block-wrapper';
+      if (!pre.parentElement.classList.contains("code-block-wrapper")) {
+        const wrapper = document.createElement("div");
+        wrapper.className = "code-block-wrapper";
         pre.parentNode.insertBefore(wrapper, pre);
         wrapper.appendChild(pre);
       }
 
       // Create copy button
-      const button = document.createElement('button');
-      button.className = 'copy-button';
-      button.textContent = 'Copy';
-      button.setAttribute('aria-label', 'Copy code to clipboard');
+      const button = document.createElement("button");
+      button.className = "copy-button";
+      button.textContent = "Copy";
+      button.setAttribute("aria-label", "Copy code to clipboard");
 
-      button.addEventListener('click', async function() {
+      button.addEventListener("click", async function () {
         try {
           await navigator.clipboard.writeText(block.textContent);
-          button.textContent = 'Copied!';
-          button.classList.add('copied');
+          button.textContent = "Copied!";
+          button.classList.add("copied");
 
           setTimeout(() => {
-            button.textContent = 'Copy';
-            button.classList.remove('copied');
+            button.textContent = "Copy";
+            button.classList.remove("copied");
           }, 2000);
         } catch (err) {
-          console.error('Failed to copy code:', err);
-          button.textContent = 'Failed';
+          console.error("Failed to copy code:", err);
+          button.textContent = "Failed";
 
           setTimeout(() => {
-            button.textContent = 'Copy';
+            button.textContent = "Copy";
           }, 2000);
         }
       });
@@ -176,8 +179,8 @@
   // ==================== Scroll Progress Indicator ====================
 
   function initScrollProgress() {
-    const progressBar = document.createElement('div');
-    progressBar.className = 'scroll-progress';
+    const progressBar = document.createElement("div");
+    progressBar.className = "scroll-progress";
     progressBar.style.cssText = `
       position: fixed;
       top: 0;
@@ -190,21 +193,23 @@
     `;
     document.body.appendChild(progressBar);
 
-    window.addEventListener('scroll', function() {
-      const windowHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+    window.addEventListener("scroll", function () {
+      const windowHeight =
+        document.documentElement.scrollHeight -
+        document.documentElement.clientHeight;
       const scrolled = (window.scrollY / windowHeight) * 100;
-      progressBar.style.width = scrolled + '%';
+      progressBar.style.width = scrolled + "%";
     });
   }
 
   // ==================== Keyboard Shortcuts ====================
 
   function initKeyboardShortcuts() {
-    document.addEventListener('keydown', function(e) {
+    document.addEventListener("keydown", function (e) {
       // Cmd/Ctrl + K to focus search
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
-        const searchInput = document.querySelector('.search-input');
+        const searchInput = document.querySelector(".search-input");
         if (searchInput) {
           searchInput.focus();
         }
@@ -217,22 +222,28 @@
   function markExternalLinks() {
     const links = document.querySelectorAll('a[href^="http"]');
 
-    links.forEach(link => {
+    links.forEach((link) => {
       // Check if link is external
       const isExternal = !link.href.includes(window.location.hostname);
 
       if (isExternal) {
-        link.setAttribute('target', '_blank');
-        link.setAttribute('rel', 'noopener noreferrer');
+        link.setAttribute("target", "_blank");
+        link.setAttribute("rel", "noopener noreferrer");
 
         // Add visual indicator
-        if (!link.querySelector('.external-icon')) {
-          const icon = document.createElement('span');
-          icon.className = 'external-icon';
-          icon.innerHTML = ' ↗';
-          icon.style.fontSize = '0.8em';
-          icon.style.opacity = '0.6';
+        if (!link.querySelector(".external-icon")) {
+          const icon = document.createElement("span");
+          icon.className = "external-icon";
+          icon.setAttribute("aria-hidden", "true");
+          icon.innerHTML = " ↗";
+          icon.style.fontSize = "0.8em";
+          icon.style.opacity = "0.6";
           link.appendChild(icon);
+
+          const srText = document.createElement("span");
+          srText.className = "sr-only";
+          srText.innerText = " (opens in a new tab)";
+          link.appendChild(srText);
         }
       }
     });
@@ -241,22 +252,22 @@
   // ==================== Collapsible Sections ====================
 
   function initCollapsibleSections() {
-    const collapsibles = document.querySelectorAll('.collapsible');
+    const collapsibles = document.querySelectorAll(".collapsible");
 
-    collapsibles.forEach(section => {
-      const header = section.querySelector('.collapsible-header');
-      const content = section.querySelector('.collapsible-content');
+    collapsibles.forEach((section) => {
+      const header = section.querySelector(".collapsible-header");
+      const content = section.querySelector(".collapsible-content");
 
       if (header && content) {
-        header.addEventListener('click', function() {
-          const isOpen = section.classList.contains('open');
-          section.classList.toggle('open');
+        header.addEventListener("click", function () {
+          const isOpen = section.classList.contains("open");
+          section.classList.toggle("open");
 
           // Animate height
           if (isOpen) {
             content.style.maxHeight = null;
           } else {
-            content.style.maxHeight = content.scrollHeight + 'px';
+            content.style.maxHeight = content.scrollHeight + "px";
           }
         });
       }
@@ -266,21 +277,23 @@
   // ==================== Heading Anchor Links ====================
 
   function addHeadingAnchors() {
-    const headings = document.querySelectorAll('.content-wrapper h2, .content-wrapper h3, .content-wrapper h4');
+    const headings = document.querySelectorAll(
+      ".content-wrapper h2, .content-wrapper h3, .content-wrapper h4",
+    );
 
-    headings.forEach(heading => {
+    headings.forEach((heading) => {
       if (!heading.id) {
         heading.id = heading.textContent
           .toLowerCase()
-          .replace(/[^\w\s-]/g, '')
-          .replace(/\s+/g, '-');
+          .replace(/[^\w\s-]/g, "")
+          .replace(/\s+/g, "-");
       }
 
-      const anchor = document.createElement('a');
-      anchor.className = 'heading-anchor';
-      anchor.href = '#' + heading.id;
-      anchor.innerHTML = '#';
-      anchor.title = 'Link to this section';
+      const anchor = document.createElement("a");
+      anchor.className = "heading-anchor";
+      anchor.href = "#" + heading.id;
+      anchor.innerHTML = "#";
+      anchor.title = "Link to this section";
       anchor.style.cssText = `
         margin-left: 8px;
         opacity: 0;
@@ -291,12 +304,12 @@
 
       heading.appendChild(anchor);
 
-      heading.addEventListener('mouseenter', function() {
-        anchor.style.opacity = '1';
+      heading.addEventListener("mouseenter", function () {
+        anchor.style.opacity = "1";
       });
 
-      heading.addEventListener('mouseleave', function() {
-        anchor.style.opacity = '0';
+      heading.addEventListener("mouseleave", function () {
+        anchor.style.opacity = "0";
       });
     });
   }
@@ -305,8 +318,8 @@
 
   function init() {
     // Wait for DOM to be fully loaded
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', init);
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init);
       return;
     }
 
@@ -321,7 +334,7 @@
     initCollapsibleSections();
     addHeadingAnchors();
 
-    console.log('Agent-Gantry Documentation - Navigation initialized');
+    console.log("Agent-Gantry Documentation - Navigation initialized");
   }
 
   // Start initialization


### PR DESCRIPTION
💡 What: The UX enhancement added: Modified `docs/assets/js/navigation.js` to add `aria-hidden="true"` to purely decorative "↗" icons, and added a `.sr-only` span text " (opens in a new tab)" to explicitly announce to screen reader users that external links will open in a new tab.
🎯 Why: The user problem it solves: Decorative icons placed next to external links or inside interactive buttons create a redundant or confusing user experience when read by screen readers. When a link opens in a new tab without explicit context, it causes confusion. This resolves the learning from `.Jules/palette.md`.
📸 Before/After: N/A, visual rendering is exactly the same.
♿ Accessibility: Ensures that screen reader users don't have to listen to decorative icons ("right arrow up") and explicitly know when a link is going to move them to a new tab.

---
*PR created automatically by Jules for task [3639513440941060796](https://jules.google.com/task/3639513440941060796) started by @CodeHalwell*