### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix URL parsing bypass in domain extraction

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-04-17 - Fix URL parsing bypass in domain extraction
+**Vulnerability:** The `_extract_domains` function improperly parsed protocol-relative URLs using a regex `//([a-zA-Z0-9][-a-zA-Z0-9.]*\.[a-zA-Z]{2,})`. This allowed basic authentication payloads like `//github.com@evil.com` to extract the `github.com` username instead of the `evil.com` host, bypassing domain restrictions.
+**Learning:** Always use standard URL parsing libraries (`urllib.parse`) instead of custom regex to extract hostnames from URLs.
+**Prevention:** Use a regex to match the full URL string, then pass it to `urllib.parse.urlparse` to handle authentication components securely.

--- a/agent_gantry/core/security.py
+++ b/agent_gantry/core/security.py
@@ -133,8 +133,9 @@ class SecurityPolicy:
         domains = set()
 
         # Match URLs with explicit protocol schemes (http, https, ftp, ftps)
-        # and protocol-relative URLs (//example.com)
-        url_pattern = r"(?:https?|ftps?|file)://[^\s\"\'<>]+"
+        # and protocol-relative URLs (//example.com/path) securely,
+        # avoiding matching inline comments
+        url_pattern = r"(?:https?|ftps?|file)://[^\s\"\'<>]+|//(?:[a-zA-Z0-9][-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}|localhost)\b[-a-zA-Z0-9()@:%_\+.~#?&//=]*"
         for url_match in re.finditer(url_pattern, value):
             try:
                 parsed = urllib.parse.urlparse(url_match.group(0))
@@ -142,11 +143,6 @@ class SecurityPolicy:
                     domains.add(parsed.hostname)
             except Exception:
                 pass
-
-        # Protocol-relative URLs (//example.com/path)
-        proto_relative = r"//([a-zA-Z0-9][-a-zA-Z0-9.]*\.[a-zA-Z]{2,})"
-        for match in re.finditer(proto_relative, value):
-            domains.add(match.group(1))
 
         # Block data URIs that reference external resources
         if re.search(r"data:\s*[^;,]+", value) and "data:" in value:

--- a/tests/test_phase2.py
+++ b/tests/test_phase2.py
@@ -145,6 +145,13 @@ class TestRetryAndTimeout:
 class TestSecurityPolicy:
     """Tests for security policy enforcement."""
 
+    def test_extract_domains_protocol_relative_auth_bypass(self) -> None:
+        """Phase 4.3: SecurityPolicy should not allow authentication bypasses in protocol-relative URLs."""
+        policy = SecurityPolicy()
+        domains = policy._extract_domains("//github.com@evil.com/path")
+        assert "evil.com" in domains
+        assert "github.com" not in domains
+
     @pytest.mark.asyncio
     async def test_destructive_tool_requires_confirmation(self, gantry: AgentGantry) -> None:
         """Test that destructive tools require confirmation."""
@@ -173,7 +180,10 @@ class TestSecurityPolicy:
         policy.check_permission("test_tool", {})
 
         # Third request should fail
-        with pytest.raises(PermissionDeniedError, match="Rate limit exceeded: maximum 2 requests per minute allowed."):
+        with pytest.raises(
+            PermissionDeniedError,
+            match="Rate limit exceeded: maximum 2 requests per minute allowed.",
+        ):
             policy.check_permission("test_tool", {})
 
     @pytest.mark.asyncio
@@ -232,7 +242,9 @@ class TestSecurityPolicy:
             policy.check_permission("fetch_data", {"url": "http://github.com@evil.com/"})
 
         with pytest.raises(PermissionDeniedError, match="not in allowed_domains"):
-            policy.check_permission("fetch_data", {"text": "check out http://github.com:password@evil.com/"})
+            policy.check_permission(
+                "fetch_data", {"text": "check out http://github.com:password@evil.com/"}
+            )
 
         # Empty allowed_domains should allow everything
         open_policy = SecurityPolicy(allowed_domains=[])
@@ -415,9 +427,7 @@ class TestArgumentValidation:
         assert "must be an integer" in result.error.lower()
 
         # Int where bool expected
-        result = await gantry.execute(
-            ToolCall(tool_name="process_bool", arguments={"flag": 1})
-        )
+        result = await gantry.execute(ToolCall(tool_name="process_bool", arguments={"flag": 1}))
         assert result.status == ExecutionStatus.FAILURE
         assert "must be a boolean" in result.error.lower()
 
@@ -440,17 +450,15 @@ class TestArgumentValidation:
                     "properties": {
                         "inner": {
                             "type": "object",
-                            "properties": {
-                                "active": {"type": "boolean"}
-                            },
-                            "required": ["active"]
+                            "properties": {"active": {"type": "boolean"}},
+                            "required": ["active"],
                         },
-                        "name": {"type": "string"}
+                        "name": {"type": "string"},
                     },
-                    "required": ["inner", "name"]
+                    "required": ["inner", "name"],
                 }
             },
-            "required": ["data"]
+            "required": ["data"],
         }
 
         await gantry.sync()
@@ -459,27 +467,21 @@ class TestArgumentValidation:
         result = await gantry.execute(
             ToolCall(
                 tool_name="process_model",
-                arguments={"data": {"inner": {"active": True}, "name": "test"}}
+                arguments={"data": {"inner": {"active": True}, "name": "test"}},
             )
         )
         assert result.status == ExecutionStatus.SUCCESS
 
         # Invalid top-level type
         result = await gantry.execute(
-            ToolCall(
-                tool_name="process_model",
-                arguments={"data": "not_an_object"}
-            )
+            ToolCall(tool_name="process_model", arguments={"data": "not_an_object"})
         )
         assert result.status == ExecutionStatus.FAILURE
         assert "must be an object" in result.error.lower()
 
         # Missing required property in nested object
         result = await gantry.execute(
-            ToolCall(
-                tool_name="process_model",
-                arguments={"data": {"inner": {}, "name": "test"}}
-            )
+            ToolCall(tool_name="process_model", arguments={"data": {"inner": {}, "name": "test"}})
         )
         assert result.status == ExecutionStatus.FAILURE
         assert "missing required parameter" in result.error.lower()
@@ -488,7 +490,7 @@ class TestArgumentValidation:
         result = await gantry.execute(
             ToolCall(
                 tool_name="process_model",
-                arguments={"data": {"inner": {"active": "yes"}, "name": "test"}}
+                arguments={"data": {"inner": {"active": "yes"}, "name": "test"}},
             )
         )
         assert result.status == ExecutionStatus.FAILURE


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `_extract_domains` function in `SecurityPolicy` used a naive regex `//([a-zA-Z0-9][-a-zA-Z0-9.]*\.[a-zA-Z]{2,})` to extract hostnames from protocol-relative URLs. Because it just grabbed the first text after `//`, it incorrectly extracted the username portion of a URL when basic authentication was provided (e.g. `//github.com@evil.com/path` extracted `github.com`).
🎯 **Impact:** Malicious actors or compromised LLMs could bypass the `allowed_domains` security control by simply prefixing their malicious URL with an allowed domain acting as the username (e.g., passing `//safe.com@malicious-server.net/exfiltrate`), allowing unauthorized outbound tool executions.
🔧 **Fix:** Replaced the bespoke regex logic with a unified regex that matches both standard explicit protocols (`http`, `https`, `ftp`, `ftps`, `file`) AND protocol-relative URLs. All matched strings are passed to Python's robust `urllib.parse.urlparse`, which correctly processes authentication blocks and extracts the real hostname. Added explicit test cases preventing regressions.
✅ **Verification:** Verified by running `pytest tests/test_phase2.py`, which now correctly blocks `//github.com@evil.com/path` from being classified as `github.com`.

---
*PR created automatically by Jules for task [7374496609946107825](https://jules.google.com/task/7374496609946107825) started by @CodeHalwell*