### PR TITLE
🎨 Palette: [UX improvement] Improve external link accessibility in documentation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,3 @@
-## 2026-04-15 - [External Link & Decorative Icon Accessibility]
-**Learning:** Decorative icons placed next to external links (or inside interactive buttons) shouldn't be read out by screen readers as it creates a redundant or confusing user experience. Additionally, when a link opens in a new tab (`target="_blank"`), the visual UI alone might not be enough context for a screen reader user.
-**Action:** Always add `aria-hidden="true"` to purely decorative SVGs/icons. When linking to an external resource in a new tab, use a visually hidden text block like `<span class="sr-only"> (opens in a new tab)</span>` immediately after the link text to inform assistive technologies.
+## 2026-04-17 - [External Link Decorative Icon Accessibility]
+**Learning:** For accessibility in HTML/JS components, add `aria-hidden="true"` to decorative external link icons. Instead of appending a visually hidden `.sr-only` span, which can cause visual regressions if the CSS is missing or misapplied, prefer setting an `aria-label` directly on the link element (e.g., `link.setAttribute('aria-label', originalText + ' (opens in a new tab)');`).
+**Action:** Update external link icon scripts to append the `aria-label` to the anchor tag itself, making sure to capture the original textContent before any new child nodes (like icons) are appended.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -227,12 +227,21 @@
 
         // Add visual indicator
         if (!link.querySelector('.external-icon')) {
+          // Store text content before modifying link
+          const originalText = link.textContent.trim();
+
           const icon = document.createElement('span');
           icon.className = 'external-icon';
           icon.innerHTML = ' ↗';
           icon.style.fontSize = '0.8em';
           icon.style.opacity = '0.6';
+          icon.setAttribute('aria-hidden', 'true');
           link.appendChild(icon);
+
+          // Update screen reader text via aria-label
+          if (!link.hasAttribute('aria-label')) {
+            link.setAttribute('aria-label', originalText + ' (opens in a new tab)');
+          }
         }
       }
     });


### PR DESCRIPTION
💡 **What:** The UX enhancement added
Added `aria-hidden="true"` to the decorative visual indicator (`↗`) on external links in the documentation so that it isn't read aloud by screen readers. Furthermore, a descriptive `aria-label` was added to these links to inform users using screen readers that the link will open in a new tab.

🎯 **Why:** The user problem it solves
Screen reader users would otherwise hear the confusing read-out of a visual icon (like the upward arrow) without understanding its purpose. Moreover, standard links opening in a new tab (`target="_blank"`) can disorient screen reader users if they are not explicitly warned beforehand.

📸 **Before/After:**
- Before: `<a href="...">GitHub<span class="external-icon"> ↗</span></a>` (Screen readers might announce: "Link, GitHub upward arrow")
- After: `<a href="..." aria-label="GitHub (opens in a new tab)">GitHub<span class="external-icon" aria-hidden="true"> ↗</span></a>` (Screen readers announce: "Link, GitHub (opens in a new tab)")

♿ **Accessibility:**
Ensured that the visual indicator icon is completely ignored by assistive technologies, and added clear, native `aria-label` functionality on the links to provide the context missing from the visual layout alone. Tested that the solution does not introduce visual regressions.

---
*PR created automatically by Jules for task [2537135267315560545](https://jules.google.com/task/2537135267315560545) started by @CodeHalwell*