### PR TITLE
🎨 Palette: Fix external link screen reader accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-04-17 - [External Link Decorative Icon Accessibility]
 **Learning:** For accessibility in HTML/JS components, add `aria-hidden="true"` to decorative external link icons. Instead of appending a visually hidden `.sr-only` span, which can cause visual regressions if the CSS is missing or misapplied, prefer setting an `aria-label` directly on the link element (e.g., `link.setAttribute('aria-label', originalText + ' (opens in a new tab)');`).
 **Action:** Update external link icon scripts to append the `aria-label` to the anchor tag itself, making sure to capture the original textContent before any new child nodes (like icons) are appended.
+
+## 2026-04-19 - [ARIA Labels with Visual Context]
+**Learning:** For accessibility in HTML/JS components, screen readers will read the `aria-label` attribute on an element and completely ignore its inner text. Therefore, if you add a visual indicator via a hidden element (like appending `<span class="sr-only">(opens in a new tab)</span>`), it will not be announced if the parent element already has an `aria-label`.
+**Action:** When adding context like "opens in a new tab" for external links, append that string directly to the existing `aria-label` attribute rather than adding visually hidden DOM elements to the link's text content.

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -56,11 +56,11 @@
 
       <!-- Header Actions -->
       <div class="header-actions">
-        <a href="https://github.com/CodeHalwell/Agent-Gantry" class="github-link" target="_blank" rel="noopener noreferrer">
+        <a href="https://github.com/CodeHalwell/Agent-Gantry" class="github-link" target="_blank" rel="noopener noreferrer" aria-label="GitHub (opens in a new tab)">
           <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" style="margin-right: 8px;">
             <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
           </svg>
-          GitHub<span class="sr-only"> (opens in a new tab)</span>
+          GitHub
         </a>
 
         <button class="mobile-menu-toggle" aria-label="Toggle navigation menu" aria-expanded="false">

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -243,18 +243,17 @@
           icon.style.opacity = "0.6";
           link.appendChild(icon);
 
-          // Provide screen reader context via aria-label (preferred)
-          // or a visually hidden sr-only span as a fallback.
+          // Provide screen reader context via aria-label
           if (!link.hasAttribute("aria-label")) {
             link.setAttribute(
               "aria-label",
               originalText + " (opens in a new tab)",
             );
           } else {
-            const srText = document.createElement("span");
-            srText.className = "sr-only";
-            srText.textContent = " (opens in a new tab)";
-            link.appendChild(srText);
+            const currentLabel = link.getAttribute("aria-label");
+            if (!currentLabel.includes("(opens in a new tab)")) {
+              link.setAttribute("aria-label", currentLabel + " (opens in a new tab)");
+            }
           }
         }
       }


### PR DESCRIPTION
💡 What: Updated the way "opens in a new tab" warnings are provided to screen readers for external links in the documentation template and dynamic navigation script.\n🎯 Why: If an anchor tag has an `aria-label`, screen readers read that label and ignore all inner HTML text content. Appending a visually hidden `<span class=\"sr-only\">` inside the link meant the warning was being completely dropped for users relying on screen readers.\n📸 Before/After: Visual presentation is completely unaffected.\n♿ Accessibility: Screen reader users will now correctly be informed when clicking the GitHub link or other dynamic external links that they will open in a new tab.

---
*PR created automatically by Jules for task [14021604471110726939](https://jules.google.com/task/14021604471110726939) started by @CodeHalwell*