### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection bypass via trailing newline in identifiers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** The `_extract_domains` function improperly parsed protocol-relative URLs using a regex `//([a-zA-Z0-9][-a-zA-Z0-9.]*\.[a-zA-Z]{2,})`. This allowed basic authentication payloads like `//github.com@evil.com` to extract the `github.com` username instead of the `evil.com` host, bypassing domain restrictions.
 **Learning:** Always use standard URL parsing libraries (`urllib.parse`) instead of custom regex to extract hostnames from URLs.
 **Prevention:** Use a regex to match the full URL string, then pass it to `urllib.parse.urlparse` to handle authentication components securely.
+## 2024-05-11 - [CRITICAL] Fix SQL injection bypass via trailing newline in identifiers
+**Vulnerability:** The `_validate_sql_identifier` and `validate_name` functions used `$` in their validation regular expressions (e.g., `re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", value)`). In Python's `re` module, `$` matches the end of the string or just before a trailing newline. This could allow an attacker to bypass validation and potentially perform SQL injection or logical bypasses by appending `\n` to an identifier (e.g., `valid_name\nDROP TABLE tools;`).
+**Learning:** In Python regex, always use `\Z` instead of `$` to strictly match the absolute end of the string when validating identifiers or potentially unsafe inputs, as `$` allows trailing newlines which can lead to bypass vulnerabilities.
+**Prevention:** Always use `\Z` anchor for absolute end-of-string matching in security-critical regular expressions in Python.

--- a/agent_gantry/adapters/vector_stores/remote.py
+++ b/agent_gantry/adapters/vector_stores/remote.py
@@ -34,7 +34,7 @@ def _validate_sql_identifier(value: str, field_name: str) -> None:
         raise ValueError(f"{field_name} must be 1-63 characters")
 
     # Must start with letter or underscore, contain only alphanumeric and underscores
-    if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", value):
+    if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*\Z", value):
         raise ValueError(
             f"{field_name} must start with a letter or underscore and contain only "
             "alphanumeric characters and underscores"

--- a/agent_gantry/core/security.py
+++ b/agent_gantry/core/security.py
@@ -228,7 +228,7 @@ def validate_tool_name(name: str) -> tuple[bool, str | None]:
     Returns:
         Tuple of (is_valid, error_message)
     """
-    if not re.match(r"^[a-z][a-z0-9_]{0,127}$", name):
+    if not re.match(r"^[a-z][a-z0-9_]{0,127}\Z", name):
         return False, "Name must be lowercase alphanumeric with underscores, 1-128 chars"
     return True, None
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `_validate_sql_identifier` and `validate_name` functions used `$` in their validation regular expressions (e.g., `re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", value)`). In Python's `re` module, `$` matches the end of the string or just before a trailing newline. This could allow an attacker to bypass validation and potentially perform SQL injection or logical bypasses by appending `\n` to an identifier (e.g., `valid_name\nDROP TABLE tools;`).
🎯 **Impact:** If an attacker can control the input to these functions and append a newline, they could potentially inject arbitrary SQL commands when these identifiers are interpolated into queries (e.g., in `PGVectorStore`), leading to data corruption, exfiltration, or complete database compromise. In other contexts (like tool name validation), it could lead to logical bypasses.
🔧 **Fix:** Changed the trailing anchor from `$` to `\Z` in `_validate_sql_identifier` (in `agent_gantry/adapters/vector_stores/remote.py`) and `validate_name` (in `agent_gantry/core/security.py`). The `\Z` anchor strictly matches the absolute end of the string, guaranteeing no trailing newlines are permitted.
✅ **Verification:** Verified by running the test suite (`uv run pytest tests/`). Tests pass successfully, ensuring no regressions.

---
*PR created automatically by Jules for task [7643966672691736125](https://jules.google.com/task/7643966672691736125) started by @CodeHalwell*