### PR TITLE
🎨 Palette: Add screen reader announcements for dynamic search results

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-04-21 - [Screen Reader Swallowing ARIA Labels]
 **Learning:** Screen readers completely ignore an element's inner text if an `aria-label` is present. Therefore, if a link has existing text and you want to add contextual information for screen readers (like "(opens in a new tab)"), you must include the original text inside the `aria-label` instead of just appending context via a `.sr-only` span or using `aria-label` on a child element if that behavior could lead to confusing nesting. For `aria-label` appended dynamically, ensure you preserve the original `textContent`.
 **Action:** Consistently set or append contextual string like "(opens in a new tab)" directly to the main element's `aria-label` attribute (incorporating its original text) rather than appending visually hidden child text nodes.
+
+## 2026-04-23 - [Screen Reader Announcements for Dynamic Content]
+**Learning:** For screen readers to announce dynamic content like search results when focus remains in an input field, you must use an `aria-live` region. Additionally, when using arrow keys to navigate a custom dropdown, you must manually update the `aria-live` region with the active item's text.
+**Action:** Inject a visually hidden `aria-live="polite"` element and update its `textContent` when dynamic UI regions change state or list navigation occurs.

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -3,13 +3,36 @@
  * Simple but effective search using a pre-built search index
  */
 
-(function() {
-  'use strict';
+(function () {
+  "use strict";
 
   // Search index will be populated by Jekyll or built at runtime
   let searchIndex = [];
   let searchInput = null;
   let searchResults = null;
+  let searchAnnouncer = null;
+
+  // ==================== Search Announcer ====================
+
+  /**
+   * Setup an aria-live region for screen reader announcements
+   */
+  function setupSearchAnnouncer() {
+    searchAnnouncer = document.createElement("div");
+    searchAnnouncer.setAttribute("aria-live", "polite");
+    searchAnnouncer.setAttribute("aria-atomic", "true");
+    searchAnnouncer.className = "sr-only";
+    document.body.appendChild(searchAnnouncer);
+  }
+
+  /**
+   * Announce text to screen readers
+   */
+  function announceSearch(text) {
+    if (searchAnnouncer) {
+      searchAnnouncer.textContent = text;
+    }
+  }
 
   // ==================== Search Index Building ====================
 
@@ -23,25 +46,25 @@
     const pages = [];
 
     // Add current page
-    const currentContent = document.querySelector('.content-wrapper');
+    const currentContent = document.querySelector(".content-wrapper");
     if (currentContent) {
       pages.push({
         title: document.title,
         url: window.location.pathname,
-        content: currentContent.textContent.toLowerCase()
+        content: currentContent.textContent.toLowerCase(),
       });
     }
 
     // Add linked pages from navigation
-    const navLinks = document.querySelectorAll('.nav-link');
-    navLinks.forEach(link => {
+    const navLinks = document.querySelectorAll(".nav-link");
+    navLinks.forEach((link) => {
       const url = new URL(link.href).pathname;
       const title = link.textContent.trim();
 
       pages.push({
         title: title,
         url: url,
-        content: title.toLowerCase() // Simplified - would fetch full content in production
+        content: title.toLowerCase(), // Simplified - would fetch full content in production
       });
     });
 
@@ -63,7 +86,7 @@
     const queryTerms = lowerQuery.split(/\s+/);
 
     const results = searchIndex
-      .map(page => {
+      .map((page) => {
         let score = 0;
 
         // Title match (highest weight)
@@ -72,14 +95,14 @@
         }
 
         // Individual term matches in title
-        queryTerms.forEach(term => {
+        queryTerms.forEach((term) => {
           if (page.title.toLowerCase().includes(term)) {
             score += 50;
           }
         });
 
         // Content matches
-        queryTerms.forEach(term => {
+        queryTerms.forEach((term) => {
           if (page.content.includes(term)) {
             score += 10;
           }
@@ -87,10 +110,10 @@
 
         return {
           ...page,
-          score: score
+          score: score,
         };
       })
-      .filter(page => page.score > 0)
+      .filter((page) => page.score > 0)
       .sort((a, b) => b.score - a.score)
       .slice(0, 8); // Limit to top 8 results
 
@@ -104,25 +127,27 @@
     if (!searchResults) return;
 
     // Clear previous results
-    searchResults.innerHTML = '';
+    searchResults.innerHTML = "";
 
     if (results.length === 0) {
-      searchResults.innerHTML = '<div class="search-no-results">No results found</div>';
-      searchResults.style.display = 'block';
+      searchResults.innerHTML =
+        '<div class="search-no-results">No results found</div>';
+      searchResults.style.display = "block";
+      announceSearch("No results found");
       return;
     }
 
-    results.forEach(result => {
-      const resultItem = document.createElement('a');
-      resultItem.className = 'search-result-item';
+    results.forEach((result) => {
+      const resultItem = document.createElement("a");
+      resultItem.className = "search-result-item";
       resultItem.href = result.url;
 
-      const resultTitle = document.createElement('div');
-      resultTitle.className = 'search-result-title';
+      const resultTitle = document.createElement("div");
+      resultTitle.className = "search-result-title";
       resultTitle.textContent = result.title;
 
-      const resultUrl = document.createElement('div');
-      resultUrl.className = 'search-result-url';
+      const resultUrl = document.createElement("div");
+      resultUrl.className = "search-result-url";
       resultUrl.textContent = result.url;
 
       resultItem.appendChild(resultTitle);
@@ -130,32 +155,36 @@
       searchResults.appendChild(resultItem);
     });
 
-    searchResults.style.display = 'block';
+    searchResults.style.display = "block";
+    announceSearch(
+      `${results.length} results found. Use up and down arrows to navigate.`,
+    );
   }
 
   /**
    * Hide search results
    */
   function hideResults() {
-    if (searchResults) {
-      searchResults.style.display = 'none';
+    if (searchResults && searchResults.style.display !== "none") {
+      searchResults.style.display = "none";
+      announceSearch("Search results closed");
     }
   }
 
   // ==================== Initialize Search ====================
 
   function initSearch() {
-    searchInput = document.querySelector('.search-input');
+    searchInput = document.querySelector(".search-input");
     if (!searchInput) {
-      console.log('Search input not found, skipping search initialization');
+      console.log("Search input not found, skipping search initialization");
       return;
     }
 
     // Create results container if it doesn't exist
-    searchResults = document.querySelector('.search-results');
+    searchResults = document.querySelector(".search-results");
     if (!searchResults) {
-      searchResults = document.createElement('div');
-      searchResults.className = 'search-results';
+      searchResults = document.createElement("div");
+      searchResults.className = "search-results";
       searchResults.style.cssText = `
         position: absolute;
         top: 100%;
@@ -172,15 +201,15 @@
         z-index: 1000;
       `;
 
-      const searchContainer = searchInput.closest('.search-container');
+      const searchContainer = searchInput.closest(".search-container");
       if (searchContainer) {
-        searchContainer.style.position = 'relative';
+        searchContainer.style.position = "relative";
         searchContainer.appendChild(searchResults);
       }
     }
 
     // Add search result item styles
-    const style = document.createElement('style');
+    const style = document.createElement("style");
     style.textContent = `
       .search-result-item {
         display: block;
@@ -222,7 +251,7 @@
 
     // Handle search input
     let searchTimeout;
-    searchInput.addEventListener('input', function(e) {
+    searchInput.addEventListener("input", function (e) {
       const query = e.target.value.trim();
 
       // Debounce search
@@ -238,22 +267,26 @@
     });
 
     // Handle keyboard navigation in results
-    searchInput.addEventListener('keydown', function(e) {
-      if (!searchResults || searchResults.style.display === 'none') return;
+    searchInput.addEventListener("keydown", function (e) {
+      if (!searchResults || searchResults.style.display === "none") return;
 
-      const items = searchResults.querySelectorAll('.search-result-item');
+      const items = searchResults.querySelectorAll(".search-result-item");
       if (items.length === 0) return;
 
-      const activeItem = searchResults.querySelector('.search-result-item.active');
-      let currentIndex = activeItem ? Array.from(items).indexOf(activeItem) : -1;
+      const activeItem = searchResults.querySelector(
+        ".search-result-item.active",
+      );
+      let currentIndex = activeItem
+        ? Array.from(items).indexOf(activeItem)
+        : -1;
 
-      if (e.key === 'ArrowDown') {
+      if (e.key === "ArrowDown") {
         e.preventDefault();
         currentIndex = (currentIndex + 1) % items.length;
-      } else if (e.key === 'ArrowUp') {
+      } else if (e.key === "ArrowUp") {
         e.preventDefault();
         currentIndex = currentIndex <= 0 ? items.length - 1 : currentIndex - 1;
-      } else if (e.key === 'Enter') {
+      } else if (e.key === "Enter") {
         e.preventDefault();
         if (activeItem) {
           activeItem.click();
@@ -261,7 +294,7 @@
           items[0].click();
         }
         return;
-      } else if (e.key === 'Escape') {
+      } else if (e.key === "Escape") {
         hideResults();
         searchInput.blur();
         return;
@@ -270,31 +303,41 @@
       }
 
       // Update active item
-      items.forEach(item => item.classList.remove('active'));
-      items[currentIndex].classList.add('active');
-      items[currentIndex].scrollIntoView({ block: 'nearest' });
+      items.forEach((item) => item.classList.remove("active"));
+      items[currentIndex].classList.add("active");
+      items[currentIndex].scrollIntoView({ block: "nearest" });
+
+      const activeTitle = items[currentIndex].querySelector(
+        ".search-result-title",
+      ).textContent;
+      announceSearch(activeTitle);
     });
 
     // Close search results when clicking outside
-    document.addEventListener('click', function(e) {
-      if (searchInput && searchResults &&
-          !searchInput.contains(e.target) &&
-          !searchResults.contains(e.target)) {
+    document.addEventListener("click", function (e) {
+      if (
+        searchInput &&
+        searchResults &&
+        !searchInput.contains(e.target) &&
+        !searchResults.contains(e.target)
+      ) {
         hideResults();
       }
     });
 
+    setupSearchAnnouncer();
+
     // Build search index
     buildSearchIndex();
 
-    console.log('Search initialized');
+    console.log("Search initialized");
   }
 
   // ==================== Initialize ====================
 
   function init() {
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', init);
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init);
       return;
     }
 


### PR DESCRIPTION
💡 **What:** 
Added an `announceSearch()` helper in `docs/assets/js/search.js` that maintains a visually hidden `aria-live="polite"` element. The script now announces how many results were found, when no results are found, when the search is closed via Escape, and the title of the currently focused item when using up/down arrow keyboard navigation.

🎯 **Why:** 
Previously, screen reader users relying on the documentation search input had no way of knowing how many results were returned or which result they were focusing on using the keyboard. Because focus remained on the input field (`<input class="search-input">`), standard DOM changes to the absolute-positioned dropdown were completely invisible to assistive technologies.

♿ **Accessibility:**
* Injected a semantic `aria-live="polite"` region.
* Added contextual announcements for changes in the dropdown state and keyboard navigation selection.
* Documented the need for manual `aria-live` announcements in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [5531512384141296308](https://jules.google.com/task/5531512384141296308) started by @CodeHalwell*