### PR TITLE
🎨 Palette: [accessibility] Add keyboard navigation and ARIA attributes to collapsible sections

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-04-23 - [Screen Reader Announcements for Dynamic Content]
 **Learning:** For screen readers to announce dynamic content like search results when focus remains in an input field, you must use an `aria-live` region. Additionally, when using arrow keys to navigate a custom dropdown, you must manually update the `aria-live` region with the active item's text.
 **Action:** Inject a visually hidden `aria-live="polite"` element and update its `textContent` when dynamic UI regions change state or list navigation occurs.
+
+## 2024-04-24 - Accessibility for Custom Interactive Elements
+**Learning:** Collapsible sections in `docs/assets/js/navigation.js` were built using standard `<div>` elements with only `click` event listeners. This entirely broke keyboard navigation and screen reader support, as non-semantic tags lack focusability (`tabindex="0"`) and default keyboard activation (`Enter`/`Space`).
+**Action:** When building custom interactive components like collapsibles or dropdowns with non-interactive HTML elements (div/span), always explicitly add `role="button"`, `tabindex="0"`, `aria-expanded` state, and listen to `keydown` events for `Enter` and `Space` keys to restore native behavior.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -268,20 +268,41 @@
   function initCollapsibleSections() {
     const collapsibles = document.querySelectorAll(".collapsible");
 
-    collapsibles.forEach((section) => {
+    collapsibles.forEach((section, index) => {
       const header = section.querySelector(".collapsible-header");
       const content = section.querySelector(".collapsible-content");
 
       if (header && content) {
-        header.addEventListener("click", function () {
+        // Add accessibility attributes
+        const contentId = `collapsible-content-${index}`;
+        header.setAttribute("role", "button");
+        header.setAttribute("tabindex", "0");
+        header.setAttribute(
+          "aria-expanded",
+          section.classList.contains("open") ? "true" : "false",
+        );
+        header.setAttribute("aria-controls", contentId);
+        content.id = contentId;
+
+        const toggleCollapsible = () => {
           const isOpen = section.classList.contains("open");
           section.classList.toggle("open");
+          header.setAttribute("aria-expanded", !isOpen);
 
           // Animate height
           if (isOpen) {
             content.style.maxHeight = null;
           } else {
             content.style.maxHeight = content.scrollHeight + "px";
+          }
+        };
+
+        header.addEventListener("click", toggleCollapsible);
+
+        header.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            toggleCollapsible();
           }
         });
       }


### PR DESCRIPTION
**What:** Added `role="button"`, `tabindex="0"`, `aria-expanded`, and `aria-controls` to the `.collapsible-header` element in `docs/assets/js/navigation.js`. Also added a `keydown` listener to toggle the collapsible section on `Enter` and `Space` key presses.

**Why:** Previously, collapsible sections were built using standard `<div>` elements with only `click` event listeners, which completely blocked keyboard navigation and screen reader support. 

**Accessibility:** Enables users who rely on keyboard navigation and screen readers to interact with and toggle the collapsible sections. This is a crucial UX improvement.

**Validation:** Formatted with prettier, passed all fast unit tests, and visually verified behavior via Playwright screenshot. Recorded learning safely in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [18261989334474142702](https://jules.google.com/task/18261989334474142702) started by @CodeHalwell*