### PR TITLE
🎨 Palette: [keyboard accessibility] Make heading anchors visible on focus

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-04-24 - Accessibility for Custom Interactive Elements
 **Learning:** Collapsible sections in `docs/assets/js/navigation.js` were built using standard `<div>` elements with only `click` event listeners. This entirely broke keyboard navigation and screen reader support, as non-semantic tags lack focusability (`tabindex="0"`) and default keyboard activation (`Enter`/`Space`).
 **Action:** When building custom interactive components like collapsibles or dropdowns with non-interactive HTML elements (div/span), always explicitly add `role="button"`, `tabindex="0"`, `aria-expanded` state, and listen to `keydown` events for `Enter` and `Space` keys to restore native behavior.
+
+## 2026-04-25 - [Keyboard Accessibility for JavaScript-Toggled Visibility]
+**Learning:** Elements (like heading anchors) that are only made visible on `mouseenter` become invisible traps for keyboard navigators, who cannot see what element has currently received focus when tabbing. Additionally, symbols like "#" used as links are announced poorly (e.g., "number") by screen readers unless given contextual `aria-label`s.
+**Action:** Always provide corresponding `focus` and `blur` event handlers on focusable elements if their visibility is dynamically toggled via `mouseenter`/`mouseleave`. Furthermore, ensure symbol-only links are given descriptive `aria-label`s capturing their functional context (e.g., "Link to section: [heading text]").

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -329,6 +329,7 @@
       anchor.href = "#" + heading.id;
       anchor.innerHTML = "#";
       anchor.title = "Link to this section";
+      anchor.setAttribute("aria-label", "Link to section: " + heading.textContent);
       anchor.style.cssText = `
         margin-left: 8px;
         opacity: 0;
@@ -344,6 +345,14 @@
       });
 
       heading.addEventListener("mouseleave", function () {
+        anchor.style.opacity = "0";
+      });
+
+      anchor.addEventListener("focus", function () {
+        anchor.style.opacity = "1";
+      });
+
+      anchor.addEventListener("blur", function () {
         anchor.style.opacity = "0";
       });
     });


### PR DESCRIPTION
* 💡 What: Added `focus` and `blur` event handlers to dynamically created heading anchors in `docs/assets/js/navigation.js` to mirror existing hover states, and added an informative `aria-label`.
* 🎯 Why: Previously, heading anchors were only visible on `mouseenter`, rendering them invisible when tabbed to via keyboard. The `#` innerHTML was also unhelpful for screen readers.
* 📸 Before/After: Before, keyboard tab focus was invisible and announced as "number". After, the anchor link becomes fully visible on focus and announces "Link to section: [Section Name]".
* ♿ Accessibility: Improved keyboard navigation visibility and screen reader context for heading anchors.

---
*PR created automatically by Jules for task [624902535167564555](https://jules.google.com/task/624902535167564555) started by @CodeHalwell*