### PR TITLE
🎨 Palette: [UX improvement] Add keyboard and screen reader accessibility to heading anchors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-04-24 - Accessibility for Custom Interactive Elements
 **Learning:** Collapsible sections in `docs/assets/js/navigation.js` were built using standard `<div>` elements with only `click` event listeners. This entirely broke keyboard navigation and screen reader support, as non-semantic tags lack focusability (`tabindex="0"`) and default keyboard activation (`Enter`/`Space`).
 **Action:** When building custom interactive components like collapsibles or dropdowns with non-interactive HTML elements (div/span), always explicitly add `role="button"`, `tabindex="0"`, `aria-expanded` state, and listen to `keydown` events for `Enter` and `Space` keys to restore native behavior.
+
+## 2024-05-18 - [Heading Anchor Link Accessibility]
+**Learning:** Heading anchor links dynamically made visible via `mouseenter` and `mouseleave` can be hidden from keyboard users tab navigation. Also, screen readers might only announce a symbol-only link as its symbol.
+**Action:** When creating anchor links, add `focus` and `blur` listeners to match the hover behavior, and always add an informative `aria-label` to the link tag so screen readers read a descriptive label instead of just a symbol.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -329,6 +329,10 @@
       anchor.href = "#" + heading.id;
       anchor.innerHTML = "#";
       anchor.title = "Link to this section";
+      anchor.setAttribute(
+        "aria-label",
+        "Link to " + heading.textContent + " section",
+      );
       anchor.style.cssText = `
         margin-left: 8px;
         opacity: 0;
@@ -344,6 +348,14 @@
       });
 
       heading.addEventListener("mouseleave", function () {
+        anchor.style.opacity = "0";
+      });
+
+      anchor.addEventListener("focus", function () {
+        anchor.style.opacity = "1";
+      });
+
+      anchor.addEventListener("blur", function () {
         anchor.style.opacity = "0";
       });
     });


### PR DESCRIPTION
**💡 What:** Added `focus` and `blur` event listeners to dynamically generated heading anchor links in the documentation to ensure visibility during keyboard navigation. Also added an `aria-label` to the anchors.
**🎯 Why:** Keyboard users navigating via the Tab key could not see the dynamically inserted `#` anchor links, which were only visible on mouse hover (`mouseenter`). Additionally, screen readers would only read the `#` symbol for these links, lacking context.
**♿ Accessibility:** Keyboard-only users can now see which heading anchor link they are focused on, and screen readers will announce a descriptive label such as "Link to Getting Started section" instead of just "hash".

---
*PR created automatically by Jules for task [1652044644960478484](https://jules.google.com/task/1652044644960478484) started by @CodeHalwell*