### PR TITLE
🎨 Palette: Improve heading anchor link accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-04-24 - Accessibility for Custom Interactive Elements
 **Learning:** Collapsible sections in `docs/assets/js/navigation.js` were built using standard `<div>` elements with only `click` event listeners. This entirely broke keyboard navigation and screen reader support, as non-semantic tags lack focusability (`tabindex="0"`) and default keyboard activation (`Enter`/`Space`).
 **Action:** When building custom interactive components like collapsibles or dropdowns with non-interactive HTML elements (div/span), always explicitly add `role="button"`, `tabindex="0"`, `aria-expanded` state, and listen to `keydown` events for `Enter` and `Space` keys to restore native behavior.
+
+## 2024-04-27 - Heading Anchor Visibility with Keyboard Focus
+**Learning:** Heading anchor links (`#`) that are only shown when hovering over the parent heading (`mouseenter` / `mouseleave`) are completely invisible to keyboard-only users navigating via tab, even though the anchor natively supports focus. Also, a simple `#` text gives no context to a screen reader.
+**Action:** When creating heading anchors, add `focus` and `blur` event listeners directly to the anchor to explicitly show it during keyboard navigation. Additionally, always add a descriptive `aria-label` like "Link to section: [Heading Title]" to symbol-only links.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -329,6 +329,10 @@
       anchor.href = "#" + heading.id;
       anchor.innerHTML = "#";
       anchor.title = "Link to this section";
+      anchor.setAttribute(
+        "aria-label",
+        "Link to section: " + heading.textContent.trim(),
+      );
       anchor.style.cssText = `
         margin-left: 8px;
         opacity: 0;
@@ -344,6 +348,14 @@
       });
 
       heading.addEventListener("mouseleave", function () {
+        anchor.style.opacity = "0";
+      });
+
+      anchor.addEventListener("focus", function () {
+        anchor.style.opacity = "1";
+      });
+
+      anchor.addEventListener("blur", function () {
         anchor.style.opacity = "0";
       });
     });


### PR DESCRIPTION
💡 What: Added `aria-label` to heading anchor links (`#`) and implemented `focus` and `blur` event listeners to make them visible during keyboard navigation.
🎯 Why: Previously, heading anchor links were only visible on mouse hover (`mouseenter`/`mouseleave`), rendering them completely invisible to keyboard navigators relying on the Tab key. The `#` symbol also lacked descriptive context for screen readers.
📸 Before/After: Verified visual focus state via Playwright screenshot.
♿ Accessibility: Improves WCAG compliance for keyboard accessibility (focus visibility) and screen reader usage (descriptive link text).

---
*PR created automatically by Jules for task [15297201348008541754](https://jules.google.com/task/15297201348008541754) started by @CodeHalwell*