### PR TITLE
🎨 Palette: Improve keyboard accessibility of heading anchor links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-04-24 - Accessibility for Custom Interactive Elements
 **Learning:** Collapsible sections in `docs/assets/js/navigation.js` were built using standard `<div>` elements with only `click` event listeners. This entirely broke keyboard navigation and screen reader support, as non-semantic tags lack focusability (`tabindex="0"`) and default keyboard activation (`Enter`/`Space`).
 **Action:** When building custom interactive components like collapsibles or dropdowns with non-interactive HTML elements (div/span), always explicitly add `role="button"`, `tabindex="0"`, `aria-expanded` state, and listen to `keydown` events for `Enter` and `Space` keys to restore native behavior.
+
+## 2026-04-28 - [Heading Anchor Links Accessibility]
+**Learning:** When creating elements that appear on hover (like anchor links next to headings), relying only on `mouseenter`/`mouseleave` hides them from keyboard-only users navigating via `Tab`. Furthermore, symbol-only links like `#` are opaque to screen readers unless they have a descriptive `aria-label`.
+**Action:** Always pair `mouseenter`/`mouseleave` with `focus`/`blur` event listeners for interactive elements, and add `aria-label` attributes to symbol-only links to provide context for screen readers.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -337,6 +337,11 @@
         color: var(--text-muted);
       `;
 
+      anchor.setAttribute(
+        "aria-label",
+        "Link to section: " + heading.textContent,
+      );
+
       heading.appendChild(anchor);
 
       heading.addEventListener("mouseenter", function () {
@@ -344,6 +349,14 @@
       });
 
       heading.addEventListener("mouseleave", function () {
+        anchor.style.opacity = "0";
+      });
+
+      anchor.addEventListener("focus", function () {
+        anchor.style.opacity = "1";
+      });
+
+      anchor.addEventListener("blur", function () {
         anchor.style.opacity = "0";
       });
     });


### PR DESCRIPTION
💡 What: Added `focus` and `blur` event listeners and a descriptive `aria-label` to heading anchor links in the documentation navigation script.
🎯 Why: To ensure keyboard users can visually see the anchor links when tabbed into, and to provide screen readers with descriptive context instead of reading just the `#` symbol.
📸 Before/After: Anchor links were previously visible hover-only and provided no context for screen readers. They are now accessible via keyboard navigation with visual focus and include full screen reader context.
♿ Accessibility: Improved keyboard focus visibility (`focus`/`blur`) and added context (`aria-label`) for screen readers interacting with symbol-only links.

---
*PR created automatically by Jules for task [4612520219891921230](https://jules.google.com/task/4612520219891921230) started by @CodeHalwell*