### PR TITLE
🎨 Palette: Fix keyboard focus management for smooth scrolling links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2026-04-25 - [Keyboard Accessibility for JavaScript-Toggled Visibility]
 **Learning:** Elements (like heading anchors) that are only made visible on `mouseenter` become invisible traps for keyboard navigators, who cannot see what element has currently received focus when tabbing. Additionally, symbols like "#" used as links are announced poorly (e.g., "number") by screen readers unless given contextual `aria-label`s.
 **Action:** Always provide corresponding `focus` and `blur` event handlers on focusable elements if their visibility is dynamically toggled via `mouseenter`/`mouseleave`. Furthermore, ensure symbol-only links are given descriptive `aria-label`s capturing their functional context (e.g., "Link to section: [heading text]").
+
+## 2026-04-29 - [Keyboard Focus Management with Programmatic Scrolling]
+**Learning:** Intercepting anchor clicks (like "Skip to main content") with `e.preventDefault()` to apply smooth scrolling breaks native focus movement. If focus remains on the clicked link, subsequent `Tab` presses will not start from the target element, rendering the skip link ineffective for keyboard users.
+**Action:** Always manually move focus to the target element (`target.focus({ preventScroll: true })`) and ensure it's focusable by temporarily setting `tabindex="-1"` when implementing programmatic smooth scrolling for in-page anchors.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -89,6 +89,10 @@
 
           // Update URL without triggering scroll
           history.pushState(null, "", href);
+
+          // Update focus for accessibility
+          target.setAttribute("tabindex", "-1");
+          target.focus({ preventScroll: true });
         }
       });
     });
@@ -329,7 +333,10 @@
       anchor.href = "#" + heading.id;
       anchor.innerHTML = "#";
       anchor.title = "Link to this section";
-      anchor.setAttribute("aria-label", "Link to section: " + heading.textContent);
+      anchor.setAttribute(
+        "aria-label",
+        "Link to section: " + heading.textContent,
+      );
       anchor.style.cssText = `
         margin-left: 8px;
         opacity: 0;


### PR DESCRIPTION
💡 **What:** Added programmatic focus management to the smooth scroll interception logic in `docs/assets/js/navigation.js`. When a user clicks an in-page anchor (like the "Skip to main content" link), focus is explicitly moved to the target element using `target.focus({ preventScroll: true })`.

🎯 **Why:** Previously, the smooth scroll logic intercepted clicks with `e.preventDefault()`, which prevented the browser's native behavior of moving focus to the target element. This broke keyboard navigation, as subsequent `Tab` presses would start from the original clicked link rather than continuing from the newly scrolled-to section.

♿ **Accessibility:** This directly fixes a critical keyboard navigation bug, ensuring skip links and table of contents links properly move focus for keyboard and screen reader users without sacrificing the smooth visual scrolling experience.

---
*PR created automatically by Jules for task [17253271190844490777](https://jules.google.com/task/17253271190844490777) started by @CodeHalwell*