### PR TITLE
Add first-class LangChain / LangGraph bridge

### DIFF
--- a/agent_gantry/integrations/README.md
+++ b/agent_gantry/integrations/README.md
@@ -151,7 +151,7 @@ and LangGraph (``langgraph.prebuilt.create_react_agent``).
 ```python
 from agent_gantry import AgentGantry
 from agent_gantry.core.security import SecurityPolicy
-from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+from agent_gantry.integrations import LangChainToolBridge
 
 gantry = AgentGantry()
 # Register tools...
@@ -163,7 +163,7 @@ async def approve(tool_def, arguments) -> bool:
     # Plug your approval UI / Slack ping here.
     return True
 
-bridge = GantryToolBridge(
+bridge = LangChainToolBridge(
     gantry,
     security_policy=policy,
     approval_callback=approve,

--- a/agent_gantry/integrations/README.md
+++ b/agent_gantry/integrations/README.md
@@ -139,22 +139,51 @@ tools = await fetch_framework_tools(
 # Pass tools directly to your framework
 ```
 
-### LangChain Integration
+### LangChain / LangGraph Integration (first-class bridge)
+
+The :class:`LangChainToolBridge` wraps Gantry tools as native LangChain
+``StructuredTool`` instances. Each invocation flows through Gantry's
+executor, so retries, circuit breakers, telemetry, and an optional
+``SecurityPolicy`` + approval callback all apply uniformly. The same
+``StructuredTool`` works in both LangChain (``langchain.agents.create_agent``)
+and LangGraph (``langgraph.prebuilt.create_react_agent``).
 
 ```python
-from langchain_openai import ChatOpenAI
-from agent_gantry import AgentGantry, with_semantic_tools
+from agent_gantry import AgentGantry
+from agent_gantry.core.security import SecurityPolicy
+from agent_gantry.integrations.langchain_bridge import GantryToolBridge
 
 gantry = AgentGantry()
 # Register tools...
+await gantry.sync()
 
-# Use decorator with LangChain
-@with_semantic_tools(gantry, limit=3)
-async def chat_with_langchain(prompt: str, *, tools=None):
-    llm = ChatOpenAI(model="gpt-4o")
-    # Convert to LangChain tools and use with your agent
-    # See examples/agent_frameworks/langchain_example.py for details
+policy = SecurityPolicy(require_confirmation=["delete_*", "refund_*"])
+
+async def approve(tool_def, arguments) -> bool:
+    # Plug your approval UI / Slack ping here.
+    return True
+
+bridge = GantryToolBridge(
+    gantry,
+    security_policy=policy,
+    approval_callback=approve,
+)
+
+# Top-k retrieval as native LangChain tools
+tools = await bridge.get_tools("send a follow-up email", limit=3)
+
+# Convenience: build a ready-to-run LangChain agent in one call
+agent = await bridge.build_agent(
+    "openai:gpt-4o", "send a follow-up email", limit=3
+)
 ```
+
+Tools whose ``ToolCapability`` set includes destructive entries
+(``WRITE_DATA``, ``DELETE_DATA``, ``EXECUTE_CODE``, ``FINANCIAL``,
+``PII_ACCESS``) are automatically gated by ``approval_callback`` even when
+no ``security_policy`` pattern matches — mirroring the Microsoft Agent
+Framework bridge's ``approval_mode="always_require"`` behaviour. Set
+``capability_approval=False`` to opt out.
 
 ### CrewAI Integration
 
@@ -183,6 +212,7 @@ agent = Agent(
 
 - `semantic_tools.py`: Core `with_semantic_tools` decorator and `SemanticToolSelector` class for automatic tool injection
 - `framework_adapters.py`: Helpers for converting tools to framework-specific formats (LangGraph, LangChain, CrewAI, Google ADK, Strands, Pydantic AI)
+- `langchain_bridge.py`: LangChain / LangGraph bridge — `LangChainToolBridge` wraps Gantry tools as `StructuredTool`s with security-policy + approval-callback enforcement, and exposes `get_tools()`, `wrap_tool()`, `wrap_tools()`, and `build_agent()` helpers.
 - `agent_framework_bridge.py`: Microsoft Agent Framework 1.0 GA bridge — `GantryToolBridge` wraps Gantry tools as AF `FunctionTool`s with `approval_mode` auto-derived from Gantry `ToolCapability`. Exposes three agent construction helpers:
   - `build_agent(client, query, ...)` — one-liner using `client.as_agent()`, fine for single-agent flows.
   - `as_agent(client, query, ...)` — direct `Agent(client, ...)` construction; preferred when the result feeds `WorkflowBuilder`.

--- a/agent_gantry/integrations/__init__.py
+++ b/agent_gantry/integrations/__init__.py
@@ -29,12 +29,12 @@ GantryToolBridge = AgentFrameworkToolBridge
 
 __all__: list[str] = [
     "AgentFrameworkToolBridge",
+    "fetch_framework_tools",
     "GantryApprovalMiddleware",
     "GantryObservabilityMiddleware",
     "GantryToolBridge",
     "LangChainToolBridge",
     "SemanticToolSelector",
     "SemanticToolsDecorator",
-    "fetch_framework_tools",
     "with_semantic_tools",
 ]

--- a/agent_gantry/integrations/__init__.py
+++ b/agent_gantry/integrations/__init__.py
@@ -5,24 +5,36 @@ Integrations with Microsoft Agent Framework, LangChain, LangGraph,
 Google ADK, Pydantic AI, CrewAI, and Strands.
 """
 
-from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+from agent_gantry.integrations.agent_framework_bridge import (
+    GantryToolBridge as AgentFrameworkToolBridge,
+)
 from agent_gantry.integrations.agent_framework_middleware import (
     GantryApprovalMiddleware,
     GantryObservabilityMiddleware,
 )
 from agent_gantry.integrations.framework_adapters import fetch_framework_tools
+from agent_gantry.integrations.langchain_bridge import (
+    GantryToolBridge as LangChainToolBridge,
+)
 from agent_gantry.integrations.semantic_tools import (
     SemanticToolsDecorator,
     SemanticToolSelector,
     with_semantic_tools,
 )
 
+# Back-compat: ``GantryToolBridge`` historically referred to the Microsoft
+# Agent Framework bridge. Keep the alias so existing imports continue to work
+# while new framework-specific bridges land alongside it.
+GantryToolBridge = AgentFrameworkToolBridge
+
 __all__: list[str] = [
+    "AgentFrameworkToolBridge",
     "GantryApprovalMiddleware",
     "GantryObservabilityMiddleware",
     "GantryToolBridge",
+    "LangChainToolBridge",
     "SemanticToolSelector",
     "SemanticToolsDecorator",
-    "with_semantic_tools",
     "fetch_framework_tools",
+    "with_semantic_tools",
 ]

--- a/agent_gantry/integrations/langchain_bridge.py
+++ b/agent_gantry/integrations/langchain_bridge.py
@@ -118,20 +118,38 @@ def _build_args_schema(tool_def: ToolDefinition) -> type[BaseModel]:
     Building it dynamically from Gantry's ``parameters_schema`` keeps the
     field names, descriptions, and required/optional state in sync with the
     underlying tool registration.
+
+    Optional parameters are typed as ``py_type | None`` only when the
+    schema either omits a default or explicitly defaults to ``None`` —
+    surfacing ``None`` as a valid value to LangChain. Optional parameters
+    with concrete defaults (e.g. ``{"default": "celsius"}``) keep their
+    declared type so the generated schema doesn't advertise a spurious
+    ``null`` shape that could confuse the model or downstream tools.
     """
     params_schema = tool_def.parameters_schema or {}
     properties: dict[str, dict[str, Any]] = params_schema.get("properties", {})
     required: set[str] = set(params_schema.get("required", []))
 
+    _missing = object()
     fields: dict[str, tuple[Any, Any]] = {}
     for name, info in properties.items():
         py_type = _json_type_to_python(info.get("type", "string"))
         description = info.get("description") or f"Parameter: {name}"
         if name in required:
             fields[name] = (py_type, Field(..., description=description))
+            continue
+
+        default = info.get("default", _missing)
+        # Allow None only when the schema either omits a default or
+        # explicitly defaults to null. Concrete defaults keep their
+        # declared type so the LLM-facing schema isn't widened to nullable.
+        if default is _missing or default is None:
+            field_type = py_type | None
+            field_default = None
         else:
-            default = info.get("default", None)
-            fields[name] = (py_type | None, Field(default=default, description=description))
+            field_type = py_type
+            field_default = default
+        fields[name] = (field_type, Field(default=field_default, description=description))
 
     # Pydantic refuses to build empty models with create_model; use a sentinel
     # field-less subclass so StructuredTool still has a valid args_schema.
@@ -459,15 +477,23 @@ class GantryToolBridge:
             **create_agent_kwargs: Forwarded to ``create_agent``.
 
         Raises:
-            ImportError: If ``langchain`` is not installed.
+            ModuleNotFoundError: If ``langchain`` is not installed.
+            ImportError: If ``langchain`` is installed but ``create_agent``
+                cannot be imported (e.g. an older release without that
+                symbol). The original error is propagated unchanged so the
+                version-mismatch hint is visible.
         """
         try:
             from langchain.agents import create_agent
-        except ImportError as exc:  # pragma: no cover - surfaced via tests
-            raise ImportError(
+        except ModuleNotFoundError as exc:  # pragma: no cover - surfaced via tests
+            raise ModuleNotFoundError(
                 "build_agent() requires the 'langchain' package. "
                 "Install with: pip install 'agent-gantry[agent-frameworks]'"
             ) from exc
+        # Any other ImportError (e.g. "cannot import name 'create_agent' from
+        # 'langchain.agents'" on older LangChain releases) propagates with its
+        # original message — that is more actionable than a synthesised
+        # "package not installed" hint.
 
         tools = await self.get_tools(
             query, limit=limit, score_threshold=score_threshold

--- a/agent_gantry/integrations/langchain_bridge.py
+++ b/agent_gantry/integrations/langchain_bridge.py
@@ -1,0 +1,474 @@
+"""
+LangChain bridge for Agent-Gantry.
+
+Provides first-class integration between Agent-Gantry's semantic tool routing
+and LangChain (1.x). The bridge converts Gantry tool definitions into native
+LangChain ``StructuredTool`` instances that any LangChain or LangGraph agent
+can consume directly, while routing every invocation back through Gantry's
+executor so the security policy, retries, circuit breakers, and telemetry
+all still apply.
+
+Key class:
+    - :class:`GantryToolBridge` — wraps Gantry tools as LangChain tools.
+
+Usage::
+
+    from agent_gantry import AgentGantry
+    from agent_gantry.core.security import SecurityPolicy
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+
+    @gantry.register
+    def get_weather(city: str) -> str:
+        '''Get current weather for a city.'''
+        return f"Weather in {city}: Sunny, 22C"
+
+    await gantry.sync()
+
+    bridge = GantryToolBridge(
+        gantry,
+        security_policy=SecurityPolicy(require_confirmation=["delete_*"]),
+    )
+    tools = await bridge.get_tools("What's the weather?", limit=3)
+
+    # Pass directly to any LangChain / LangGraph agent:
+    from langchain.agents import create_agent
+    agent = create_agent(model="openai:gpt-4o", tools=tools)
+    result = await agent.ainvoke({"messages": [{"role": "user", "content": "..."}]})
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field, create_model
+
+from agent_gantry.core.security import (
+    ConfirmationRequiredError,
+    PermissionDeniedError,
+    SecurityPolicy,
+)
+from agent_gantry.schema.execution import ToolCall
+from agent_gantry.schema.tool import ToolCapability
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+    from agent_gantry.schema.query import RetrievalResult
+    from agent_gantry.schema.tool import ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+
+_APPROVAL_REQUIRED_CAPS: frozenset[ToolCapability] = frozenset(
+    {
+        ToolCapability.WRITE_DATA,
+        ToolCapability.DELETE_DATA,
+        ToolCapability.EXECUTE_CODE,
+        ToolCapability.FINANCIAL,
+        ToolCapability.PII_ACCESS,
+    }
+)
+
+
+ApprovalCallback = Callable[
+    ["ToolDefinition", dict[str, Any]],
+    "bool | Awaitable[bool]",
+]
+"""Callback invoked when a tool requires human approval before execution.
+
+Receives the ``ToolDefinition`` and the call arguments. Return ``True`` to
+allow the call to proceed, ``False`` to deny (raises
+:class:`PermissionDeniedError`). May be sync or async.
+"""
+
+
+def _require_langchain_installed(caller: str) -> None:
+    """Raise a descriptive ImportError when langchain-core is not installed."""
+    try:
+        import langchain_core  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            f"{caller}() requires the 'langchain-core' package. "
+            "Install with: pip install 'agent-gantry[agent-frameworks]'"
+        ) from exc
+
+
+def _json_type_to_python(json_type: str) -> Any:
+    """Map a JSON Schema type string to a Python type for Pydantic fields."""
+    mapping: dict[str, Any] = {
+        "string": str,
+        "integer": int,
+        "number": float,
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }
+    return mapping.get(json_type, str)
+
+
+def _build_args_schema(tool_def: ToolDefinition) -> type[BaseModel]:
+    """Construct a Pydantic ``args_schema`` from a Gantry tool's JSON schema.
+
+    LangChain's ``StructuredTool`` uses an ``args_schema`` (a Pydantic model
+    class) to validate inputs and to render the tool definition for the LLM.
+    Building it dynamically from Gantry's ``parameters_schema`` keeps the
+    field names, descriptions, and required/optional state in sync with the
+    underlying tool registration.
+    """
+    params_schema = tool_def.parameters_schema or {}
+    properties: dict[str, dict[str, Any]] = params_schema.get("properties", {})
+    required: set[str] = set(params_schema.get("required", []))
+
+    fields: dict[str, tuple[Any, Any]] = {}
+    for name, info in properties.items():
+        py_type = _json_type_to_python(info.get("type", "string"))
+        description = info.get("description") or f"Parameter: {name}"
+        if name in required:
+            fields[name] = (py_type, Field(..., description=description))
+        else:
+            default = info.get("default", None)
+            fields[name] = (py_type | None, Field(default=default, description=description))
+
+    # Pydantic refuses to build empty models with create_model; use a sentinel
+    # field-less subclass so StructuredTool still has a valid args_schema.
+    if not fields:
+        return create_model(f"{tool_def.name}_NoArgs", __base__=BaseModel)
+
+    return create_model(f"{tool_def.name}_Args", __base__=BaseModel, **fields)
+
+
+def _tool_requires_approval(tool_def: ToolDefinition) -> bool:
+    """Return True if the tool's capabilities mark it as approval-gated."""
+    return bool(set(tool_def.capabilities) & _APPROVAL_REQUIRED_CAPS)
+
+
+def _cache_key(tool_def: ToolDefinition) -> str:
+    return f"{tool_def.namespace}:{tool_def.name}:{tool_def.version}"
+
+
+class GantryToolBridge:
+    """
+    Bridge between Agent-Gantry and LangChain (and LangGraph).
+
+    Retrieves semantically relevant tools from Gantry and wraps them as
+    LangChain ``StructuredTool`` instances. The wrapped tools route every
+    invocation back through ``gantry.execute(...)`` so retries, circuit
+    breakers, security policy, and telemetry all flow through uniformly.
+
+    Args:
+        gantry: The AgentGantry instance providing tool retrieval and execution.
+        score_threshold: Default minimum relevance score for tool selection.
+        security_policy: Optional :class:`SecurityPolicy` enforced before each
+            tool invocation. When a tool matches a ``require_confirmation``
+            pattern, the bridge consults ``approval_callback`` (if set) or
+            raises :class:`ConfirmationRequiredError` if none is configured.
+        approval_callback: Optional async-or-sync callable consulted when a
+            tool requires human approval (either because the
+            ``security_policy`` flagged it, or because the tool's capabilities
+            include destructive ones such as ``WRITE_DATA`` / ``DELETE_DATA``
+            / ``EXECUTE_CODE`` / ``FINANCIAL`` / ``PII_ACCESS``). Receives the
+            ``ToolDefinition`` and the call arguments and must return a bool.
+        capability_approval: When ``True`` (default), tools whose capabilities
+            include any of the destructive set are also gated by
+            ``approval_callback``, mirroring the AF bridge's
+            ``approval_mode="always_require"`` behaviour. Set ``False`` to
+            only gate tools matched by ``security_policy.require_confirmation``.
+    """
+
+    def __init__(
+        self,
+        gantry: AgentGantry,
+        *,
+        score_threshold: float = 0.3,
+        security_policy: SecurityPolicy | None = None,
+        approval_callback: ApprovalCallback | None = None,
+        capability_approval: bool = True,
+    ) -> None:
+        self._gantry = gantry
+        self._score_threshold = score_threshold
+        self._security_policy = security_policy
+        self._approval_callback = approval_callback
+        self._capability_approval = capability_approval
+        self._tool_cache: dict[str, Any] = {}
+
+    async def _retrieve(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        score_threshold: float | None = None,
+        **query_kwargs: Any,
+    ) -> RetrievalResult:
+        from agent_gantry.schema.query import ConversationContext, ToolQuery
+
+        threshold = (
+            score_threshold if score_threshold is not None else self._score_threshold
+        )
+
+        context_fields = set(ConversationContext.model_fields.keys()) - {"query"}
+        context_kwargs = {
+            k: v for k, v in query_kwargs.items() if k in context_fields
+        }
+        tool_query_fields = set(ToolQuery.model_fields.keys()) - {
+            "context",
+            "limit",
+            "score_threshold",
+        }
+        tq_kwargs = {k: v for k, v in query_kwargs.items() if k in tool_query_fields}
+
+        return await self._gantry.retrieve(
+            ToolQuery(
+                context=ConversationContext(query=query, **context_kwargs),
+                limit=limit,
+                score_threshold=threshold,
+                **tq_kwargs,
+            )
+        )
+
+    async def _consult_approval(
+        self,
+        tool_def: ToolDefinition,
+        arguments: dict[str, Any],
+        reason: str,
+    ) -> None:
+        """Invoke the approval callback (if any), or raise."""
+        if self._approval_callback is None:
+            raise ConfirmationRequiredError(
+                f"Tool {tool_def.name} requires human approval ({reason}); "
+                "no approval_callback configured on GantryToolBridge."
+            )
+
+        result = self._approval_callback(tool_def, arguments)
+        if hasattr(result, "__await__"):
+            result = await result  # type: ignore[assignment]
+        if not result:
+            raise PermissionDeniedError(
+                f"Tool {tool_def.name} denied by approval_callback ({reason})."
+            )
+
+    async def _gate(
+        self, tool_def: ToolDefinition, arguments: dict[str, Any]
+    ) -> None:
+        """Run security-policy + capability-approval checks before execution."""
+        if self._security_policy is not None:
+            try:
+                self._security_policy.check_permission(tool_def.name, arguments)
+            except ConfirmationRequiredError as err:
+                logger.info(
+                    "GantryToolBridge: '%s' requires approval (policy: %s)",
+                    tool_def.name,
+                    err,
+                )
+                await self._consult_approval(tool_def, arguments, "policy match")
+            except PermissionDeniedError:
+                logger.warning(
+                    "GantryToolBridge: denied execution of '%s' by policy",
+                    tool_def.name,
+                )
+                raise
+
+        if self._capability_approval and _tool_requires_approval(tool_def):
+            await self._consult_approval(
+                tool_def, arguments, "destructive capability"
+            )
+
+    def _wrap_tool(self, tool_def: ToolDefinition) -> Any:
+        """Build a LangChain ``StructuredTool`` for a single Gantry tool."""
+        _require_langchain_installed("GantryToolBridge")
+        from langchain_core.tools import StructuredTool
+
+        args_schema = _build_args_schema(tool_def)
+        gantry = self._gantry
+        bridge = self
+        tool_name = tool_def.name
+        tool_desc = tool_def.description or f"Gantry tool: {tool_name}"
+
+        async def _arun(**kwargs: Any) -> Any:
+            await bridge._gate(tool_def, kwargs)
+            telemetry = getattr(gantry, "_telemetry", None)
+            span_cm = None
+            if telemetry is not None:
+                try:
+                    span_cm = telemetry.span(
+                        "langchain_tool_invocation", {"tool_name": tool_name}
+                    )
+                except Exception:  # pragma: no cover - telemetry best-effort
+                    logger.debug(
+                        "GantryToolBridge: telemetry.span failed",
+                        exc_info=True,
+                    )
+                    span_cm = None
+
+            async def _invoke() -> Any:
+                result = await gantry.execute(
+                    ToolCall(tool_name=tool_name, arguments=kwargs)
+                )
+                status = (
+                    result.status.value
+                    if hasattr(result.status, "value")
+                    else str(result.status)
+                )
+                if status == "success":
+                    val = result.result
+                    return val if isinstance(val, str) else json.dumps(val)
+                # Surfacing the error via exception lets LangChain agents
+                # handle/retry; bare strings would be returned as the tool's
+                # observation and the agent might continue blindly.
+                raise RuntimeError(
+                    f"{tool_name} failed: {result.error or 'tool execution failed'}"
+                )
+
+            if span_cm is None:
+                return await _invoke()
+            async with span_cm:
+                return await _invoke()
+
+        def _run(**kwargs: Any) -> Any:
+            # Sync entrypoint: LangChain calls this when the agent isn't async.
+            # Delegate to the async path via asyncio.run when there is no
+            # running loop; otherwise fall back to a fresh event loop on a
+            # thread to avoid "asyncio.run() cannot be called from a running
+            # event loop" inside LangGraph's threadpool.
+            import asyncio
+
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                return asyncio.run(_arun(**kwargs))
+
+            import threading
+
+            container: dict[str, Any] = {}
+
+            def _runner() -> None:
+                try:
+                    container["result"] = asyncio.run(_arun(**kwargs))
+                except BaseException as exc:  # pragma: no cover - re-raised below
+                    container["error"] = exc
+
+            thread = threading.Thread(target=_runner, daemon=True)
+            thread.start()
+            thread.join()
+            if "error" in container:
+                raise container["error"]
+            return container["result"]
+
+        return StructuredTool.from_function(
+            func=_run,
+            coroutine=_arun,
+            name=tool_name,
+            description=tool_desc,
+            args_schema=args_schema,
+        )
+
+    def wrap_tool(self, tool_def: ToolDefinition, *, cache: bool = True) -> Any:
+        """Wrap a single ``ToolDefinition`` as a LangChain ``StructuredTool``."""
+        if not cache:
+            return self._wrap_tool(tool_def)
+        key = _cache_key(tool_def)
+        existing = self._tool_cache.get(key)
+        if existing is not None:
+            return existing
+        wrapped = self._wrap_tool(tool_def)
+        self._tool_cache[key] = wrapped
+        return wrapped
+
+    def wrap_tools(
+        self, tool_defs: list[ToolDefinition], *, cache: bool = True
+    ) -> list[Any]:
+        """Wrap a list of ``ToolDefinition`` objects."""
+        return [self.wrap_tool(td, cache=cache) for td in tool_defs]
+
+    async def get_tools(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        score_threshold: float | None = None,
+        cache: bool = True,
+        **query_kwargs: Any,
+    ) -> list[Any]:
+        """Retrieve top-k tools for ``query`` and return them as LangChain tools."""
+        result = await self._retrieve(
+            query, limit=limit, score_threshold=score_threshold, **query_kwargs
+        )
+        return [self.wrap_tool(scored.tool, cache=cache) for scored in result.tools]
+
+    async def get_tools_with_scores(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        score_threshold: float | None = None,
+        cache: bool = True,
+        **query_kwargs: Any,
+    ) -> list[tuple[Any, float]]:
+        """Retrieve top-k tools alongside their relevance scores."""
+        result = await self._retrieve(
+            query, limit=limit, score_threshold=score_threshold, **query_kwargs
+        )
+        return [
+            (self.wrap_tool(scored.tool, cache=cache), scored.final_score)
+            for scored in result.tools
+        ]
+
+    async def build_agent(
+        self,
+        model: Any,
+        query: str,
+        *,
+        limit: int = 5,
+        score_threshold: float | None = None,
+        extra_tools: list[Any] | None = None,
+        **create_agent_kwargs: Any,
+    ) -> Any:
+        """Build a ``langchain.agents.create_agent`` agent wired with retrieved tools.
+
+        Convenience wrapper for the common case where you want a ready-to-run
+        LangChain agent backed by Gantry-selected tools. Returns whatever
+        ``langchain.agents.create_agent`` returns (a ``CompiledStateGraph``
+        in LangChain 1.x).
+
+        Args:
+            model: The model passed to ``create_agent`` — either an
+                initialised LangChain chat model or a provider string such
+                as ``"openai:gpt-4o"``.
+            query: The user query used to seed semantic tool retrieval.
+            limit: Maximum tools to surface from Gantry.
+            score_threshold: Override the bridge default score threshold.
+            extra_tools: Additional LangChain tools to include alongside the
+                Gantry-retrieved set (e.g. tools that aren't registered with
+                Gantry).
+            **create_agent_kwargs: Forwarded to ``create_agent``.
+
+        Raises:
+            ImportError: If ``langchain`` is not installed.
+        """
+        try:
+            from langchain.agents import create_agent
+        except ImportError as exc:  # pragma: no cover - surfaced via tests
+            raise ImportError(
+                "build_agent() requires the 'langchain' package. "
+                "Install with: pip install 'agent-gantry[agent-frameworks]'"
+            ) from exc
+
+        tools = await self.get_tools(
+            query, limit=limit, score_threshold=score_threshold
+        )
+        if extra_tools:
+            tools = [*tools, *extra_tools]
+        return create_agent(model=model, tools=tools, **create_agent_kwargs)
+
+    def clear_cache(self) -> None:
+        """Drop all cached wrapped tools — useful when tool definitions change."""
+        self._tool_cache.clear()
+
+
+__all__ = [
+    "ApprovalCallback",
+    "GantryToolBridge",
+]

--- a/agent_gantry/integrations/langchain_bridge.py
+++ b/agent_gantry/integrations/langchain_bridge.py
@@ -253,7 +253,15 @@ class GantryToolBridge:
     async def _gate(
         self, tool_def: ToolDefinition, arguments: dict[str, Any]
     ) -> None:
-        """Run security-policy + capability-approval checks before execution."""
+        """Run security-policy + capability-approval checks before execution.
+
+        A single tool invocation triggers at most one approval prompt even
+        when both gates apply: the policy check runs first, and if it
+        already consulted the approval callback we skip the capability
+        check rather than asking the human a second time for the same call.
+        """
+        approval_consulted = False
+
         if self._security_policy is not None:
             try:
                 self._security_policy.check_permission(tool_def.name, arguments)
@@ -264,6 +272,7 @@ class GantryToolBridge:
                     err,
                 )
                 await self._consult_approval(tool_def, arguments, "policy match")
+                approval_consulted = True
             except PermissionDeniedError:
                 logger.warning(
                     "GantryToolBridge: denied execution of '%s' by policy",
@@ -271,7 +280,11 @@ class GantryToolBridge:
                 )
                 raise
 
-        if self._capability_approval and _tool_requires_approval(tool_def):
+        if (
+            not approval_consulted
+            and self._capability_approval
+            and _tool_requires_approval(tool_def)
+        ):
             await self._consult_approval(
                 tool_def, arguments, "destructive capability"
             )

--- a/examples/agent_frameworks/langchain_example.py
+++ b/examples/agent_frameworks/langchain_example.py
@@ -22,7 +22,7 @@ from langgraph.prebuilt import create_react_agent
 
 from agent_gantry import AgentGantry
 from agent_gantry.core.security import SecurityPolicy
-from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+from agent_gantry.integrations import LangChainToolBridge
 
 load_dotenv()
 
@@ -54,7 +54,7 @@ async def main() -> None:
         print(f"[approval] {tool_def.name}({arguments}) -> auto-approve")
         return True
 
-    bridge = GantryToolBridge(
+    bridge = LangChainToolBridge(
         gantry,
         security_policy=policy,
         approval_callback=approve,

--- a/examples/agent_frameworks/langchain_example.py
+++ b/examples/agent_frameworks/langchain_example.py
@@ -1,8 +1,16 @@
 """
 LangChain + LangGraph Agent-Gantry integration example.
 
-Uses LangGraph's create_react_agent (the recommended approach since LangChain
-dropped its own agent executor abstractions in favour of LangGraph in 1.x).
+Uses ``GantryToolBridge`` to wrap Gantry tools as native LangChain
+``StructuredTool`` instances. The bridge enforces an optional
+``SecurityPolicy`` and approval callback before each tool runs and routes
+every invocation through ``gantry.execute`` so retries, circuit breakers,
+and telemetry all flow through uniformly.
+
+The wrapped tools are usable in either LangChain (``langchain.agents.create_agent``)
+or LangGraph (``langgraph.prebuilt.create_react_agent``) — the same
+``StructuredTool`` works in both because LangGraph reuses LangChain's tool
+abstraction.
 """
 
 import asyncio
@@ -13,69 +21,58 @@ from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
 from agent_gantry import AgentGantry
-from agent_gantry.schema.execution import ToolCall
+from agent_gantry.core.security import SecurityPolicy
+from agent_gantry.integrations.langchain_bridge import GantryToolBridge
 
 load_dotenv()
 
 
-async def main():
-    # 1. Initialize Agent-Gantry
+async def main() -> None:
+    # 1. Initialise Agent-Gantry and register tools.
     gantry = AgentGantry()
 
     @gantry.register(tags=["weather"])
-    def get_weather(location: str):
+    def get_weather(location: str) -> str:
         """Get the current weather in a given location."""
-        return f"The weather in {location} is sunny and 25°C."
+        return f"The weather in {location} is sunny and 25C."
 
     @gantry.register(tags=["finance"])
-    def get_stock_price(symbol: str):
+    def get_stock_price(symbol: str) -> str:
         """Get the current stock price for a symbol."""
         return f"The stock price for {symbol} is $150.00."
 
     await gantry.sync()
 
-    # 2. Define the user query
+    # 2. Build a GantryToolBridge with a security policy. Any tool whose
+    # name matches ``require_confirmation`` will block execution unless the
+    # supplied ``approval_callback`` returns True.
+    policy = SecurityPolicy(require_confirmation=["delete_*", "refund_*"])
+
+    async def approve(tool_def, arguments) -> bool:
+        # Stand-in for an actual human-in-the-loop UI / Slack ping. Returning
+        # ``True`` allows the call; ``False`` denies it.
+        print(f"[approval] {tool_def.name}({arguments}) -> auto-approve")
+        return True
+
+    bridge = GantryToolBridge(
+        gantry,
+        security_policy=policy,
+        approval_callback=approve,
+    )
+
+    # 3. Define the user query and let the bridge retrieve only the relevant
+    # tools as native LangChain ``StructuredTool`` instances.
     user_query = "What's the weather in London and the stock price for AAPL?"
+    tools = await bridge.get_tools(user_query, limit=2, score_threshold=0.1)
+    print(f"Bridge surfaced {len(tools)} tools: {[t.name for t in tools]}")
 
-    # 3. Use Agent-Gantry to retrieve only relevant tools
-    # Lowering threshold for SimpleEmbedder compatibility in this example
-    retrieved_tools = await gantry.retrieve_tools(user_query, limit=2, score_threshold=0.1)
-    print(f"Gantry retrieved {len(retrieved_tools)} tools.")
-
-    # 4. Wrap Gantry tools as LangChain tools for use in LangGraph
-    from langchain.tools import tool
-
-    def make_langchain_tool(tool_name: str, tool_desc: str, gantry_instance: AgentGantry):
-        """Factory that binds the captured tool_name into a LangChain tool."""
-
-        @tool
-        async def tool_wrapper(**kwargs):
-            result = await gantry_instance.execute(ToolCall(tool_name=tool_name, arguments=kwargs))
-            return result.result if result.status == "success" else result.error
-
-        tool_wrapper.__name__ = tool_name
-        tool_wrapper.__doc__ = tool_desc
-        return tool_wrapper
-
-    langchain_tools = [
-        make_langchain_tool(
-            ts["function"]["name"],
-            ts["function"]["description"],
-            gantry,
-        )
-        for ts in retrieved_tools
-    ]
-
-    # 5. Build and run a LangGraph ReAct agent
-    # create_react_agent is the LangGraph-native replacement for the old
-    # LangChain AgentExecutor pattern.
+    # 4. Run a LangGraph ReAct agent backed by the Gantry-selected tools.
     llm = ChatOpenAI(model="gpt-4o", temperature=0)
-    agent = create_react_agent(llm, tools=langchain_tools)
+    agent = create_react_agent(llm, tools=tools)
 
-    print("\n--- Running LangGraph ReAct Agent with Gantry-sourced tools ---")
+    print("\n--- LangGraph ReAct agent with Gantry-sourced tools ---")
     result = await agent.ainvoke({"messages": [HumanMessage(content=user_query)]})
-
-    print(f"\nFinal Response: {result['messages'][-1].content}")
+    print(f"\nFinal response: {result['messages'][-1].content}")
 
 
 if __name__ == "__main__":

--- a/tests/test_langchain_bridge.py
+++ b/tests/test_langchain_bridge.py
@@ -482,6 +482,79 @@ async def test_build_agent_passes_tools_to_create_agent(
 
 
 @pytest.mark.asyncio
+async def test_optional_param_with_concrete_default_is_not_nullable() -> None:
+    """Optional parameters with non-None defaults must not be typed as ``T | None``.
+
+    Widening the type to nullable advertises a spurious ``null`` shape to the
+    LLM and can confuse downstream tools that don't accept ``None``.
+    """
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+    weather_def = await _populate_gantry(gantry)  # ``units`` defaults to "celsius"
+    bridge = GantryToolBridge(gantry)
+    tool = bridge.wrap_tool(weather_def)
+
+    units_field = tool.args_schema.model_fields["units"]
+    # The field accepts ``str``, not ``str | None``: pydantic's runtime
+    # ``annotation`` is the resolved type with no ``Optional`` wrapper.
+    assert units_field.annotation is str
+    assert units_field.default == "celsius"
+
+
+@pytest.mark.asyncio
+async def test_optional_param_without_default_is_nullable() -> None:
+    """Optional parameters with no default keep ``T | None`` so callers can omit them."""
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+    no_default_def = ToolDefinition(
+        name="search",
+        description="Search docs.",
+        parameters_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Query"},
+                "limit": {"type": "integer", "description": "Max results"},
+            },
+            "required": ["query"],
+        },
+    )
+    await gantry.add_tool(no_default_def)
+
+    bridge = GantryToolBridge(gantry)
+    tool = bridge.wrap_tool(no_default_def)
+
+    limit_field = tool.args_schema.model_fields["limit"]
+    # ``int | None`` resolves to a Union annotation at runtime
+    assert limit_field.annotation is not int
+    assert limit_field.default is None
+
+
+def test_public_api_aliases_resolve_to_correct_bridges() -> None:
+    """``LangChainToolBridge`` and ``GantryToolBridge`` exports must point at
+    the right bridge classes so the public API contract can't regress.
+    """
+    from agent_gantry.integrations import (
+        AgentFrameworkToolBridge,
+        GantryToolBridge,
+        LangChainToolBridge,
+    )
+    from agent_gantry.integrations.agent_framework_bridge import (
+        GantryToolBridge as _AFBridge,
+    )
+    from agent_gantry.integrations.langchain_bridge import (
+        GantryToolBridge as _LCBridge,
+    )
+
+    assert LangChainToolBridge is _LCBridge
+    assert AgentFrameworkToolBridge is _AFBridge
+    # Back-compat alias still points at the AF bridge so existing imports
+    # of ``GantryToolBridge`` from ``agent_gantry.integrations`` keep working.
+    assert GantryToolBridge is _AFBridge
+
+
+@pytest.mark.asyncio
 async def test_get_tools_with_scores_returns_pairs() -> None:
     from agent_gantry.integrations.langchain_bridge import GantryToolBridge
 

--- a/tests/test_langchain_bridge.py
+++ b/tests/test_langchain_bridge.py
@@ -1,0 +1,454 @@
+"""
+Tests for the LangChain bridge.
+
+These tests stub out ``langchain_core`` and ``langchain`` so the suite runs
+even when the framework is not installed, mirroring the existing pattern
+used for the Microsoft Agent Framework bridge tests.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.core.security import (
+    ConfirmationRequiredError,
+    PermissionDeniedError,
+    SecurityPolicy,
+)
+from agent_gantry.schema.tool import ToolCapability, ToolDefinition
+
+# ---------------------------------------------------------------------------
+# langchain_core stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubStructuredTool:
+    """Minimal stand-in for langchain_core.tools.StructuredTool.
+
+    Captures the kwargs passed to ``from_function`` so tests can assert on
+    name/description/args_schema and invoke the wrapped coroutine.
+    """
+
+    def __init__(
+        self,
+        *,
+        func: Any,
+        coroutine: Any,
+        name: str,
+        description: str,
+        args_schema: Any,
+    ) -> None:
+        self.func = func
+        self.coroutine = coroutine
+        self.name = name
+        self.description = description
+        self.args_schema = args_schema
+
+    @classmethod
+    def from_function(
+        cls,
+        *,
+        func: Any,
+        coroutine: Any,
+        name: str,
+        description: str,
+        args_schema: Any,
+    ) -> _StubStructuredTool:
+        return cls(
+            func=func,
+            coroutine=coroutine,
+            name=name,
+            description=description,
+            args_schema=args_schema,
+        )
+
+
+@pytest.fixture(autouse=True)
+def stub_langchain_core(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install langchain_core / langchain_core.tools stubs for every test.
+
+    The bridge imports ``langchain_core`` for the install check and
+    ``langchain_core.tools.StructuredTool`` for the actual wrapping. Both are
+    replaced with stub modules so we can run without the real package.
+    """
+    langchain_core = ModuleType("langchain_core")
+    tools_mod = ModuleType("langchain_core.tools")
+    tools_mod.StructuredTool = _StubStructuredTool
+    langchain_core.tools = tools_mod  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "langchain_core", langchain_core)
+    monkeypatch.setitem(sys.modules, "langchain_core.tools", tools_mod)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _populate_gantry(gantry: AgentGantry) -> ToolDefinition:
+    """Register a single benign tool and return its definition."""
+    weather_def = ToolDefinition(
+        name="get_weather",
+        description="Get the current weather for a city.",
+        parameters_schema={
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "City name"},
+                "units": {
+                    "type": "string",
+                    "description": "Temperature units",
+                    "default": "celsius",
+                },
+            },
+            "required": ["city"],
+        },
+    )
+    await gantry.add_tool(weather_def)
+    return weather_def
+
+
+async def _populate_destructive_gantry(gantry: AgentGantry) -> ToolDefinition:
+    """Register a destructive tool that requires approval by capability."""
+    delete_def = ToolDefinition(
+        name="delete_account",
+        description="Permanently delete a user account.",
+        parameters_schema={
+            "type": "object",
+            "properties": {
+                "user_id": {"type": "string", "description": "User to delete"},
+            },
+            "required": ["user_id"],
+        },
+        capabilities=[ToolCapability.DELETE_DATA],
+    )
+    await gantry.add_tool(delete_def)
+    return delete_def
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wrap_tool_builds_structured_tool_with_metadata() -> None:
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+    weather_def = await _populate_gantry(gantry)
+    bridge = GantryToolBridge(gantry)
+
+    tool = bridge.wrap_tool(weather_def)
+
+    assert isinstance(tool, _StubStructuredTool)
+    assert tool.name == "get_weather"
+    assert tool.description == weather_def.description
+    # args_schema must be a Pydantic model with the expected fields
+    fields = tool.args_schema.model_fields
+    assert "city" in fields
+    assert "units" in fields
+    # Required field surfaced as required
+    assert fields["city"].is_required()
+    # Optional with default surfaces with the default value
+    assert not fields["units"].is_required()
+
+
+@pytest.mark.asyncio
+async def test_wrap_tool_caches_repeated_calls() -> None:
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+    weather_def = await _populate_gantry(gantry)
+    bridge = GantryToolBridge(gantry)
+
+    first = bridge.wrap_tool(weather_def)
+    second = bridge.wrap_tool(weather_def)
+    assert first is second
+
+    bridge.clear_cache()
+    third = bridge.wrap_tool(weather_def)
+    assert third is not first
+
+
+@pytest.mark.asyncio
+async def test_get_tools_returns_top_k_langchain_tools() -> None:
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+    await _populate_gantry(gantry)
+    await gantry.add_tool(
+        ToolDefinition(
+            name="send_email",
+            description="Send an email to a recipient.",
+            parameters_schema={
+                "type": "object",
+                "properties": {
+                    "to": {"type": "string", "description": "Recipient"},
+                    "body": {"type": "string", "description": "Email body"},
+                },
+                "required": ["to", "body"],
+            },
+        )
+    )
+
+    bridge = GantryToolBridge(gantry)
+    tools = await bridge.get_tools(
+        "what is the weather in Paris", limit=1, score_threshold=0.0
+    )
+
+    assert len(tools) == 1
+    assert tools[0].name == "get_weather"
+
+
+@pytest.mark.asyncio
+async def test_wrapped_tool_executes_via_gantry(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+    weather_def = await _populate_gantry(gantry)
+
+    captured: dict[str, Any] = {}
+
+    class _FakeStatus:
+        value = "success"
+
+    class _FakeResult:
+        status = _FakeStatus()
+        result = "Sunny, 22C"
+        error = None
+
+    async def fake_execute(self: AgentGantry, call: Any) -> Any:
+        captured["call"] = call
+        return _FakeResult()
+
+    monkeypatch.setattr(AgentGantry, "execute", fake_execute, raising=False)
+
+    bridge = GantryToolBridge(gantry)
+    tool = bridge.wrap_tool(weather_def)
+
+    output = await tool.coroutine(city="Paris")
+
+    assert output == "Sunny, 22C"
+    assert captured["call"].tool_name == "get_weather"
+    assert captured["call"].arguments == {"city": "Paris"}
+
+
+@pytest.mark.asyncio
+async def test_wrapped_tool_raises_on_execution_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+    weather_def = await _populate_gantry(gantry)
+
+    class _FailStatus:
+        value = "error"
+
+    class _FailResult:
+        status = _FailStatus()
+        result = None
+        error = "boom"
+
+    async def fake_execute(self: AgentGantry, call: Any) -> Any:
+        return _FailResult()
+
+    monkeypatch.setattr(AgentGantry, "execute", fake_execute, raising=False)
+
+    bridge = GantryToolBridge(gantry)
+    tool = bridge.wrap_tool(weather_def)
+
+    with pytest.raises(RuntimeError, match="get_weather failed: boom"):
+        await tool.coroutine(city="Paris")
+
+
+@pytest.mark.asyncio
+async def test_security_policy_denial_blocks_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+
+    delete_def = ToolDefinition(
+        name="delete_records",
+        description="Delete records.",
+        parameters_schema={
+            "type": "object",
+            "properties": {
+                "table": {"type": "string", "description": "Table name"},
+            },
+            "required": ["table"],
+        },
+    )
+    await gantry.add_tool(delete_def)
+
+    async def should_not_execute(self: AgentGantry, call: Any) -> Any:
+        raise AssertionError("execute should not run when policy denies")
+
+    monkeypatch.setattr(AgentGantry, "execute", should_not_execute, raising=False)
+
+    policy = SecurityPolicy(require_confirmation=["delete_*"])
+    bridge = GantryToolBridge(gantry, security_policy=policy)
+    tool = bridge.wrap_tool(delete_def)
+
+    with pytest.raises(ConfirmationRequiredError):
+        await tool.coroutine(table="users")
+
+
+@pytest.mark.asyncio
+async def test_security_policy_with_approval_callback_proceeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+    delete_def = await _populate_destructive_gantry(gantry)
+
+    seen: list[tuple[str, dict[str, Any]]] = []
+
+    class _Status:
+        value = "success"
+
+    class _OK:
+        status = _Status()
+        result = "deleted"
+        error = None
+
+    async def fake_execute(self: AgentGantry, call: Any) -> Any:
+        return _OK()
+
+    monkeypatch.setattr(AgentGantry, "execute", fake_execute, raising=False)
+
+    async def approve(td: ToolDefinition, args: dict[str, Any]) -> bool:
+        seen.append((td.name, args))
+        return True
+
+    bridge = GantryToolBridge(gantry, approval_callback=approve)
+    tool = bridge.wrap_tool(delete_def)
+
+    output = await tool.coroutine(user_id="abc")
+
+    assert output == "deleted"
+    assert seen == [("delete_account", {"user_id": "abc"})]
+
+
+@pytest.mark.asyncio
+async def test_capability_approval_callback_denial_blocks_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+    delete_def = await _populate_destructive_gantry(gantry)
+
+    async def should_not_execute(self: AgentGantry, call: Any) -> Any:
+        raise AssertionError("execute should not run when approval is denied")
+
+    monkeypatch.setattr(AgentGantry, "execute", should_not_execute, raising=False)
+
+    def deny(td: ToolDefinition, args: dict[str, Any]) -> bool:
+        return False
+
+    bridge = GantryToolBridge(gantry, approval_callback=deny)
+    tool = bridge.wrap_tool(delete_def)
+
+    with pytest.raises(PermissionDeniedError):
+        await tool.coroutine(user_id="abc")
+
+
+@pytest.mark.asyncio
+async def test_capability_approval_can_be_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``capability_approval=False``, destructive caps don't gate execution."""
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+    delete_def = await _populate_destructive_gantry(gantry)
+
+    class _Status:
+        value = "success"
+
+    class _OK:
+        status = _Status()
+        result = "deleted"
+        error = None
+
+    async def fake_execute(self: AgentGantry, call: Any) -> Any:
+        return _OK()
+
+    monkeypatch.setattr(AgentGantry, "execute", fake_execute, raising=False)
+
+    bridge = GantryToolBridge(gantry, capability_approval=False)
+    tool = bridge.wrap_tool(delete_def)
+
+    output = await tool.coroutine(user_id="abc")
+    assert output == "deleted"
+
+
+@pytest.mark.asyncio
+async def test_build_agent_passes_tools_to_create_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``build_agent`` should call ``langchain.agents.create_agent`` with retrieved tools."""
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    # Stub langchain.agents.create_agent
+    langchain_pkg = ModuleType("langchain")
+    agents_mod = ModuleType("langchain.agents")
+
+    captured: dict[str, Any] = {}
+
+    def fake_create_agent(*, model: Any, tools: list[Any], **kwargs: Any) -> str:
+        captured["model"] = model
+        captured["tools"] = tools
+        captured["kwargs"] = kwargs
+        return "fake-agent"
+
+    agents_mod.create_agent = fake_create_agent
+    langchain_pkg.agents = agents_mod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "langchain", langchain_pkg)
+    monkeypatch.setitem(sys.modules, "langchain.agents", agents_mod)
+
+    gantry = AgentGantry()
+    await _populate_gantry(gantry)
+
+    bridge = GantryToolBridge(gantry)
+    agent = await bridge.build_agent(
+        "openai:gpt-4o",
+        "what is the weather in Paris",
+        limit=1,
+        score_threshold=0.0,
+        prompt="You are a helpful assistant.",
+    )
+
+    assert agent == "fake-agent"
+    assert captured["model"] == "openai:gpt-4o"
+    assert len(captured["tools"]) == 1
+    assert captured["tools"][0].name == "get_weather"
+    assert captured["kwargs"] == {"prompt": "You are a helpful assistant."}
+
+
+@pytest.mark.asyncio
+async def test_get_tools_with_scores_returns_pairs() -> None:
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+    await _populate_gantry(gantry)
+
+    bridge = GantryToolBridge(gantry)
+    pairs = await bridge.get_tools_with_scores(
+        "what is the weather in Paris", limit=1, score_threshold=0.0
+    )
+
+    assert len(pairs) == 1
+    tool, score = pairs[0]
+    assert tool.name == "get_weather"
+    assert isinstance(score, float)
+    assert 0.0 <= score <= 1.0

--- a/tests/test_langchain_bridge.py
+++ b/tests/test_langchain_bridge.py
@@ -393,6 +393,52 @@ async def test_capability_approval_can_be_disabled(
 
 
 @pytest.mark.asyncio
+async def test_approval_callback_invoked_once_when_both_gates_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tools matching both policy patterns and destructive caps must only prompt once."""
+    from agent_gantry.integrations.langchain_bridge import GantryToolBridge
+
+    gantry = AgentGantry()
+    # ``delete_account`` matches both ``delete_*`` policy patterns AND the
+    # destructive ``DELETE_DATA`` capability gate.
+    delete_def = await _populate_destructive_gantry(gantry)
+
+    class _Status:
+        value = "success"
+
+    class _OK:
+        status = _Status()
+        result = "deleted"
+        error = None
+
+    async def fake_execute(self: AgentGantry, call: Any) -> Any:
+        return _OK()
+
+    monkeypatch.setattr(AgentGantry, "execute", fake_execute, raising=False)
+
+    call_count = 0
+
+    async def approve(td: ToolDefinition, args: dict[str, Any]) -> bool:
+        nonlocal call_count
+        call_count += 1
+        return True
+
+    policy = SecurityPolicy(require_confirmation=["delete_*"])
+    bridge = GantryToolBridge(
+        gantry, security_policy=policy, approval_callback=approve
+    )
+    tool = bridge.wrap_tool(delete_def)
+
+    output = await tool.coroutine(user_id="abc")
+    assert output == "deleted"
+    assert call_count == 1, (
+        "approval_callback should be invoked exactly once, "
+        f"but was invoked {call_count} times"
+    )
+
+
+@pytest.mark.asyncio
 async def test_build_agent_passes_tools_to_create_agent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

First of seven planned bridges that elevate framework integrations from "thin schema converter" to "native tool with full Gantry execution semantics". Mirrors the existing Microsoft Agent Framework bridge.

- New `agent_gantry/integrations/langchain_bridge.py` — wraps Gantry `ToolDefinition`s as LangChain `StructuredTool` instances. The same wrapped tool works unchanged in both LangChain (`langchain.agents.create_agent`) and LangGraph (`langgraph.prebuilt.create_react_agent`).
- Optional `SecurityPolicy` + `approval_callback` gate every invocation before it hits `gantry.execute(...)`. Tools whose `ToolCapability` set includes destructive entries (`WRITE_DATA`, `DELETE_DATA`, `EXECUTE_CODE`, `FINANCIAL`, `PII_ACCESS`) are auto-gated by the approval callback, matching the AF bridge's `approval_mode="always_require"` semantics.
- Per-invocation Gantry telemetry span when `gantry._telemetry` is configured, so LangChain-driven tool calls show up alongside every other Gantry-traced operation.
- 11 new tests with `langchain_core` / `langchain` import stubs (no real LangChain install required for CI).
- Rewritten `examples/agent_frameworks/langchain_example.py` demonstrates the full wiring.
- `agent_gantry.integrations` now exports `LangChainToolBridge`; the legacy `GantryToolBridge` symbol stays pointed at the Microsoft Agent Framework bridge with `AgentFrameworkToolBridge` as the explicit alias for clarity.

## Public API

```python
bridge = LangChainToolBridge(
    gantry,
    security_policy=SecurityPolicy(require_confirmation=["delete_*"]),
    approval_callback=my_approval_fn,
)
tools = await bridge.get_tools("send a follow-up email", limit=3)
agent = await bridge.build_agent("openai:gpt-4o", "send a follow-up email", limit=3)
```

## Test plan

- [x] `uv run pytest tests/test_langchain_bridge.py` — 11 passed
- [x] `uv run pytest tests/ --ignore=tests/integration --ignore=mcp/a2a tests` — 391 passed, 0 failed
- [x] `uv run ruff check` clean on all touched files
- [ ] CI matrix on the PR branch

## Notes

- Targets `claude/simplify-dependencies-2Henw` (PR #146) so this stacks cleanly on the trimmed `[agent-frameworks]` extra. Once #146 lands, GitHub will auto-retarget this PR to `main`.
- Six more bridges to go: LangGraph (thin layer on this one), Google ADK, Pydantic AI, CrewAI, Strands. Each will get its own PR.

https://claude.ai/code/session_01P66ynieu9xgmKsee2qH4Jj

---
_Generated by [Claude Code](https://claude.ai/code/session_01P66ynieu9xgmKsee2qH4Jj)_