### PR TITLE
feat: add GantryContextProvider for AF-native dynamic tool injection

### DIFF
--- a/agent_gantry/__init__.py
+++ b/agent_gantry/__init__.py
@@ -7,6 +7,9 @@ Core Philosophy: Context is precious. Execution is sacred. Trust is earned.
 """
 
 from agent_gantry.core.gantry import AgentGantry, create_default_gantry
+from agent_gantry.integrations.agent_framework_provider import (
+    GantryContextProvider,
+)
 from agent_gantry.integrations.semantic_tools import (
     set_default_gantry,
     with_semantic_tools,
@@ -24,6 +27,7 @@ from agent_gantry.schema.tool import (
 __version__ = "0.1.4"
 __all__ = [
     "AgentGantry",
+    "GantryContextProvider",
     "create_default_gantry",
     "with_semantic_tools",
     "set_default_gantry",

--- a/agent_gantry/integrations/__init__.py
+++ b/agent_gantry/integrations/__init__.py
@@ -10,6 +10,9 @@ from agent_gantry.integrations.agent_framework_middleware import (
     GantryApprovalMiddleware,
     GantryObservabilityMiddleware,
 )
+from agent_gantry.integrations.agent_framework_provider import (
+    GantryContextProvider,
+)
 from agent_gantry.integrations.framework_adapters import fetch_framework_tools
 from agent_gantry.integrations.semantic_tools import (
     SemanticToolsDecorator,
@@ -19,6 +22,7 @@ from agent_gantry.integrations.semantic_tools import (
 
 __all__: list[str] = [
     "GantryApprovalMiddleware",
+    "GantryContextProvider",
     "GantryObservabilityMiddleware",
     "GantryToolBridge",
     "SemanticToolSelector",

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -1,0 +1,320 @@
+"""
+Microsoft Agent Framework context provider for Agent-Gantry.
+
+``GantryContextProvider`` is the idiomatic, AF-native way to attach
+Agent-Gantry to an :class:`agent_framework.Agent`. It plugs into the AF 1.2
+context-engineering pipeline by subclassing
+:class:`agent_framework.ContextProvider`, which means it co-operates by
+construction with every other provider — most importantly with
+:class:`agent_framework.SkillsProvider`. Each provider contributes its own
+tools and instructions via ``SessionContext.extend_tools`` /
+``extend_instructions`` keyed by a unique ``source_id``; AF merges them
+without conflict.
+
+Why a context provider rather than (only) the existing
+:class:`~agent_gantry.integrations.agent_framework_bridge.GantryToolBridge`?
+The bridge is excellent for *static* tool sets — pre-bake once, pass to
+``Agent(tools=[...])``. The provider is for *dynamic* per-turn tool
+selection: every ``agent.run(...)`` call, the latest user message is
+matched against Gantry's semantic router and only the top-k tools are
+injected. This minimises the tool-definition payload sent to the LLM,
+which is the original design goal of Agent-Gantry.
+
+Both APIs coexist intentionally:
+
+.. code-block:: python
+
+    # Static — known tool set, baked at construction:
+    bridge = GantryToolBridge(gantry)
+    tools = bridge.wrap_tools(my_defs)
+    agent = Agent(client, "...", tools=tools)
+
+    # Dynamic — per-turn semantic retrieval:
+    provider = GantryContextProvider(gantry, top_k=5)
+    agent = Agent(client, "...", context_providers=[provider])
+
+    # Mixed — pinned static + dynamic top-up + AF skills, all in one agent:
+    agent = Agent(
+        client,
+        "...",
+        tools=bridge.wrap_tools(pinned_defs),
+        context_providers=[
+            GantryContextProvider(gantry, top_k=3, skills=True),
+            SkillsProvider(skills=[my_af_skill]),
+        ],
+    )
+
+The provider also flows transparently through every AF orchestration
+primitive (``WorkflowBuilder``, ``SequentialBuilder``, ``HandoffBuilder``,
+``AgentExecutor``, ``WorkflowAgent``) because they all dispatch through
+``agent.run()``, which fires the provider pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+    from agent_gantry.integrations.anthropic_skills import SkillRegistry
+    from agent_gantry.schema.tool import ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+
+def _import_context_provider() -> type:
+    """Lazily import :class:`agent_framework.ContextProvider`.
+
+    Import is deferred to instantiation so the module remains importable
+    in environments without ``agent-framework`` installed (e.g. unit
+    tests for the rest of Gantry).
+    """
+    try:
+        from agent_framework import ContextProvider
+    except ImportError as exc:  # pragma: no cover - depends on install
+        raise ImportError(
+            "GantryContextProvider requires the 'agent-framework' package. "
+            "Install with: pip install 'agent-gantry[agent-frameworks]'"
+        ) from exc
+    return ContextProvider
+
+
+def _last_user_text(messages: list[Any]) -> str:
+    """Return the text of the most recent user message, or empty string.
+
+    AF stores incoming user turns in ``SessionContext.input_messages``.
+    We pick the most recent ``user``-role message — that's the query
+    Gantry should retrieve tools against.
+    """
+    for msg in reversed(messages or []):
+        role = getattr(msg, "role", None)
+        if role is None or str(role) == "user":
+            text = getattr(msg, "text", None)
+            if text:
+                return text
+    return ""
+
+
+class GantryContextProvider:
+    """AF context provider that injects semantically-selected Gantry tools.
+
+    Constructing the provider returns an instance of the dynamically
+    generated ``agent_framework.ContextProvider`` subclass. The factory
+    pattern keeps the import of ``agent_framework`` lazy so importing
+    ``agent_gantry`` doesn't require AF to be installed.
+
+    Args:
+        gantry: The :class:`~agent_gantry.core.gantry.AgentGantry` instance
+            providing semantic retrieval and execution.
+        top_k: Maximum number of dynamically retrieved tools per ``agent.run``
+            call. Defaults to ``5``.
+        score_threshold: Minimum semantic relevance score for retrieved
+            tools. Defaults to ``0.3``.
+        skills: When ``True``, every invocation also injects the union of
+            tools bound to all registered Gantry skills (from the supplied
+            ``skill_registry`` if any, else the registry attached to the
+            gantry instance via :class:`SkillsClient`). These tools are
+            *always* included regardless of the semantic match. Defaults
+            to ``False``.
+        skill_registry: Optional explicit
+            :class:`~agent_gantry.integrations.anthropic_skills.SkillRegistry`.
+            When ``None`` and ``skills=True``, the provider attempts to use
+            ``gantry._skill_registry`` if present; otherwise it logs a
+            warning and skips skill tools.
+        always_include: Optional list of Gantry tool names to inject on
+            every invocation (in addition to the dynamic top-k). Useful
+            for pinning utility tools the LLM should always see.
+        as_function_tool: Forwarded to the underlying
+            :class:`GantryToolBridge`. ``None`` (default) auto-detects;
+            ``True`` forces ``agent_framework.FunctionTool`` wrapping;
+            ``False`` returns bare callables (still accepted by AF).
+        source_id: Provider identifier used by AF for tool/message
+            attribution. Defaults to ``"agent_gantry"``. Override when
+            running multiple Gantry instances side-by-side.
+        bridge: Optional pre-built :class:`GantryToolBridge` to reuse its
+            wrapper cache across multiple providers. When ``None`` a new
+            bridge is built from the supplied ``gantry``.
+        **query_kwargs: Additional keyword arguments forwarded to
+            :meth:`GantryToolBridge.get_tools` (e.g. ``namespaces``,
+            ``required_capabilities``, ``enable_reranking``).
+
+    Example:
+        .. code-block:: python
+
+            from agent_framework import Agent, SkillsProvider
+            from agent_framework.openai import OpenAIChatClient
+            from agent_gantry import AgentGantry
+            from agent_gantry.integrations import GantryContextProvider
+
+            gantry = AgentGantry()
+            # ... register tools, sync ...
+
+            agent = Agent(
+                OpenAIChatClient(),
+                "You are a helpful assistant.",
+                context_providers=[
+                    GantryContextProvider(gantry, top_k=5, skills=True),
+                    SkillsProvider(skill_paths="./skills"),
+                ],
+            )
+            await agent.run("Book a flight to Tokyo")  # flight tools auto-injected
+    """
+
+    def __new__(
+        cls,
+        gantry: AgentGantry,
+        *,
+        top_k: int = 5,
+        score_threshold: float = 0.3,
+        skills: bool = False,
+        skill_registry: SkillRegistry | None = None,
+        always_include: list[str] | None = None,
+        as_function_tool: bool | None = None,
+        source_id: str = "agent_gantry",
+        bridge: GantryToolBridge | None = None,
+        **query_kwargs: Any,
+    ) -> Any:
+        context_provider_cls = _import_context_provider()
+
+        bridge = bridge or GantryToolBridge(
+            gantry,
+            score_threshold=score_threshold,
+            as_function_tool=as_function_tool,
+        )
+        always_include = list(always_include or [])
+
+        class _GantryContextProviderImpl(context_provider_cls):  # type: ignore[misc,valid-type]
+            """Concrete ContextProvider subclass; see :class:`GantryContextProvider`."""
+
+            def __init__(self) -> None:
+                super().__init__(source_id=source_id)
+                self._gantry = gantry
+                self._bridge = bridge
+                self._top_k = top_k
+                self._score_threshold = score_threshold
+                self._skills_enabled = skills
+                self._skill_registry = skill_registry
+                self._always_include = always_include
+                self._query_kwargs = dict(query_kwargs)
+
+            async def before_run(
+                self,
+                *,
+                agent: Any,
+                session: Any,
+                context: Any,
+                state: dict[str, Any],
+            ) -> None:
+                query = _last_user_text(context.input_messages)
+                tools: list[Any] = []
+                seen: set[str] = set()
+
+                # 1) Dynamic semantic retrieval against the latest user turn.
+                if query:
+                    try:
+                        retrieved = await self._bridge.get_tools(
+                            query,
+                            limit=self._top_k,
+                            score_threshold=self._score_threshold,
+                            **self._query_kwargs,
+                        )
+                    except Exception:
+                        # Tool retrieval should never break the agent run.
+                        logger.exception(
+                            "GantryContextProvider: semantic retrieval failed; "
+                            "continuing without dynamic tools."
+                        )
+                        retrieved = []
+                    for t in retrieved:
+                        name = getattr(t, "name", None) or getattr(t, "__name__", None)
+                        if name and name in seen:
+                            continue
+                        if name:
+                            seen.add(name)
+                        tools.append(t)
+
+                # 2) Skills: always-on tools bound to registered Gantry skills.
+                if self._skills_enabled:
+                    skill_tool_names = self._collect_skill_tool_names()
+                    extra = self._wrap_named(skill_tool_names, seen)
+                    tools.extend(extra)
+
+                # 3) Explicit always_include pins.
+                if self._always_include:
+                    extra = self._wrap_named(self._always_include, seen)
+                    tools.extend(extra)
+
+                if tools:
+                    context.extend_tools(self.source_id, tools)
+                    logger.debug(
+                        "GantryContextProvider: injected %d tools (query=%r)",
+                        len(tools),
+                        query[:60],
+                    )
+
+            def _resolve_skill_registry(self) -> SkillRegistry | None:
+                if self._skill_registry is not None:
+                    return self._skill_registry
+                # Best-effort: pick up a registry attached to the gantry
+                # instance (e.g. via SkillsClient).
+                return getattr(self._gantry, "_skill_registry", None) or getattr(
+                    self._gantry, "skill_registry", None
+                )
+
+            def _collect_skill_tool_names(self) -> list[str]:
+                registry = self._resolve_skill_registry()
+                if registry is None:
+                    logger.debug(
+                        "GantryContextProvider: skills=True but no SkillRegistry "
+                        "available on gantry — no skill tools injected."
+                    )
+                    return []
+                names: list[str] = []
+                seen_names: set[str] = set()
+                for skill in registry.list_skills():
+                    for tool_name in skill.tools or []:
+                        if tool_name not in seen_names:
+                            seen_names.add(tool_name)
+                            names.append(tool_name)
+                return names
+
+            def _wrap_named(
+                self, names: list[str], seen: set[str]
+            ) -> list[Any]:
+                wrapped: list[Any] = []
+                for name in names:
+                    if name in seen:
+                        continue
+                    tool_def = self._lookup_tool_def(name)
+                    if tool_def is None:
+                        logger.warning(
+                            "GantryContextProvider: tool %r not found in "
+                            "registry; skipping.",
+                            name,
+                        )
+                        continue
+                    wrapped.append(self._bridge.wrap_single(tool_def))
+                    seen.add(name)
+                return wrapped
+
+            def _lookup_tool_def(self, name: str) -> ToolDefinition | None:
+                registry = getattr(self._gantry, "_registry", None)
+                if registry is None:
+                    return None
+                lookup = getattr(registry, "get_tool_by_name", None)
+                if callable(lookup):
+                    found = lookup(name)
+                    if found is not None:
+                        return found
+                lookup = getattr(registry, "get_tool", None)
+                if callable(lookup):
+                    return lookup(name)
+                return None
+
+        return _GantryContextProviderImpl()
+
+
+__all__ = ["GantryContextProvider"]

--- a/examples/agent_frameworks/README.md
+++ b/examples/agent_frameworks/README.md
@@ -14,7 +14,8 @@ The general pattern is:
 
 ## Examples Included
 
-- `agent_framework_example.py`: Microsoft Agent Framework **1.0 GA** integration demonstrating three construction patterns:
+- `agent_framework_provider_example.py` — **recommended**: AF-native integration via `GantryContextProvider`. The provider plugs into `Agent(context_providers=[...])` and dynamically injects the top-k tools for each `agent.run(...)` — no pre-baking, coexists with `SkillsProvider`, and flows through every workflow builder unchanged. Includes a `skills=True` flag for always-on skill-bound tools and an `always_include` pin list.
+- `agent_framework_example.py`: Microsoft Agent Framework **1.0 GA** integration via `GantryToolBridge` (still useful when the tool set is *static* and known at agent-construction time). Demonstrates three construction patterns:
   1. `bridge.build_agent(client, query, ...)` — convenience one-liner via `client.as_agent()`.
   2. `bridge.as_agent(client, query, ...)` — direct `Agent(client, ...)` construction; preferred for `WorkflowBuilder` because the result is a first-class `Agent`.
   3. `bridge.build_workflow([specs], edges=[...])` — fan-out/handoff routing where each participating agent receives its own semantically-selected Gantry tool subset.

--- a/examples/agent_frameworks/agent_framework_provider_example.py
+++ b/examples/agent_frameworks/agent_framework_provider_example.py
@@ -1,0 +1,169 @@
+"""
+``GantryContextProvider`` — the AF-native way to plug Gantry into an Agent.
+
+This example shows the *idiomatic* Microsoft Agent Framework integration:
+attach Agent-Gantry as an :class:`agent_framework.ContextProvider` and let
+AF call ``before_run`` on every ``agent.run(...)``. The provider extracts
+the latest user message, retrieves the top-k semantically relevant tools
+from Gantry, and injects them into the per-invocation
+``SessionContext.tools``.
+
+Why this matters:
+
+* **Per-turn dynamic tool selection** — no need to pre-bake a tool list
+  before constructing the agent. Each turn picks fresh tools.
+* **Zero interference with AF Skills** — :class:`SkillsProvider` and
+  :class:`GantryContextProvider` are sibling :class:`ContextProvider`
+  instances that AF merges by ``source_id``. Both providers contribute
+  tools and instructions; nobody overwrites anybody.
+* **Workflow-builder compatible** — ``WorkflowBuilder``,
+  ``SequentialBuilder``, ``HandoffBuilder``, ``AgentExecutor`` and
+  ``WorkflowAgent`` all dispatch through ``agent.run()``, which fires the
+  provider pipeline. Drop a Gantry-backed agent into any orchestration
+  primitive without further changes.
+
+The example walks through three patterns:
+
+1. **Bare Agent** with ``GantryContextProvider`` — minimum-viable wiring.
+2. **Coexistence** with :class:`SkillsProvider` — both providers attached,
+   each with its own ``source_id``.
+3. **Workflow** — the same provider-equipped agent dropped into
+   ``SequentialBuilder``.
+"""
+
+import asyncio
+
+from agent_framework import Agent, Skill, SkillsProvider
+from agent_framework.openai import OpenAIChatClient
+from agent_framework.orchestrations import SequentialBuilder
+from dotenv import load_dotenv
+
+from agent_gantry import AgentGantry, GantryContextProvider
+
+
+def build_gantry() -> AgentGantry:
+    """Create a Gantry instance with a few representative tools."""
+    gantry = AgentGantry()
+
+    @gantry.register
+    def get_weather(city: str) -> str:
+        """Get the current weather for a city."""
+        return f"Weather in {city}: Sunny, 22C"
+
+    @gantry.register
+    def book_flight(origin: str, destination: str) -> str:
+        """Book a flight between two cities."""
+        return f"Booked flight: {origin} -> {destination}"
+
+    @gantry.register
+    def lookup_user(user_id: str) -> dict:
+        """Look up a user profile from the CRM."""
+        return {"id": user_id, "plan": "pro"}
+
+    @gantry.register
+    def issue_refund(user_id: str, amount: float) -> str:
+        """Issue a refund to a user."""
+        return f"Refunded ${amount:.2f} to {user_id}"
+
+    return gantry
+
+
+async def example_bare_agent(gantry: AgentGantry) -> None:
+    """Pattern 1: minimum-viable Agent + GantryContextProvider.
+
+    Each ``agent.run(query)`` triggers semantic retrieval against
+    ``query`` and injects the top-k matching tools — *without* the caller
+    pre-computing a tools list.
+    """
+    agent = Agent(
+        OpenAIChatClient(),
+        "You are a helpful concierge. Use tools to fulfil requests.",
+        context_providers=[
+            GantryContextProvider(gantry, top_k=3, score_threshold=0.0),
+        ],
+    )
+
+    result = await agent.run("What's the weather in Tokyo?")
+    print("[bare] →", result.text)
+
+
+async def example_with_af_skills(gantry: AgentGantry) -> None:
+    """Pattern 2: GantryContextProvider alongside AF SkillsProvider.
+
+    Both providers are first-class ``ContextProvider`` instances, attached
+    to the same agent with distinct ``source_id`` values. AF merges their
+    contributions cleanly: SkillsProvider adds skill tools and prompt
+    instructions, Gantry adds the dynamically retrieved tool set.
+
+    The ``skills=True`` flag on the Gantry provider additionally pins the
+    union of tools bound to *Gantry's* registered skills (separate from
+    AF skills) on every run.
+    """
+    summarise_skill = Skill(
+        name="summarise",
+        description="Summarise the conversation so far.",
+        content=(
+            "When the user asks for a summary, produce a 3-bullet recap of "
+            "the conversation."
+        ),
+    )
+
+    agent = Agent(
+        OpenAIChatClient(),
+        "You are a customer-service assistant.",
+        context_providers=[
+            GantryContextProvider(
+                gantry,
+                top_k=3,
+                score_threshold=0.0,
+                skills=True,           # always include Gantry-skill-bound tools
+                always_include=["lookup_user"],  # pinned utility tool
+            ),
+            SkillsProvider(skills=[summarise_skill]),
+        ],
+    )
+
+    result = await agent.run("I want a refund of $42 on order ABC.")
+    print("[skills] →", result.text)
+
+
+async def example_workflow(gantry: AgentGantry) -> None:
+    """Pattern 3: provider-equipped agents inside a SequentialBuilder.
+
+    ``SequentialBuilder`` calls each agent's ``run`` in turn, which fires
+    the provider pipeline on every step. The same Gantry instance can
+    feed multiple agents — each one gets tools tailored to its role
+    because each retrieval is driven by the previous step's output.
+    """
+    client = OpenAIChatClient()
+
+    triage = Agent(
+        client,
+        "You triage customer requests.",
+        name="Triage",
+        context_providers=[GantryContextProvider(gantry, top_k=2, score_threshold=0.0)],
+    )
+    resolver = Agent(
+        client,
+        "You resolve the customer's issue using the available tools.",
+        name="Resolver",
+        context_providers=[GantryContextProvider(gantry, top_k=3, score_threshold=0.0)],
+    )
+
+    workflow = SequentialBuilder(participants=[triage, resolver]).build()
+    result = await workflow.run("My flight LHR->NRT was cancelled, please rebook.")
+    print("[workflow] →", result)
+
+
+async def main() -> None:
+    load_dotenv()
+    gantry = build_gantry()
+    await gantry.sync()
+
+    await example_bare_agent(gantry)
+    await example_with_af_skills(gantry)
+    await example_workflow(gantry)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_agent_framework_provider.py
+++ b/tests/test_agent_framework_provider.py
@@ -1,0 +1,250 @@
+"""
+Tests for :class:`agent_gantry.integrations.GantryContextProvider`.
+
+The provider is the AF-native way to attach Gantry to an
+``agent_framework.Agent`` and must:
+
+* Inject the top-k semantically relevant tools into ``SessionContext`` for
+  each ``agent.run`` call.
+* Coexist with other ``ContextProvider`` instances (e.g.
+  ``SkillsProvider``) without interfering — verified here by checking
+  ``source_id`` attribution and that we only ever *append* to
+  ``context.tools``.
+* Honour the ``skills=True`` flag for always-on skill-bound tools.
+* Honour explicit ``always_include`` pins.
+* Fail safe on retrieval errors and on empty input.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ``agent_framework`` is required to construct the provider; skip the entire
+# module when the optional dependency is missing.
+af = pytest.importorskip("agent_framework")
+
+from agent_gantry import AgentGantry, GantryContextProvider  # noqa: E402
+from agent_gantry.integrations.anthropic_skills import SkillRegistry  # noqa: E402
+
+
+def _user_msg(text: str) -> "af.Message":
+    return af.Message(role="user", contents=[text])
+
+
+def _tool_names(tools: list) -> list[str]:
+    out: list[str] = []
+    for t in tools:
+        out.append(getattr(t, "name", None) or getattr(t, "__name__", "?"))
+    return out
+
+
+@pytest.fixture
+async def gantry_with_tools() -> AgentGantry:
+    g = AgentGantry()
+
+    @g.register
+    def get_weather(city: str) -> str:
+        """Get the current weather for a city."""
+        return f"Weather: {city}"
+
+    @g.register
+    def book_flight(origin: str, destination: str) -> str:
+        """Book a flight between two cities."""
+        return f"flight {origin}->{destination}"
+
+    @g.register
+    def lookup_user(user_id: str) -> str:
+        """Look up a user by ID."""
+        return f"user {user_id}"
+
+    @g.register
+    def issue_refund(amount: float) -> str:
+        """Issue a refund to a customer account."""
+        return f"refund {amount}"
+
+    await g.sync()
+    return g
+
+
+class TestGantryContextProvider:
+    @pytest.mark.asyncio
+    async def test_injects_top_k_tools(self, gantry_with_tools: AgentGantry) -> None:
+        """before_run extracts the latest user message and injects top-k tools."""
+        provider = GantryContextProvider(
+            gantry_with_tools, top_k=2, score_threshold=0.0
+        )
+        ctx = af.SessionContext(input_messages=[_user_msg("weather in Paris")])
+
+        await provider.before_run(agent=None, session=None, context=ctx, state={})
+
+        assert len(ctx.tools) <= 2
+        assert "get_weather" in _tool_names(ctx.tools)
+
+    @pytest.mark.asyncio
+    async def test_default_source_id(self, gantry_with_tools: AgentGantry) -> None:
+        """Provider defaults to a stable source_id for AF attribution."""
+        provider = GantryContextProvider(gantry_with_tools)
+        assert provider.source_id == "agent_gantry"
+
+    @pytest.mark.asyncio
+    async def test_custom_source_id(self, gantry_with_tools: AgentGantry) -> None:
+        """source_id is overridable so multiple gantries can run side-by-side."""
+        provider = GantryContextProvider(gantry_with_tools, source_id="gantry_a")
+        assert provider.source_id == "gantry_a"
+
+    @pytest.mark.asyncio
+    async def test_empty_input_messages_does_not_crash(
+        self, gantry_with_tools: AgentGantry
+    ) -> None:
+        """A run with no input messages must not raise — provider stays passive."""
+        provider = GantryContextProvider(gantry_with_tools, score_threshold=0.0)
+        ctx = af.SessionContext(input_messages=[])
+
+        await provider.before_run(agent=None, session=None, context=ctx, state={})
+
+        assert ctx.tools == []
+
+    @pytest.mark.asyncio
+    async def test_picks_latest_user_message(
+        self, gantry_with_tools: AgentGantry
+    ) -> None:
+        """When several messages are present, the latest user turn drives retrieval."""
+        provider = GantryContextProvider(
+            gantry_with_tools, top_k=1, score_threshold=0.0
+        )
+        ctx = af.SessionContext(
+            input_messages=[
+                _user_msg("totally unrelated topic"),
+                _user_msg("book me a flight from LHR to NRT"),
+            ]
+        )
+
+        await provider.before_run(agent=None, session=None, context=ctx, state={})
+
+        assert "book_flight" in _tool_names(ctx.tools)
+
+    @pytest.mark.asyncio
+    async def test_always_include_pins_tools(
+        self, gantry_with_tools: AgentGantry
+    ) -> None:
+        """always_include adds pinned tools regardless of semantic match."""
+        provider = GantryContextProvider(
+            gantry_with_tools,
+            top_k=1,
+            score_threshold=0.0,
+            always_include=["issue_refund"],
+        )
+        ctx = af.SessionContext(input_messages=[_user_msg("weather in Paris")])
+
+        await provider.before_run(agent=None, session=None, context=ctx, state={})
+
+        names = _tool_names(ctx.tools)
+        assert "issue_refund" in names
+
+    @pytest.mark.asyncio
+    async def test_skills_flag_injects_registered_skill_tools(
+        self, gantry_with_tools: AgentGantry
+    ) -> None:
+        """skills=True always injects the union of skill-bound tool names."""
+        skills = SkillRegistry()
+        skills.register(
+            name="customer_support",
+            description="Customer support utilities",
+            instructions="Use when handling customer issues.",
+            tools=["lookup_user", "issue_refund"],
+        )
+        provider = GantryContextProvider(
+            gantry_with_tools,
+            top_k=1,
+            score_threshold=0.0,
+            skills=True,
+            skill_registry=skills,
+        )
+        ctx = af.SessionContext(input_messages=[_user_msg("weather in Paris")])
+
+        await provider.before_run(agent=None, session=None, context=ctx, state={})
+
+        names = _tool_names(ctx.tools)
+        assert "lookup_user" in names
+        assert "issue_refund" in names
+
+    @pytest.mark.asyncio
+    async def test_skills_flag_without_registry_is_safe(
+        self, gantry_with_tools: AgentGantry, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """skills=True without a registry logs a debug note and keeps going."""
+        provider = GantryContextProvider(
+            gantry_with_tools, top_k=1, score_threshold=0.0, skills=True
+        )
+        ctx = af.SessionContext(input_messages=[_user_msg("weather")])
+
+        await provider.before_run(agent=None, session=None, context=ctx, state={})
+
+        # Still injects the dynamic top-1 result; just no skill tools added.
+        assert len(ctx.tools) >= 1
+
+    @pytest.mark.asyncio
+    async def test_unknown_pinned_tool_logs_warning(
+        self, gantry_with_tools: AgentGantry, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unknown names in always_include warn but don't break the run."""
+        import logging
+
+        provider = GantryContextProvider(
+            gantry_with_tools,
+            top_k=1,
+            score_threshold=0.0,
+            always_include=["does_not_exist"],
+        )
+        ctx = af.SessionContext(input_messages=[_user_msg("weather")])
+
+        with caplog.at_level(logging.WARNING):
+            await provider.before_run(
+                agent=None, session=None, context=ctx, state={}
+            )
+        assert "does_not_exist" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_does_not_overwrite_other_provider_tools(
+        self, gantry_with_tools: AgentGantry
+    ) -> None:
+        """The provider must only *append* to context.tools, never replace.
+
+        This is what guarantees coexistence with ``SkillsProvider`` and any
+        other ``ContextProvider`` upstream in the pipeline.
+        """
+        provider = GantryContextProvider(
+            gantry_with_tools, top_k=1, score_threshold=0.0
+        )
+        sentinel = object()
+        ctx = af.SessionContext(
+            input_messages=[_user_msg("weather")],
+            tools=[sentinel],  # pretend another provider already added one
+        )
+
+        await provider.before_run(agent=None, session=None, context=ctx, state={})
+
+        assert sentinel in ctx.tools
+        assert len(ctx.tools) > 1
+
+    @pytest.mark.asyncio
+    async def test_retrieval_failure_is_swallowed(
+        self, gantry_with_tools: AgentGantry, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A retrieval exception must not break ``agent.run``."""
+        provider = GantryContextProvider(
+            gantry_with_tools, top_k=1, score_threshold=0.0
+        )
+
+        async def _boom(*_a: object, **_k: object) -> list:
+            raise RuntimeError("retrieval down")
+
+        # Patch the bridge's get_tools rather than gantry.retrieve so the
+        # provider's own try/except path is exercised.
+        monkeypatch.setattr(provider._bridge, "get_tools", _boom)
+
+        ctx = af.SessionContext(input_messages=[_user_msg("weather")])
+        await provider.before_run(agent=None, session=None, context=ctx, state={})
+
+        # No exception, no tools injected — agent.run continues.
+        assert ctx.tools == []


### PR DESCRIPTION
Introduces an agent_framework.ContextProvider subclass that plugs Gantry
into Agent(context_providers=[...]). On every agent.run(...), before_run
extracts the latest user message, retrieves the top-k semantically
relevant tools, and appends them to SessionContext.tools — no pre-baking
required.

The provider co-operates by construction with SkillsProvider and any
other context provider (each contributes via its own source_id), and
flows transparently through SequentialBuilder / HandoffBuilder /
WorkflowBuilder / AgentExecutor since they all dispatch through
agent.run().

Adds:
- skills=True flag: always inject tools bound to registered Gantry
  Skills regardless of semantic match.
- always_include: explicit pin list for utility tools the LLM should
  always see.
- Lazy AF import so importing agent_gantry stays cheap when AF is not
  installed.
- 11 unit tests covering retrieval, latest-message selection, skills
  flag, pin list, source_id attribution, error containment, and
  coexistence with upstream providers.
- Example demonstrating bare Agent, coexistence with SkillsProvider,
  and inclusion in a SequentialBuilder workflow.

The existing GantryToolBridge API is unchanged for callers with static
tool sets that prefer pre-baking via tools=[...].