### PR TITLE
🎨 Palette: Close search results on focus out

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-04-29 - [Keyboard Focus Management with Programmatic Scrolling]
 **Learning:** Intercepting anchor clicks (like "Skip to main content") with `e.preventDefault()` to apply smooth scrolling breaks native focus movement. If focus remains on the clicked link, subsequent `Tab` presses will not start from the target element, rendering the skip link ineffective for keyboard users.
 **Action:** Always manually move focus to the target element (`target.focus({ preventScroll: true })`) and ensure it's focusable by temporarily setting `tabindex="-1"` when implementing programmatic smooth scrolling for in-page anchors.
+
+## 2026-04-30 - [Keyboard Accessibility for Custom Dropdowns]
+**Learning:** Custom dropdowns (like search results) that rely on `click` outside to close will remain open when a keyboard user presses `Tab` to navigate away from the input or container. This can leave floating content visible and obscure other parts of the page.
+**Action:** When implementing custom dropdowns, always include a `document.addEventListener("focusin", ...)` listener to check if the newly focused element is outside the dropdown container, and if so, close the dropdown to maintain a clean UI for keyboard users.

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -325,6 +325,18 @@
       }
     });
 
+    // Close search results when focus leaves the search area
+    document.addEventListener("focusin", function (e) {
+      if (
+        searchInput &&
+        searchResults &&
+        !searchInput.contains(e.target) &&
+        !searchResults.contains(e.target)
+      ) {
+        hideResults();
+      }
+    });
+
     setupSearchAnnouncer();
 
     // Build search index


### PR DESCRIPTION
💡 **What:** Added a document `focusin` event listener to `docs/assets/js/search.js` that closes the search results dropdown when focus leaves the search input and results container.
🎯 **Why:** To improve keyboard accessibility. Previously, if a keyboard user opened the search results and then pressed `Tab` to navigate to the next link on the page, the search results dropdown remained open, floating over and obscuring the page content.
♿ **Accessibility:** This ensures custom dropdowns clean up their visual state when keyboard focus moves away from them, matching expected native `<select>` or `popover` behavior.

---
*PR created automatically by Jules for task [6709448283441314731](https://jules.google.com/task/6709448283441314731) started by @CodeHalwell*