### PR TITLE
Add thinking_display control and is_error flag for tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- **`AnthropicFeatures.thinking_display`** — new optional field (`"summarized"` | `"omitted"`)
+  that controls thinking visibility in the response. `"summarized"` condenses the thinking
+  block; `"omitted"` hides it but preserves the signature for multi-turn continuity.
+  Exposed through `create_anthropic_client(thinking_display=...)`.
+  *Source: https://platform.claude.com/docs/en/api/messages (thinking parameter)*
+  *Risk: safe additive — existing code unaffected; default is None (full thinking shown).*
+
+### Fixed
+
+- **`AnthropicAdapter.format_tool_result` now accepts `is_error: bool = False`** — when
+  `True`, the `"is_error": true` field is included in the `tool_result` block so the
+  model can distinguish error content from a normal tool result.
+  *Source: https://platform.claude.com/docs/en/api/messages (tool_result block)*
+  *Risk: safe additive — callers that do not pass `is_error` see no change.*
+
+- **`AnthropicClient.execute_tool_calls` and `SkillsClient.execute_tool_calls` now set
+  `"is_error": true` on tool result blocks when execution fails** — previously, failed
+  tool calls were represented only by an `"Error: …"` content string with no API-level
+  error flag, preventing the model from reliably distinguishing tool errors from tool
+  output that happens to mention errors.
+  *Risk: safe with shim — callers that re-send the tool results array to `messages.create`
+  will now include the `is_error` field; this is additive and backward-compatible.*
+
+### Changed
+
+- **Dependency: `agent-framework` bumped to `>=1.2.2,<2.0.0`** (was `>=1.2.1,<2.0.0`).
+  Picks up the observability span-nesting fix during streaming and full conversation-history
+  propagation for hosted workflow agents. **Breaking in AF 1.2.2**: sequential-approval and
+  concurrent workflow terminal outputs now return as `AgentResponse` rather than a plain
+  string. Calling code that does `str(result)` or `print(result)` continues to work; code
+  that pattern-matches on the raw string type must be updated.
+  *Source: https://pypi.org/pypi/agent-framework/1.2.2/json*
+  *Risk: safe with shim — `AgentResponse` is str-coercible; bare-string assumptions break.*
+
+- **Dependency: `langchain` bumped to `>=1.2.16`** (was `>=1.2.15`). Minor patch release.
+  *Risk: safe internal.*
+
+- **Docs: `docs/reference/llm_sdk_compatibility.md` header updated from "Late 2025" to
+  "April 2026"** — reflects the actual date of the most recent compatibility review.
+
 - **Full Microsoft Agent Framework 1.0 GA integration**:
   - `GantryToolBridge` now emits real `agent_framework.FunctionTool` instances
     via the GA `@tool` decorator. Gantry's `ToolCapability` set is auto-mapped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ToolSpecAdapter.format_tool_result` protocol extended with `is_error: bool = False`** — all
+  concrete adapters (`OpenAIAdapter`, `OpenAIResponsesAdapter`, `AnthropicAdapter`,
+  `GeminiAdapter`) now accept the optional keyword argument so callers typed against the
+  protocol can pass `is_error` without casting. Non-Anthropic adapters accept and ignore the
+  flag; `AnthropicAdapter` uses it to emit the Anthropic `"is_error"` field.
+  *Risk: safe additive — default is `False`, backward-compatible.*
+
+- **Unit tests for `is_error` semantics** — added to `TestAnthropicAdapter` in
+  `test_tool_spec_adapters.py`, to `TestAnthropicClient` in `test_anthropic_features.py`,
+  and to `TestSkillsClient` in `test_anthropic_skills.py`. Each test pair asserts that
+  `is_error: true` is present on failure and absent on success, and that dict results are
+  JSON-serialised rather than `str()`-coerced.
+
+- **Unit tests for `thinking_display` payload injection** — added three focused tests in
+  `TestAnthropicClient` verifying that `create_message()` passes `thinking.display` to
+  `AsyncAnthropic.messages.create()` for adaptive mode, extended mode, and that the key is
+  absent when `thinking_display=None`.
+
 - **`AnthropicFeatures.thinking_display`** — new optional field (`"summarized"` | `"omitted"`)
   that controls thinking visibility in the response. `"summarized"` condenses the thinking
   block; `"omitted"` hides it but preserves the signature for multi-turn continuity.
@@ -31,6 +49,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output that happens to mention errors.
   *Risk: safe with shim — callers that re-send the tool results array to `messages.create`
   will now include the `is_error` field; this is additive and backward-compatible.*
+
+- **`AnthropicClient.execute_tool_calls` and `SkillsClient.execute_tool_calls` now use
+  `json.dumps()` for non-string tool results** — previously `str()` was used, which
+  produces Python repr notation (e.g. `{'key': 'val'}` with single quotes) rather than
+  valid JSON, causing downstream parse failures when the model or the caller attempted to
+  deserialise the content.
+  *Risk: safe correctness fix — `str` results pass through unchanged; dict/list results are
+  now JSON-serialised consistently with `AnthropicAdapter.format_tool_result`.*
+
+- **`ExecutionStatus.SUCCESS` used for status comparisons in `AnthropicClient` and
+  `SkillsClient`** — replaced bare `!= "success"` string literals with
+  `!= ExecutionStatus.SUCCESS` for type-safety and consistency with the rest of the
+  codebase (e.g. `agent_gantry/servers/mcp_server.py`).
+  *Risk: none — `ExecutionStatus` inherits from `str` so the comparison is equivalent.*
 
 ### Changed
 

--- a/agent_gantry/adapters/tool_spec/base.py
+++ b/agent_gantry/adapters/tool_spec/base.py
@@ -123,6 +123,8 @@ class ToolSpecAdapter(Protocol):
         tool_name: str,
         result: Any,
         tool_call_id: str | None = None,
+        *,
+        is_error: bool = False,
     ) -> dict[str, Any]:
         """
         Format a tool result for sending back to the provider.
@@ -131,6 +133,9 @@ class ToolSpecAdapter(Protocol):
             tool_name: Name of the executed tool
             result: Result from tool execution
             tool_call_id: Provider-specific tool call identifier
+            is_error: Whether the tool execution failed (Anthropic uses this
+                to set ``is_error`` on the tool_result block; other providers
+                may ignore it)
 
         Returns:
             Provider-formatted tool result

--- a/agent_gantry/adapters/tool_spec/providers.py
+++ b/agent_gantry/adapters/tool_spec/providers.py
@@ -124,6 +124,8 @@ class OpenAIAdapter:
         tool_name: str,
         result: Any,
         tool_call_id: str | None = None,
+        *,
+        is_error: bool = False,
     ) -> dict[str, Any]:
         """Format result for OpenAI tool_outputs."""
         content = result if isinstance(result, str) else json.dumps(result)
@@ -254,6 +256,8 @@ class OpenAIResponsesAdapter:
         tool_name: str,
         result: Any,
         tool_call_id: str | None = None,
+        *,
+        is_error: bool = False,
     ) -> dict[str, Any]:
         """
         Format result for OpenAI Responses API function_call_output.
@@ -460,6 +464,8 @@ class GeminiAdapter:
         tool_name: str,
         result: Any,
         tool_call_id: str | None = None,
+        *,
+        is_error: bool = False,
     ) -> dict[str, Any]:
         """Format result for Gemini function response."""
         response_content = result if isinstance(result, dict) else {"result": result}

--- a/agent_gantry/adapters/tool_spec/providers.py
+++ b/agent_gantry/adapters/tool_spec/providers.py
@@ -357,13 +357,22 @@ class AnthropicAdapter:
         tool_name: str,
         result: Any,
         tool_call_id: str | None = None,
+        *,
+        is_error: bool = False,
     ) -> dict[str, Any]:
-        """Format result for Anthropic tool_result."""
+        """Format result for Anthropic tool_result.
+
+        Pass ``is_error=True`` when the tool execution failed so the model can
+        distinguish error content from normal tool output.
+        Source: https://platform.claude.com/docs/en/api/messages (tool_result block)
+        """
         content = result if isinstance(result, str) else json.dumps(result)
         response: dict[str, Any] = {
             "type": "tool_result",
             "content": content,
         }
+        if is_error:
+            response["is_error"] = True
         if tool_call_id:
             response["tool_use_id"] = tool_call_id
         return response

--- a/agent_gantry/integrations/anthropic_features.py
+++ b/agent_gantry/integrations/anthropic_features.py
@@ -14,12 +14,13 @@ Provides easy access to Anthropic's beta features including:
 
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass
 from typing import Any, Literal
 
 from agent_gantry import AgentGantry
-from agent_gantry.schema.execution import ToolCall
+from agent_gantry.schema.execution import ExecutionStatus, ToolCall
 from agent_gantry.schema.query import ConversationContext, ToolQuery
 
 
@@ -139,21 +140,21 @@ class AnthropicClient:
             )
             tools = [t.tool.to_dialect("anthropic") for t in retrieval_result.tools]
 
-        # Build thinking payload — adaptive takes precedence over extended when both are set
-        if self._features.adaptive_thinking_effort and "thinking" not in kwargs:
-            thinking_block: dict[str, Any] = {
-                "type": "adaptive",
-                "effort": self._features.adaptive_thinking_effort,
-            }
-            if self._features.thinking_display:
-                thinking_block["display"] = self._features.thinking_display
-            kwargs["thinking"] = thinking_block
-        elif self._features.enable_extended_thinking and self._features.thinking_budget_tokens:
-            if "thinking" not in kwargs:
+        # Build thinking payload — adaptive takes precedence over extended when both are set.
+        # Display key and kwargs assignment happen once after the block is constructed.
+        if "thinking" not in kwargs:
+            thinking_block: dict[str, Any] | None = None
+            if self._features.adaptive_thinking_effort:
+                thinking_block = {
+                    "type": "adaptive",
+                    "effort": self._features.adaptive_thinking_effort,
+                }
+            elif self._features.enable_extended_thinking and self._features.thinking_budget_tokens:
                 thinking_block = {
                     "type": "enabled",
                     "budget_tokens": self._features.thinking_budget_tokens,
                 }
+            if thinking_block is not None:
                 if self._features.thinking_display:
                     thinking_block["display"] = self._features.thinking_display
                 kwargs["thinking"] = thinking_block
@@ -200,11 +201,16 @@ class AnthropicClient:
                 # is_error signals model-level tool failure; omitting it when the
                 # tool succeeded avoids unnecessary noise.
                 # Source: https://platform.claude.com/docs/en/api/messages (tool_result)
-                is_error = result.status != "success"
+                is_error = result.status != ExecutionStatus.SUCCESS
+                content: str
+                if is_error:
+                    content = f"Error: {result.error}"
+                else:
+                    content = result.result if isinstance(result.result, str) else json.dumps(result.result)
                 tool_result: dict[str, Any] = {
                     "type": "tool_result",
                     "tool_use_id": block.id,
-                    "content": str(result.result) if not is_error else f"Error: {result.error}",
+                    "content": content,
                 }
                 if is_error:
                     tool_result["is_error"] = True

--- a/agent_gantry/integrations/anthropic_features.py
+++ b/agent_gantry/integrations/anthropic_features.py
@@ -33,6 +33,11 @@ class AnthropicFeatures:
     # Adaptive thinking: model self-regulates depth; recommended for Opus 4.6+, Sonnet 4.6+,
     # Opus 4.7. Mutually exclusive with enable_extended_thinking.
     adaptive_thinking_effort: Literal["low", "medium", "high"] | None = None
+    # Controls whether thinking blocks appear in the response content.
+    # "summarized" — thinking is condensed; "omitted" — thinking is hidden but its
+    # signature is still returned for multi-turn continuity.
+    # Source: https://platform.claude.com/docs/en/api/messages (thinking parameter)
+    thinking_display: Literal["summarized", "omitted"] | None = None
 
 
 class AnthropicClient:
@@ -136,16 +141,22 @@ class AnthropicClient:
 
         # Build thinking payload — adaptive takes precedence over extended when both are set
         if self._features.adaptive_thinking_effort and "thinking" not in kwargs:
-            kwargs["thinking"] = {
+            thinking_block: dict[str, Any] = {
                 "type": "adaptive",
                 "effort": self._features.adaptive_thinking_effort,
             }
+            if self._features.thinking_display:
+                thinking_block["display"] = self._features.thinking_display
+            kwargs["thinking"] = thinking_block
         elif self._features.enable_extended_thinking and self._features.thinking_budget_tokens:
             if "thinking" not in kwargs:
-                kwargs["thinking"] = {
+                thinking_block = {
                     "type": "enabled",
                     "budget_tokens": self._features.thinking_budget_tokens,
                 }
+                if self._features.thinking_display:
+                    thinking_block["display"] = self._features.thinking_display
+                kwargs["thinking"] = thinking_block
 
         # Create message
         response = await self._client.messages.create(
@@ -185,16 +196,19 @@ class AnthropicClient:
                     )
                 )
 
-                # Format result for Anthropic
-                tool_results.append(
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": block.id,
-                        "content": str(result.result)
-                        if result.status == "success"
-                        else f"Error: {result.error}",
-                    }
-                )
+                # Format result for Anthropic.
+                # is_error signals model-level tool failure; omitting it when the
+                # tool succeeded avoids unnecessary noise.
+                # Source: https://platform.claude.com/docs/en/api/messages (tool_result)
+                is_error = result.status != "success"
+                tool_result: dict[str, Any] = {
+                    "type": "tool_result",
+                    "tool_use_id": block.id,
+                    "content": str(result.result) if not is_error else f"Error: {result.error}",
+                }
+                if is_error:
+                    tool_result["is_error"] = True
+                tool_results.append(tool_result)
 
         return tool_results
 
@@ -265,6 +279,7 @@ async def create_anthropic_client(
     enable_thinking: Literal["interleaved", "extended", "adaptive", None] = None,
     thinking_budget_tokens: int | None = None,
     adaptive_effort: Literal["low", "medium", "high"] = "medium",
+    thinking_display: Literal["summarized", "omitted"] | None = None,
 ) -> AnthropicClient:
     """
     Convenience function to create an Anthropic client with features.
@@ -279,6 +294,9 @@ async def create_anthropic_client(
         thinking_budget_tokens: Budget for extended thinking (ignored for other modes)
         adaptive_effort: Effort level for adaptive thinking — ``"low"``, ``"medium"`` (default),
             or ``"high"`` (ignored unless ``enable_thinking="adaptive"``)
+        thinking_display: Controls thinking visibility in the response. ``"summarized"``
+            condenses the thinking block; ``"omitted"`` hides it but preserves the
+            signature for multi-turn continuity. ``None`` (default) shows full thinking.
 
     Returns:
         Configured AnthropicClient
@@ -299,6 +317,7 @@ async def create_anthropic_client(
         enable_extended_thinking=(enable_thinking == "extended"),
         thinking_budget_tokens=thinking_budget_tokens,
         adaptive_thinking_effort=adaptive_effort if enable_thinking == "adaptive" else None,
+        thinking_display=thinking_display,
     )
 
     return AnthropicClient(

--- a/agent_gantry/integrations/anthropic_skills.py
+++ b/agent_gantry/integrations/anthropic_skills.py
@@ -329,14 +329,21 @@ class SkillsClient:
         # Execute all tools concurrently
         results = await asyncio.gather(*tool_executions)
 
-        # Format results for Anthropic
+        # Format results for Anthropic.
+        # is_error signals model-level tool failure so the model can distinguish
+        # error content from normal tool output.
+        # Source: https://platform.claude.com/docs/en/api/messages (tool_result)
         tool_results = []
         for block_id, result in zip(tool_use_ids, results):
-            tool_results.append({
+            is_error = result.status != "success"
+            tool_result: dict[str, Any] = {
                 "type": "tool_result",
                 "tool_use_id": block_id,
-                "content": str(result.result) if result.status == "success" else f"Error: {result.error}",
-            })
+                "content": str(result.result) if not is_error else f"Error: {result.error}",
+            }
+            if is_error:
+                tool_result["is_error"] = True
+            tool_results.append(tool_result)
 
         return tool_results
 

--- a/agent_gantry/integrations/anthropic_skills.py
+++ b/agent_gantry/integrations/anthropic_skills.py
@@ -13,12 +13,13 @@ that Claude can reason about and use effectively.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from agent_gantry import AgentGantry
-from agent_gantry.schema.execution import ToolCall
+from agent_gantry.schema.execution import ExecutionStatus, ToolCall
 from agent_gantry.schema.query import ConversationContext, ToolQuery
 
 
@@ -335,11 +336,16 @@ class SkillsClient:
         # Source: https://platform.claude.com/docs/en/api/messages (tool_result)
         tool_results = []
         for block_id, result in zip(tool_use_ids, results):
-            is_error = result.status != "success"
+            is_error = result.status != ExecutionStatus.SUCCESS
+            content: str
+            if is_error:
+                content = f"Error: {result.error}"
+            else:
+                content = result.result if isinstance(result.result, str) else json.dumps(result.result)
             tool_result: dict[str, Any] = {
                 "type": "tool_result",
                 "tool_use_id": block_id,
-                "content": str(result.result) if not is_error else f"Error: {result.error}",
+                "content": content,
             }
             if is_error:
                 tool_result["is_error"] = True

--- a/docs/reference/llm_sdk_compatibility.md
+++ b/docs/reference/llm_sdk_compatibility.md
@@ -1,6 +1,6 @@
-# LLM SDK Compatibility Guide (Late 2025)
+# LLM SDK Compatibility Guide (April 2026)
 
-This document details Agent-Gantry's compatibility with major Python LLM SDKs as of late 2025.
+This document details Agent-Gantry's compatibility with major Python LLM SDKs as of April 2026.
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,13 @@ dev = [
     "python-dotenv>=1.0.0",
 ]
 agent-frameworks = [
-    # Bump to 1.2.1: picks up GeminiChatClient (1.1.0), HandoffBuilder fixes (1.1.1),
-    # functional workflow API and AF→A2A bridge (1.2.0).
-    "agent-framework>=1.2.1,<2.0.0",
+    # Bump to 1.2.2: picks up GeminiChatClient (1.1.0), HandoffBuilder fixes (1.1.1),
+    # functional workflow API and AF→A2A bridge (1.2.0), observability span-nesting fix
+    # and hosted-workflow conversation-history propagation (1.2.2). Note the 1.2.2
+    # breaking change: sequential-approval and concurrent workflow terminal outputs now
+    # return as AgentResponse instead of a plain string — callers should use str() or
+    # .content to extract text.
+    "agent-framework>=1.2.2,<2.0.0",
     "autogen-agentchat>=0.7.5",
     "autogen-ext[openai]>=0.7.5",
     # crewai>=1.12.0 pins opentelemetry-api<1.35, which conflicts with
@@ -61,7 +65,7 @@ agent-frameworks = [
     # introduces the incompatibility. To use crewai>=1.12.0, install it in a
     # separate environment without agent-framework.
     "crewai>=1.6.1",
-    "langchain>=1.2.15",
+    "langchain>=1.2.16",
     "langchain-openai>=1.2.1",
     "langgraph>=1.1.10",
     "llama-index-core>=0.14.21",

--- a/tests/test_anthropic_features.py
+++ b/tests/test_anthropic_features.py
@@ -78,6 +78,7 @@ class TestAnthropicFeatures:
         assert features.enable_interleaved_thinking is False
         assert features.enable_extended_thinking is False
         assert features.thinking_budget_tokens is None
+        assert features.thinking_display is None
 
     def test_interleaved_thinking_config(self):
         """Test interleaved thinking configuration."""
@@ -93,6 +94,15 @@ class TestAnthropicFeatures:
         )
         assert features.enable_extended_thinking is True
         assert features.thinking_budget_tokens == 5000
+
+    def test_thinking_display_config(self):
+        """Test thinking_display field is stored correctly."""
+        features = AnthropicFeatures(
+            adaptive_thinking_effort="medium",
+            thinking_display="omitted",
+        )
+        assert features.thinking_display == "omitted"
+        assert features.adaptive_thinking_effort == "medium"
 
 
 class TestAnthropicClient:
@@ -151,6 +161,113 @@ class TestAnthropicClient:
         )
         client = AnthropicClient(api_key="test-key", features=features)
         assert client._features == features
+
+    @pytest.mark.asyncio
+    async def test_thinking_display_adaptive(self):
+        """Test that thinking_display is included in adaptive thinking payload."""
+        features = AnthropicFeatures(
+            adaptive_thinking_effort="high",
+            thinking_display="omitted",
+        )
+        client = AnthropicClient(api_key="test-key", features=features)
+
+        # Mock the underlying create call
+        mock_response = MagicMock()
+        mock_response.content = []
+        client._client.messages.create = AsyncMock(return_value=mock_response)
+
+        await client.create_message(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "Hello"}],
+            auto_retrieve_tools=False,
+        )
+
+        call_kwargs = client._client.messages.create.call_args.kwargs
+        assert "thinking" in call_kwargs
+        assert call_kwargs["thinking"]["type"] == "adaptive"
+        assert call_kwargs["thinking"]["effort"] == "high"
+        assert call_kwargs["thinking"]["display"] == "omitted"
+
+    @pytest.mark.asyncio
+    async def test_thinking_display_extended(self):
+        """Test that thinking_display is included in extended thinking payload."""
+        features = AnthropicFeatures(
+            enable_extended_thinking=True,
+            thinking_budget_tokens=8000,
+            thinking_display="summarized",
+        )
+        client = AnthropicClient(api_key="test-key", features=features)
+
+        mock_response = MagicMock()
+        mock_response.content = []
+        client._client.messages.create = AsyncMock(return_value=mock_response)
+
+        await client.create_message(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "Hello"}],
+            auto_retrieve_tools=False,
+        )
+
+        call_kwargs = client._client.messages.create.call_args.kwargs
+        assert "thinking" in call_kwargs
+        assert call_kwargs["thinking"]["type"] == "enabled"
+        assert call_kwargs["thinking"]["budget_tokens"] == 8000
+        assert call_kwargs["thinking"]["display"] == "summarized"
+
+    @pytest.mark.asyncio
+    async def test_thinking_display_absent_when_none(self):
+        """Test that display key is absent when thinking_display is None."""
+        features = AnthropicFeatures(
+            adaptive_thinking_effort="medium",
+            thinking_display=None,
+        )
+        client = AnthropicClient(api_key="test-key", features=features)
+
+        mock_response = MagicMock()
+        mock_response.content = []
+        client._client.messages.create = AsyncMock(return_value=mock_response)
+
+        await client.create_message(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "Hello"}],
+            auto_retrieve_tools=False,
+        )
+
+        call_kwargs = client._client.messages.create.call_args.kwargs
+        assert "thinking" in call_kwargs
+        assert "display" not in call_kwargs["thinking"]
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_calls_failure_sets_is_error(self, mock_anthropic_tool_response):
+        """Test that a failed tool execution sets is_error=True on the result."""
+        gantry = MagicMock(spec=AgentGantry)
+        mock_result = MagicMock()
+        mock_result.status = "failure"
+        mock_result.error = "Tool crashed"
+        gantry.execute = AsyncMock(return_value=mock_result)
+
+        client = AnthropicClient(api_key="test-key", gantry=gantry)
+        tool_results = await client.execute_tool_calls(mock_anthropic_tool_response)
+
+        assert len(tool_results) == 1
+        assert tool_results[0]["is_error"] is True
+        assert "Tool crashed" in tool_results[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_calls_success_omits_is_error(self, mock_anthropic_tool_response):
+        """Test that a successful tool execution does NOT set is_error."""
+        gantry = MagicMock(spec=AgentGantry)
+        mock_result = MagicMock()
+        mock_result.status = "success"
+        mock_result.result = {"temperature": 25, "unit": "C"}
+        gantry.execute = AsyncMock(return_value=mock_result)
+
+        client = AnthropicClient(api_key="test-key", gantry=gantry)
+        tool_results = await client.execute_tool_calls(mock_anthropic_tool_response)
+
+        assert len(tool_results) == 1
+        assert "is_error" not in tool_results[0]
+        assert tool_results[0]["content"] == '{"temperature": 25, "unit": "C"}'
 
 
 class TestCreateAnthropicClient:

--- a/tests/test_anthropic_skills.py
+++ b/tests/test_anthropic_skills.py
@@ -238,6 +238,56 @@ class TestSkillsClient:
         assert "Tool executed" in tool_results[0]["content"]
 
     @pytest.mark.asyncio
+    async def test_execute_tool_calls_failure_sets_is_error(self):
+        """Test that a failed tool execution sets is_error=True."""
+        gantry = MagicMock(spec=AgentGantry)
+        mock_result = MagicMock()
+        mock_result.status = "failure"
+        mock_result.error = "Downstream service unavailable"
+        gantry.execute = AsyncMock(return_value=mock_result)
+
+        client = SkillsClient(api_key="test-key", gantry=gantry)
+
+        response = MagicMock()
+        tool_block = MagicMock()
+        tool_block.type = "tool_use"
+        tool_block.id = "tool_err_1"
+        tool_block.name = "failing_tool"
+        tool_block.input = {}
+        response.content = [tool_block]
+
+        tool_results = await client.execute_tool_calls(response)
+
+        assert len(tool_results) == 1
+        assert tool_results[0]["is_error"] is True
+        assert "Downstream service unavailable" in tool_results[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_calls_success_omits_is_error(self):
+        """Test that a successful tool execution omits is_error."""
+        gantry = MagicMock(spec=AgentGantry)
+        mock_result = MagicMock()
+        mock_result.status = "success"
+        mock_result.result = {"order_id": "ORD-42", "status": "shipped"}
+        gantry.execute = AsyncMock(return_value=mock_result)
+
+        client = SkillsClient(api_key="test-key", gantry=gantry)
+
+        response = MagicMock()
+        tool_block = MagicMock()
+        tool_block.type = "tool_use"
+        tool_block.id = "tool_ok_1"
+        tool_block.name = "get_order"
+        tool_block.input = {"order_id": "ORD-42"}
+        response.content = [tool_block]
+
+        tool_results = await client.execute_tool_calls(response)
+
+        assert len(tool_results) == 1
+        assert "is_error" not in tool_results[0]
+        assert tool_results[0]["content"] == '{"order_id": "ORD-42", "status": "shipped"}'
+
+    @pytest.mark.asyncio
     async def test_execute_tool_calls_without_gantry(self):
         """Test that execute_tool_calls requires gantry."""
         client = SkillsClient(api_key="test-key")

--- a/tests/test_tool_spec_adapters.py
+++ b/tests/test_tool_spec_adapters.py
@@ -313,6 +313,33 @@ class TestAnthropicAdapter:
         assert result["type"] == "tool_result"
         assert result["tool_use_id"] == "toolu_abc123"
         assert "content" in result
+        assert "is_error" not in result
+
+    def test_format_tool_result_is_error(self) -> None:
+        """Test that is_error=True sets the is_error flag in the result."""
+        adapter = AnthropicAdapter()
+        result = adapter.format_tool_result(
+            tool_name="get_weather",
+            result="something went wrong",
+            tool_call_id="toolu_abc123",
+            is_error=True,
+        )
+
+        assert result["type"] == "tool_result"
+        assert result["is_error"] is True
+        assert result["content"] == "something went wrong"
+
+    def test_format_tool_result_no_is_error_on_success(self) -> None:
+        """Test that is_error key is absent when is_error=False (default)."""
+        adapter = AnthropicAdapter()
+        result = adapter.format_tool_result(
+            tool_name="get_weather",
+            result={"temp": 25, "condition": "sunny"},
+            tool_call_id="toolu_xyz",
+        )
+
+        assert "is_error" not in result
+        assert result["content"] == '{"temp": 25, "condition": "sunny"}'
 
 
 class TestGeminiAdapter:

--- a/uv.lock
+++ b/uv.lock
@@ -56,14 +56,14 @@ wheels = [
 
 [[package]]
 name = "agent-framework"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-framework-core", extra = ["all"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/c5/06e7b497e039a074c33a2cf31a5afeb3f1df3dc49a5a7163d526912fa557/agent_framework-1.2.1.tar.gz", hash = "sha256:f12ffe1b77212493293d44e0d09c17992dc41e83fc9b529d14c50aa24c217f74", size = 4653593, upload-time = "2026-04-28T09:26:02.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/ee/2b5b02ae0273edfc5a4f29a9e82c08f7c52360ae825b62ad5ea2555be2c2/agent_framework-1.2.2.tar.gz", hash = "sha256:418b16086c5c0e0bcb1bba171513e7bc54bd78011282105925d78f0cb3bb2e51", size = 4863836, upload-time = "2026-04-29T08:55:24.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/42/be6a41aa1a4592a144b1b69fee399ba8b786ba161ea4342eec434b240fcc/agent_framework-1.2.1-py3-none-any.whl", hash = "sha256:977b425dd5e8825081b6311b60333ea9be5540006314e7a9229ad8b1e3ef5b24", size = 5685, upload-time = "2026-04-28T09:26:04.88Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6e/e8ef7f990b7c024b90ec8204b304247a26bafa057d77654dab23c60787db/agent_framework-1.2.2-py3-none-any.whl", hash = "sha256:e31b8ce50d3d40274e88eee7c0a8a6eec5638bf76a75fa54012a33126b7b8798", size = 5685, upload-time = "2026-04-29T08:55:54.98Z" },
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework-core"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -236,9 +236,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/3a/8a30a45e744a714ebde5bcf8c491deadac0af7c0a0090f44310946628624/agent_framework_core-1.2.1.tar.gz", hash = "sha256:25fbe1a169243147d8c22b1d3fcddb997feea52b5b12ffda57c78a9211b34aed", size = 306826, upload-time = "2026-04-28T09:25:34.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/6a/dae422906f3a664a54c079238ba97a7d1be6958782e341381ea0db228007/agent_framework_core-1.2.2.tar.gz", hash = "sha256:486ddecbdc0c47acf890b2230e5986beb1c5dc8cca39d8faeb008013ba7aa0e5", size = 309480, upload-time = "2026-04-29T08:55:57.206Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/96/7eef5a6b4de657cc5c5e62f9df7b4bfb2b030df5a002515c54304fd81eb7/agent_framework_core-1.2.1-py3-none-any.whl", hash = "sha256:730de31eab690ea81dc59d7526e9c15511ef93e28bdca6284471e465978a35f5", size = 345584, upload-time = "2026-04-28T09:25:45.17Z" },
+    { url = "https://files.pythonhosted.org/packages/68/1d/2aeada01b7c0e72fd363332c8f283eea229f3b044b816c8c0ae3cb8cf517/agent_framework_core-1.2.2-py3-none-any.whl", hash = "sha256:67c1eb8a22cb1d710c478cf2f4dd278ee9dae3ea5643a4d6e63256fdf3a121ee", size = 348302, upload-time = "2026-04-29T08:55:55.895Z" },
 ]
 
 [package.optional-dependencies]
@@ -637,7 +637,7 @@ vector-stores = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.1,<2.0.0" },
+    { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.2,<2.0.0" },
     { name = "agent-gantry", extras = ["dev", "embeddings", "openai", "cohere", "vector-stores", "lancedb", "nomic", "mcp", "a2a", "llm-providers", "agent-frameworks", "example-tools"], marker = "extra == 'all'" },
     { name = "agent-gantry", extras = ["openai", "anthropic", "google-genai", "google-vertexai", "mistral", "groq"], marker = "extra == 'llm-providers'" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.97.0" },
@@ -662,7 +662,7 @@ requires-dist = [
     { name = "huggingface-hub", extras = ["hf-xet"], marker = "extra == 'example-tools'", specifier = ">=0.36.0" },
     { name = "jsonschema", specifier = ">=4.18.0" },
     { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.4.0" },
-    { name = "langchain", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.15" },
+    { name = "langchain", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.16" },
     { name = "langchain-openai", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.1" },
     { name = "langgraph", marker = "extra == 'agent-frameworks'", specifier = ">=1.1.10" },
     { name = "llama-index-core", marker = "extra == 'agent-frameworks'", specifier = ">=0.14.21" },
@@ -3788,16 +3788,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.15"
+version = "1.2.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", size = 574732, upload-time = "2026-04-03T14:26:03.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/34/47318136a1995aed51455a243db135eb244c5af97a9f5232f5f5f505da21/langchain-1.2.16.tar.gz", hash = "sha256:8a091122418a2b2ea12cf2a4ddc47f51012ee5ec3f9a93b5f351eeb8d1bc9c70", size = 577003, upload-time = "2026-04-29T21:02:44.666Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", size = 112714, upload-time = "2026-04-03T14:26:02.557Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0c/1cafab69a16b7d949b71bde9b5ea8e7bfd5ad082718389bb47a2284e3787/langchain-1.2.16-py3-none-any.whl", hash = "sha256:d2cef7452fe54a12d587dbac93daf37b7bbfde0719e8a47a79fe576e1411c28c", size = 112903, upload-time = "2026-04-29T21:02:42.779Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR adds support for controlling thinking visibility in Claude API responses and improves tool error handling by properly signaling failed tool executions to the model.

## Key Changes

### Thinking Display Control
- **New `AnthropicFeatures.thinking_display` field**: Allows controlling whether thinking blocks appear in responses with options `"summarized"` (condensed) or `"omitted"` (hidden but signature preserved for multi-turn continuity)
- **Exposed via `create_anthropic_client(thinking_display=...)`**: Convenience function now accepts the new parameter
- **Applied to both adaptive and extended thinking modes**: The `display` field is conditionally added to the thinking payload when configured

### Tool Error Handling
- **`AnthropicAdapter.format_tool_result()` now accepts `is_error` parameter**: When `True`, includes `"is_error": true` in the tool_result block so the model can distinguish error content from normal tool output
- **`AnthropicClient.execute_tool_calls()` now sets `is_error` flag**: Failed tool executions are marked with `"is_error": true` instead of relying solely on error text in the content
- **`SkillsClient.execute_tool_calls()` updated similarly**: Consistent error handling across both implementations

## Implementation Details
- The `thinking_display` field is optional and defaults to `None` (full thinking shown), maintaining backward compatibility
- The `is_error` flag is only included in tool_result blocks when the tool execution actually failed, avoiding unnecessary noise
- Both changes are additive and backward-compatible; existing code continues to work without modification
- Added source documentation links to Anthropic API reference for maintainability

## Documentation
- Updated CHANGELOG.md with detailed entries for all changes
- Updated docs/reference/llm_sdk_compatibility.md header date to April 2026
- Bumped dependencies: `agent-framework>=1.2.2` and `langchain>=1.2.16`

https://claude.ai/code/session_017SvXdDg3J1UduZdY8D2AKX