### PR TITLE
🎨 Palette: Add aria-current semantic state to dynamic navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-04-30 - [Keyboard Accessibility for Custom Dropdowns]
 **Learning:** Custom dropdowns (like search results) that rely on `click` outside to close will remain open when a keyboard user presses `Tab` to navigate away from the input or container. This can leave floating content visible and obscure other parts of the page.
 **Action:** When implementing custom dropdowns, always include a `document.addEventListener("focusin", ...)` listener to check if the newly focused element is outside the dropdown container, and if so, close the dropdown to maintain a clean UI for keyboard users.
+
+## 2026-05-01 - [Semantic Context for Dynamic Navigation Links]
+**Learning:** Dynamically applying visual `.active` classes to navigation items via client-side JavaScript leaves screen readers oblivious to the active state. Users relying on assistive technology will not know which link represents their current page if only visual classes are modified.
+**Action:** When conditionally applying an `.active` class to indicate the current page or step, consistently apply `link.setAttribute("aria-current", "page")` simultaneously, and ensure you `removeAttribute("aria-current")` when the active state is removed.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -48,6 +48,7 @@
       // Exact match or starts with for sub-pages
       if (currentPath === linkPath || currentPath.startsWith(linkPath + "/")) {
         link.classList.add("active");
+        link.setAttribute("aria-current", "page");
 
         // Expand parent section if in submenu
         const parentMenu = link.closest(".nav-submenu");
@@ -59,6 +60,7 @@
         }
       } else {
         link.classList.remove("active");
+        link.removeAttribute("aria-current");
       }
     });
   }


### PR DESCRIPTION
💡 What: Added `aria-current="page"` attribute assignment to the dynamic navigation highlighting script in `docs/assets/js/navigation.js`.
🎯 Why: Previously, only the visual `.active` class was toggled when a navigation link matched the current path. Sighted users could see the current page indicator, but screen reader users were oblivious to this active state. Toggling `aria-current="page"` gives assistive technologies the same semantic context as the visual cues.
📸 Before/After: Verified locally using a headless Playwright script to mock `window.location` and assert both `.active` and `aria-current="page"` are correctly added to the active link.
♿ Accessibility: Improved semantic clarity for navigation. Added a journal entry about semantic context for dynamically toggled visual classes.

---
*PR created automatically by Jules for task [13855818743789262208](https://jules.google.com/task/13855818743789262208) started by @CodeHalwell*