### PR TITLE
Add per-call retrieval, query strategies, and provider introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cross-event-loop failures with `DurableAIAgentWorker` and similar
+  worker-thread loops.** When a gantry was constructed in one context
+  (often module import time) and then driven from a different event
+  loop on a worker thread, contended access to the rate limiter's
+  ``asyncio.Lock`` raised ``RuntimeError: ... is bound to a different
+  event loop`` because ``asyncio`` synchronisation primitives bind to
+  the loop they were first awaited on. Symptoms in the wild: every
+  tool execution returning ``"Error: Function failed."`` (Agent
+  Framework's opaque catch-all) once the durable worker took over.
+  ``RateLimiter`` now keeps one lock per running loop, lazily
+  constructed on first use; closed loops are pruned opportunistically.
+  Bounded leak: one entry per distinct loop ever used, typically
+  1–2 per process.
+- **Sync tool handlers no longer use the deprecated
+  ``asyncio.get_event_loop()``** in
+  ``ExecutionEngine._execute_with_timeout``. Replaced with
+  ``asyncio.to_thread(...)``, which always binds to the running loop
+  and removes another cross-loop hazard for worker-thread setups.
+- **Bridge wrapper now surfaces the underlying exception** instead of
+  letting it propagate up to Agent Framework's tool runner — which
+  rewrites every exception as the unhelpful ``"Error: Function
+  failed."`` string when ``include_detailed_errors`` is off.
+  Wrappers built by ``GantryToolBridge`` (and therefore by
+  ``GantryContextProvider``) catch any exception from
+  ``gantry.execute(...)`` and return a structured
+  ``{"error": "<ExcType>: <message>"}`` JSON string. Failed
+  ``ToolResult``s also include ``error_type`` in the surfaced text.
+- **New cross-loop test suite** (``tests/test_executor_cross_loop.py``)
+  reproduces the durable-worker scenario: gantry built on one loop,
+  driven from a worker-thread loop, with genuine lock contention to
+  force the binding path. The suite also covers exception surfacing
+  for both handler-level and executor-level failures.
+
 ### Added
 
 - **`agent_gantry.query` module** — built-in deterministic query-generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   driven from a worker-thread loop, with genuine lock contention to
   force the binding path. The suite also covers exception surfacing
   for both handler-level and executor-level failures.
+- **New durable-worker integration test**
+  (``tests/test_durable_worker_integration.py``) drives a real
+  :class:`agent_framework.RawAgent` with a ``BaseChatClient`` subclass
+  that emits one or more ``function_call`` items, then runs each
+  request via ``asyncio.run`` — the exact loop topology used by
+  :class:`agent_framework_durabletask.DurableAIAgentWorker`. Covers:
+  sequential ``asyncio.run`` requests with sync handlers; parallel
+  function-call dispatch with async handlers (real lock contention);
+  worker-thread execution; and worker-thread → main-thread
+  sequencing. Tools are pre-resolved once at "module load" via
+  :class:`GantryToolBridge`, mirroring the integrator pattern.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``ExecutionEngine._execute_with_timeout``. Replaced with
   ``asyncio.to_thread(...)``, which always binds to the running loop
   and removes another cross-loop hazard for worker-thread setups.
+- **``NomicEmbedder`` no longer uses ``asyncio.get_event_loop()``** in
+  ``embed_text``, ``embed_batch``, ``embed_query``, and ``health_check``.
+  Replaced all four with ``asyncio.to_thread(...)``. The previous code
+  warned under ``-W error::DeprecationWarning`` on 3.10+ and would have
+  picked up the wrong loop in ``DurableAIAgentWorker``-style setups.
 - **Bridge wrapper now surfaces the underlying exception** instead of
   letting it propagate up to Agent Framework's tool runner — which
   rewrites every exception as the unhelpful ``"Error: Function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`agent_gantry.query` module** — built-in deterministic query-generation
+  strategies for semantic retrieval: `last_user_text` (default),
+  `last_assistant_text`, `last_tool_result`, `concatenate_recent`, and
+  `fallback_chain`. Strategies operate on AF messages, dicts, or anything
+  exposing `role` + `text`/`content`.
+- **`GantryContextProvider` per-call retrieval** — new
+  `query_strategy="per_call"` (default `"per_run"` is back-compat) plus
+  `query_generator=...` parameter for per-chat-round semantic refresh.
+  `provider.as_chat_middleware()` returns the AF chat middleware that wires
+  the per-round refresh into `Agent(middleware=[...])`. Solves the
+  "tool selection is fixed for the whole `agent.run()`" limitation flagged
+  by integrators of multi-step workflows.
+- **`required=[...]` parameter on `GantryContextProvider`** — hard pins a
+  set of tools and raises `MissingRequiredToolError` at construction time
+  if any are missing from the gantry. Catches typos / dropped registrations
+  earlier than runtime agent failure.
+- **Public read-only properties on `GantryContextProvider`** — `top_k`,
+  `score_threshold`, `query_strategy`, `always_include`, `required`,
+  `gantry`, `bridge`. External observability code can read configuration
+  without poking at private attributes.
+- **`AgentGantry.preview(query, ...)`** — read-only ranking helper that
+  returns `(qualified_name, score)` pairs, useful for calibrating
+  `score_threshold` without spinning up an agent.
+- **`AgentGantry.list_tools_sync()`** — sync, in-memory inspection of
+  registered tools (no `await`, no vector store round-trip). Complements
+  the existing async `list_tools()`.
+- **`agent_gantry.adapters.embedders` re-exports `SentenceTransformersEmbedder`,
+  `OpenAIEmbedder`, `AzureOpenAIEmbedder`** alongside `NomicEmbedder` and
+  `SimpleEmbedder`, all behind lazy imports — you can write
+  `from agent_gantry.adapters.embedders import SentenceTransformersEmbedder`
+  without knowing the deep submodule path. Same pattern applied to
+  `agent_gantry.adapters.rerankers` (`CohereReranker`, `CrossEncoderReranker`).
+- **Tests** — `tests/test_query_strategies.py` covers the new query module,
+  `preview`, `list_tools_sync`, the `SimpleEmbedder` warning, FunctionTool
+  registration, and adapter re-exports.
+
+### Changed
+
+- **`AgentGantry.register()` now accepts `agent_framework.tool`-decorated
+  FunctionTool objects** (or any wrapper exposing `.name` / `.func`).
+  Previously raised `AttributeError: 'FunctionTool' object has no attribute
+  '__name__'`. Bare callables continue to work unchanged.
+- **`SimpleEmbedder` warns when paired with `score_threshold > 0.0`** —
+  hash-based similarity scores cluster tightly regardless of relevance, so
+  a non-zero threshold typically returns 0 tools silently. The first
+  retrieval call now emits a `UserWarning` recommending a real embedder.
+- **`SimpleEmbedder` docstring** updated to lead with "for testing only —
+  produces near-uniform similarity scores", to make its non-production
+  nature obvious from `help(SimpleEmbedder)`.
+- **`EmbeddingAdapter` docstring** corrected: lists actual implementations
+  (`SimpleEmbedder`, `NomicEmbedder`, `SentenceTransformersEmbedder`,
+  `OpenAIEmbedder`, `AzureOpenAIEmbedder`) instead of the old typo'd
+  `SentenceTransformerEmbedder` (singular).
+- **`SentenceTransformersEmbedder` no longer triggers a `FutureWarning`**
+  on first init — calls `get_embedding_dimension()` when available and
+  falls back to the deprecated `get_sentence_embedding_dimension()` only
+  on older releases.
+
 ## [0.2.0] - 2026-05-01
 
 ### Changed

--- a/agent_gantry/__init__.py
+++ b/agent_gantry/__init__.py
@@ -9,6 +9,7 @@ Core Philosophy: Context is precious. Execution is sacred. Trust is earned.
 from agent_gantry.core.gantry import AgentGantry, create_default_gantry
 from agent_gantry.integrations.agent_framework_provider import (
     GantryContextProvider,
+    MissingRequiredToolError,
 )
 from agent_gantry.integrations.semantic_tools import (
     set_default_gantry,
@@ -28,6 +29,7 @@ __version__ = "0.2.0"
 __all__ = [
     "AgentGantry",
     "GantryContextProvider",
+    "MissingRequiredToolError",
     "create_default_gantry",
     "with_semantic_tools",
     "set_default_gantry",

--- a/agent_gantry/adapters/embedders/__init__.py
+++ b/agent_gantry/adapters/embedders/__init__.py
@@ -1,13 +1,36 @@
 """
 Embedding adapters for Agent-Gantry.
+
+The base protocol :class:`EmbeddingAdapter` and the dependency-free
+:class:`SimpleEmbedder` are imported eagerly. Heavier adapters that pull in
+optional third-party dependencies (sentence-transformers, OpenAI SDK,
+LlamaIndex, etc.) are lazy-loaded via ``__getattr__`` so importing this
+module never forces optional installs.
+
+All names listed in ``__all__`` are accessible from this module — including
+the lazy ones — so a single ``from agent_gantry.adapters.embedders import X``
+works regardless of whether ``X`` lives behind an optional dep:
+
+.. code-block:: python
+
+    from agent_gantry.adapters.embedders import (
+        SimpleEmbedder,
+        SentenceTransformersEmbedder,  # requires sentence-transformers
+        NomicEmbedder,                  # requires sentence-transformers
+        OpenAIEmbedder,                 # requires openai
+        AzureOpenAIEmbedder,            # requires openai
+    )
 """
 
 from agent_gantry.adapters.embedders.base import EmbeddingAdapter
 from agent_gantry.adapters.embedders.simple import SimpleEmbedder
 
 __all__ = [
+    "AzureOpenAIEmbedder",
     "EmbeddingAdapter",
     "NomicEmbedder",
+    "OpenAIEmbedder",
+    "SentenceTransformersEmbedder",
     "SimpleEmbedder",
 ]
 
@@ -18,4 +41,22 @@ def __getattr__(name: str) -> type:
         from agent_gantry.adapters.embedders.nomic import NomicEmbedder
 
         return NomicEmbedder
+    if name == "SentenceTransformersEmbedder":
+        from agent_gantry.adapters.embedders.sentence_transformers import (
+            SentenceTransformersEmbedder,
+        )
+
+        return SentenceTransformersEmbedder
+    if name == "OpenAIEmbedder":
+        from agent_gantry.adapters.embedders.openai import OpenAIEmbedder
+
+        return OpenAIEmbedder
+    if name == "AzureOpenAIEmbedder":
+        from agent_gantry.adapters.embedders.openai import AzureOpenAIEmbedder
+
+        return AzureOpenAIEmbedder
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/agent_gantry/adapters/embedders/base.py
+++ b/agent_gantry/adapters/embedders/base.py
@@ -12,8 +12,8 @@ class EmbeddingAdapter(Protocol):
     """
     Text embedding abstraction.
 
-    Implementations: OpenAIEmbedder, AzureOpenAIEmbedder, CohereEmbedder,
-                     HuggingFaceEmbedder, SentenceTransformerEmbedder, OllamaEmbedder.
+    Implementations: SimpleEmbedder, NomicEmbedder, SentenceTransformersEmbedder,
+                     OpenAIEmbedder, AzureOpenAIEmbedder.
     """
 
     @property

--- a/agent_gantry/adapters/embedders/nomic.py
+++ b/agent_gantry/adapters/embedders/nomic.py
@@ -171,9 +171,8 @@ class NomicEmbedder(EmbeddingAdapter):
         prefixed_text = f"{self._task_prefix}{text}"
 
         # Generate embedding (run in thread pool to avoid blocking event loop)
-        loop = asyncio.get_event_loop()
-        embedding = await loop.run_in_executor(
-            None, lambda: self._model.encode([prefixed_text], normalize_embeddings=True)
+        embedding = await asyncio.to_thread(
+            lambda: self._model.encode([prefixed_text], normalize_embeddings=True)
         )
         result = embedding.tolist()
 
@@ -211,9 +210,8 @@ class NomicEmbedder(EmbeddingAdapter):
         if batch_size is not None:
             kwargs["batch_size"] = batch_size
 
-        loop = asyncio.get_event_loop()
-        embeddings = await loop.run_in_executor(
-            None, lambda: self._model.encode(prefixed_texts, **kwargs)
+        embeddings = await asyncio.to_thread(
+            lambda: self._model.encode(prefixed_texts, **kwargs)
         )
         result = embeddings.tolist()
 
@@ -242,9 +240,8 @@ class NomicEmbedder(EmbeddingAdapter):
         prefixed_query = f"search_query: {query}"
 
         # Generate embedding (run in thread pool to avoid blocking event loop)
-        loop = asyncio.get_event_loop()
-        embedding = await loop.run_in_executor(
-            None, lambda: self._model.encode([prefixed_query], normalize_embeddings=True)
+        embedding = await asyncio.to_thread(
+            lambda: self._model.encode([prefixed_query], normalize_embeddings=True)
         )
         result = embedding.tolist()
 
@@ -263,9 +260,8 @@ class NomicEmbedder(EmbeddingAdapter):
         try:
             self._ensure_initialized()
             # Quick sanity check (run in thread pool to avoid blocking event loop)
-            loop = asyncio.get_event_loop()
-            test_embedding = await loop.run_in_executor(
-                None, lambda: self._model.encode(["test"], normalize_embeddings=True)
+            test_embedding = await asyncio.to_thread(
+                lambda: self._model.encode(["test"], normalize_embeddings=True)
             )
             return len(test_embedding[0]) > 0
         except Exception:

--- a/agent_gantry/adapters/embedders/sentence_transformers.py
+++ b/agent_gantry/adapters/embedders/sentence_transformers.py
@@ -70,7 +70,15 @@ class SentenceTransformersEmbedder(EmbeddingAdapter):
             kwargs["device"] = self._device
 
         self._model = SentenceTransformer(self._model_name, **kwargs)
-        self._native_dimension = self._model.get_sentence_embedding_dimension()
+        # ``get_sentence_embedding_dimension`` was renamed to
+        # ``get_embedding_dimension`` in newer sentence-transformers releases;
+        # call the new name when available and fall back to the old one
+        # silently to remain compatible across versions.
+        get_dim = (
+            getattr(self._model, "get_embedding_dimension", None)
+            or self._model.get_sentence_embedding_dimension
+        )
+        self._native_dimension = get_dim()
 
         if self._requested_dimension and self._requested_dimension > self._native_dimension:
             warnings.warn(

--- a/agent_gantry/adapters/embedders/simple.py
+++ b/agent_gantry/adapters/embedders/simple.py
@@ -12,14 +12,11 @@ Cohere) and pass a non-zero ``score_threshold`` only with those.
 from __future__ import annotations
 
 import hashlib
-import logging
 import math
 import re
 from collections.abc import Iterable
 
 from agent_gantry.adapters.embedders.base import EmbeddingAdapter
-
-logger = logging.getLogger(__name__)
 
 
 class SimpleEmbedder(EmbeddingAdapter):

--- a/agent_gantry/adapters/embedders/simple.py
+++ b/agent_gantry/adapters/embedders/simple.py
@@ -1,22 +1,47 @@
 """
 Lightweight, dependency-free embedder for local development and tests.
 
-Uses a deterministic token hashing scheme to produce fixed-length vectors.
-This keeps retrieval fast and avoids heavyweight model downloads.
+**For testing only — produces near-uniform similarity scores.** Uses a
+deterministic token hashing scheme to produce fixed-length vectors. This keeps
+retrieval fast and avoids heavyweight model downloads, but has no semantic
+understanding: similarity reflects token overlap, not meaning. For production
+use install one of the real embedders (Nomic, SentenceTransformers, OpenAI,
+Cohere) and pass a non-zero ``score_threshold`` only with those.
 """
 
 from __future__ import annotations
 
 import hashlib
+import logging
 import math
 import re
+import warnings
 from collections.abc import Iterable
 
 from agent_gantry.adapters.embedders.base import EmbeddingAdapter
 
+logger = logging.getLogger(__name__)
+
 
 class SimpleEmbedder(EmbeddingAdapter):
-    """A tiny, deterministic embedder suitable for unit tests."""
+    """**For testing only — produces near-uniform similarity scores.**
+
+    Hash-based deterministic embedder suitable for unit tests and local
+    development without downloading models. Not for production retrieval;
+    its scores cluster tightly around 0.0–0.3 even for unrelated text, so
+    pairing it with a non-zero ``score_threshold`` typically results in
+    "0 tools surfaced" silently.
+
+    For meaningful retrieval, use one of the real embedders:
+
+    - :class:`agent_gantry.adapters.embedders.NomicEmbedder` (local,
+      ``pip install agent-gantry[nomic]``)
+    - :class:`agent_gantry.adapters.embedders.SentenceTransformersEmbedder`
+      (local, ``pip install agent-gantry[sentence-transformers]``)
+    - :class:`agent_gantry.adapters.embedders.OpenAIEmbedder` (remote)
+    """
+
+    _warned_about_threshold: bool = False
 
     def __init__(self, dimension: int = 64) -> None:
         self._dimension = dimension

--- a/agent_gantry/adapters/embedders/simple.py
+++ b/agent_gantry/adapters/embedders/simple.py
@@ -15,7 +15,6 @@ import hashlib
 import logging
 import math
 import re
-import warnings
 from collections.abc import Iterable
 
 from agent_gantry.adapters.embedders.base import EmbeddingAdapter

--- a/agent_gantry/adapters/rerankers/__init__.py
+++ b/agent_gantry/adapters/rerankers/__init__.py
@@ -1,9 +1,32 @@
 """
 Reranker adapters for Agent-Gantry.
+
+The base :class:`RerankerAdapter` protocol is imported eagerly; concrete
+implementations that pull in optional dependencies (cohere, sentence-transformers
+cross-encoders) are lazy-loaded via ``__getattr__`` so importing this module
+does not require optional installs.
 """
 
 from agent_gantry.adapters.rerankers.base import RerankerAdapter
 
 __all__ = [
+    "CohereReranker",
+    "CrossEncoderReranker",
     "RerankerAdapter",
 ]
+
+
+def __getattr__(name: str) -> type:
+    if name == "CohereReranker":
+        from agent_gantry.adapters.rerankers.cohere import CohereReranker
+
+        return CohereReranker
+    if name == "CrossEncoderReranker":
+        from agent_gantry.adapters.rerankers.cross_encoder import CrossEncoderReranker
+
+        return CrossEncoderReranker
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/agent_gantry/core/executor.py
+++ b/agent_gantry/core/executor.py
@@ -213,17 +213,24 @@ class ExecutionEngine:
         arguments: dict[str, Any],
         timeout_ms: int,
     ) -> Any:
-        """Execute a handler with a timeout."""
+        """Execute a handler with a timeout.
+
+        Sync handlers are dispatched via :func:`asyncio.to_thread`, which
+        binds correctly to the *running* loop. ``asyncio.get_event_loop()``
+        is deprecated in 3.10+ when there is no running loop, and in worker-
+        thread contexts (e.g. ``DurableAIAgentWorker``) it can return a
+        different loop from the one currently running, surfacing as cross-
+        loop runtime errors when the executor is driven from a loop other
+        than the one the gantry was constructed on.
+        """
         timeout_s = timeout_ms / 1000
 
         if asyncio.iscoroutinefunction(handler):
             return await asyncio.wait_for(handler(**arguments), timeout=timeout_s)
-        else:
-            loop = asyncio.get_event_loop()
-            return await asyncio.wait_for(
-                loop.run_in_executor(None, lambda: handler(**arguments)),
-                timeout=timeout_s,
-            )
+        return await asyncio.wait_for(
+            asyncio.to_thread(handler, **arguments),
+            timeout=timeout_s,
+        )
 
     async def _execute_handler_with_retries(
         self,

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -400,11 +400,42 @@ class AgentGantry:
         """
 
         def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
-            tool_name = name or fn.__name__
-            tool_description = fn.__doc__ or f"Tool: {tool_name}"
+            # Accept agent_framework FunctionTool (or any tool-spec wrapper
+            # exposing .name + .func). AF's @tool decorator produces an
+            # object without ``__name__``, which would otherwise break the
+            # legacy ``fn.__name__`` lookup. Unwrap to the bare callable
+            # while remembering the original wrapper so the decorator's
+            # return value still matches what the caller passed in.
+            original = fn
+            wrapper_name = getattr(fn, "name", None)
+            wrapper_func = getattr(fn, "func", None)
+            wrapper_desc = getattr(fn, "description", None)
+            if wrapper_func is not None and callable(wrapper_func):
+                underlying = wrapper_func
+            else:
+                underlying = fn
 
-            # Build parameters schema from function signature
-            parameters_schema = build_parameters_schema(fn)
+            tool_name = (
+                name
+                or wrapper_name
+                or getattr(underlying, "__name__", None)
+                or getattr(original, "__name__", None)
+            )
+            if not tool_name:
+                raise TypeError(
+                    "AgentGantry.register() could not determine a tool name. "
+                    "Pass `name=...` explicitly, or supply a callable with a "
+                    "__name__ (or an agent_framework FunctionTool with .name)."
+                )
+
+            tool_description = (
+                (underlying.__doc__ if hasattr(underlying, "__doc__") else None)
+                or wrapper_desc
+                or f"Tool: {tool_name}"
+            )
+
+            # Build parameters schema from the underlying callable's signature.
+            parameters_schema = build_parameters_schema(underlying)
 
             tool = ToolDefinition(
                 name=tool_name,
@@ -418,14 +449,14 @@ class AgentGantry:
             )
 
             self._pending_tools.append(tool)
-            self._tool_handlers[tool_name] = fn
+            self._tool_handlers[tool_name] = underlying
 
             # Register both tool definition and handler in the registry
             key = f"{namespace}.{tool_name}"
             self._registry.register_tool(tool)
-            self._registry.register_handler(key, fn)
+            self._registry.register_handler(key, underlying)
 
-            return fn
+            return original
 
         if func is not None:
             return decorator(func)
@@ -771,6 +802,28 @@ class AgentGantry:
 
         # Auto-sync with smart change detection
         await self.ensure_synced()
+
+        # SimpleEmbedder produces hash-based scores that cluster tightly
+        # regardless of semantic relevance. Pairing it with a non-zero
+        # score_threshold typically results in "0 tools surfaced" silently
+        # (which integrators report as a frustrating first-day failure).
+        # Warn loudly on the first such retrieval call.
+        if isinstance(self._embedder, SimpleEmbedder) and not SimpleEmbedder._warned_about_threshold:
+            threshold = getattr(query, "score_threshold", None) or 0.0
+            if threshold > 0.0:
+                SimpleEmbedder._warned_about_threshold = True
+                import warnings as _warnings
+
+                _warnings.warn(
+                    "SimpleEmbedder produces hash-based similarity scores with "
+                    "no semantic understanding; pairing it with "
+                    f"score_threshold={threshold} will likely filter all "
+                    "tools out. Set score_threshold=0.0 for SimpleEmbedder, "
+                    "or install a real embedder: "
+                    "pip install agent-gantry[nomic]",
+                    UserWarning,
+                    stacklevel=3,
+                )
 
         overall_start = perf_counter()
         if self._config.reranker.enabled and self._reranker is not None:
@@ -1288,6 +1341,93 @@ class AgentGantry:
         await self._ensure_initialized()
         await self.ensure_synced()
         return await self._vector_store.list_all(namespace=namespace)
+
+    def list_tools_sync(
+        self,
+        namespace: str | None = None,
+    ) -> list[ToolDefinition]:
+        """
+        Synchronously list locally-registered tools.
+
+        Reads from the in-memory registry only — does not hit the vector
+        store and does not trigger sync. This is the natural API for
+        read-only inspection (telemetry, debug printers, validators) where
+        going through ``await`` is awkward and the in-memory view is
+        sufficient.
+
+        Args:
+            namespace: Filter by namespace.
+
+        Returns:
+            List of tool definitions known to the registry.
+        """
+        registered = self._registry.list_tools()
+        pending = self._pending_tools
+
+        seen: set[str] = set()
+        out: list[ToolDefinition] = []
+        for tool in (*registered, *pending):
+            key = f"{tool.namespace}.{tool.name}"
+            if key in seen:
+                continue
+            if namespace is not None and tool.namespace != namespace:
+                continue
+            seen.add(key)
+            out.append(tool)
+        return out
+
+    async def preview(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        score_threshold: float | None = None,
+        **query_kwargs: Any,
+    ) -> list[tuple[str, float]]:
+        """
+        Preview which tools would surface for a given query.
+
+        Read-only helper for calibrating ``score_threshold`` and ``top_k``
+        without spinning up the full agent. Returns ``(tool_name, score)``
+        pairs sorted by descending score.
+
+        Args:
+            query: Natural-language query to retrieve against.
+            limit: Maximum number of candidates to return (default 10).
+            score_threshold: Override the score threshold. ``None`` uses
+                the configured default of ``0.0`` so you can see the full
+                ranking, including tools that would be filtered out.
+            **query_kwargs: Forwarded to :class:`ToolQuery` /
+                :class:`ConversationContext` (``namespaces``, etc.).
+
+        Returns:
+            List of ``(qualified_name, semantic_score)`` tuples sorted
+            descending by score. Qualified name is ``namespace.name``.
+
+        Example:
+            >>> ranked = await gantry.preview(
+            ...     "find boundaries in OCR text",
+            ...     limit=10,
+            ...     score_threshold=0.0,
+            ... )
+            >>> for name, score in ranked:
+            ...     print(f"{score:.3f}  {name}")
+        """
+        from agent_gantry.schema.query import ConversationContext, ToolQuery
+
+        threshold = 0.0 if score_threshold is None else score_threshold
+        context = ConversationContext(query=query)
+        tool_query = ToolQuery(
+            context=context,
+            limit=limit,
+            score_threshold=threshold,
+            **query_kwargs,
+        )
+        result = await self.retrieve(tool_query)
+        return [
+            (f"{st.tool.namespace}.{st.tool.name}", st.semantic_score)
+            for st in result.tools
+        ]
 
     def export_tools(self) -> list[ToolDefinition]:
         """

--- a/agent_gantry/core/rate_limiter.py
+++ b/agent_gantry/core/rate_limiter.py
@@ -2,12 +2,23 @@
 Rate limiting for tool execution.
 
 Provides rate limiting capabilities to prevent abuse and manage resource consumption.
+
+asyncio synchronisation primitives (``asyncio.Lock`` etc.) bind to the event
+loop they are first awaited on. Constructing a single ``asyncio.Lock`` inside
+``RateLimiter.__init__`` and reusing it across multiple loops — for example a
+gantry built at import time and then driven from a worker-thread loop owned by
+``DurableAIAgentWorker`` — produces ``RuntimeError: ... is bound to a
+different event loop`` on the second loop. To stay correct in those setups we
+keep one ``asyncio.Lock`` per running loop, lazily constructed via
+:func:`_lock_for_running_loop`. Each loop sees its own lock and concurrent
+counters remain consistent within that loop.
 """
 
 from __future__ import annotations
 
 import asyncio
 import time
+import weakref
 from collections import defaultdict, deque
 from typing import TYPE_CHECKING, Any
 
@@ -57,7 +68,36 @@ class RateLimiter:
 
         # Concurrent execution tracking
         self._concurrent: dict[str, int] = defaultdict(int)
-        self._concurrent_lock = asyncio.Lock()
+        # One Lock per running event loop — see module docstring. The
+        # entries leak at the rate of one lock per distinct loop ever used,
+        # which is a bounded constant in practice (typically 1–2 loops per
+        # process). Closed loops are pruned lazily on lookup.
+        self._loop_locks: dict[int, tuple[weakref.ref[asyncio.AbstractEventLoop], asyncio.Lock]] = {}
+
+    def _lock_for_running_loop(self) -> asyncio.Lock:
+        """Return a per-running-loop ``asyncio.Lock``.
+
+        Construction happens with a running loop so the lock binds
+        correctly. Callers are inside ``async def`` methods, so this is
+        guaranteed.
+        """
+        loop = asyncio.get_running_loop()
+        key = id(loop)
+        existing = self._loop_locks.get(key)
+        if existing is not None:
+            existing_loop_ref, existing_lock = existing
+            existing_loop = existing_loop_ref()
+            if existing_loop is loop:
+                return existing_lock
+            # id collision after a loop was GC'd — fall through and rebuild.
+        lock = asyncio.Lock()
+        self._loop_locks[key] = (weakref.ref(loop), lock)
+        # Opportunistic cleanup of stale entries (closed loops).
+        for stale_key in [
+            k for k, (ref, _l) in self._loop_locks.items() if ref() is None
+        ]:
+            self._loop_locks.pop(stale_key, None)
+        return lock
 
     def _get_key(self, tool_name: str, namespace: str = "default") -> str:
         """Get rate limit key based on configuration."""
@@ -89,7 +129,7 @@ class RateLimiter:
         key = self._get_key(tool_name, namespace)
 
         # Check concurrent limit
-        async with self._concurrent_lock:
+        async with self._lock_for_running_loop():
             if self._concurrent[key] >= self._config.max_concurrent:
                 raise RateLimitExceeded(
                     f"Concurrent execution limit ({self._config.max_concurrent}) exceeded for {key}",
@@ -105,7 +145,7 @@ class RateLimiter:
             await self._fixed_window_check(key)
 
         # Increment concurrent counter
-        async with self._concurrent_lock:
+        async with self._lock_for_running_loop():
             self._concurrent[key] += 1
 
     async def release(
@@ -126,7 +166,7 @@ class RateLimiter:
         key = self._get_key(tool_name, namespace)
 
         # Decrement concurrent counter
-        async with self._concurrent_lock:
+        async with self._lock_for_running_loop():
             self._concurrent[key] = max(0, self._concurrent[key] - 1)
 
     async def _sliding_window_check(self, key: str) -> None:
@@ -263,7 +303,7 @@ class RateLimiter:
             self._last_refill[key] = time.time()
             self._window_calls[key] = 0
             self._window_start[key] = time.time()
-            async with self._concurrent_lock:
+            async with self._lock_for_running_loop():
                 self._concurrent[key] = 0
         else:
             self._call_history.clear()
@@ -271,5 +311,5 @@ class RateLimiter:
             self._last_refill.clear()
             self._window_calls.clear()
             self._window_start.clear()
-            async with self._concurrent_lock:
+            async with self._lock_for_running_loop():
                 self._concurrent.clear()

--- a/agent_gantry/integrations/__init__.py
+++ b/agent_gantry/integrations/__init__.py
@@ -12,6 +12,7 @@ from agent_gantry.integrations.agent_framework_middleware import (
 )
 from agent_gantry.integrations.agent_framework_provider import (
     GantryContextProvider,
+    MissingRequiredToolError,
 )
 from agent_gantry.integrations.framework_adapters import fetch_framework_tools
 from agent_gantry.integrations.semantic_tools import (
@@ -25,6 +26,7 @@ __all__: list[str] = [
     "GantryContextProvider",
     "GantryObservabilityMiddleware",
     "GantryToolBridge",
+    "MissingRequiredToolError",
     "SemanticToolSelector",
     "SemanticToolsDecorator",
     "with_semantic_tools",

--- a/agent_gantry/integrations/agent_framework_bridge.py
+++ b/agent_gantry/integrations/agent_framework_bridge.py
@@ -150,13 +150,34 @@ def _build_callable_for_tool(
     required_params = set(params_schema.get("required", []))
 
     async def _execute(**kwargs: Any) -> str:
-        result = await gantry.execute(
-            ToolCall(tool_name=tool_name, arguments=kwargs)
-        )
+        # Surface any underlying exception as a structured error string. If
+        # ``gantry.execute`` itself raises (e.g. a cross-event-loop
+        # asyncio.Lock blowup, a connection error, an unexpected validation
+        # error in the executor) the exception would otherwise propagate
+        # into Agent Framework's tool runner, which replaces it with the
+        # opaque ``"Error: Function failed."`` string when
+        # ``include_detailed_errors`` is off (the default). That makes
+        # debugging extremely hard for integrators. We convert any exception
+        # into a JSON ``{"error": "..."}`` payload so the model — and the
+        # human reading the trace — sees the real root cause.
+        try:
+            result = await gantry.execute(
+                ToolCall(tool_name=tool_name, arguments=kwargs)
+            )
+        except Exception as exc:
+            return json.dumps(
+                {"error": f"{type(exc).__name__}: {exc}"}
+            )
         if result.status.value == "success":
             val = result.result
             return val if isinstance(val, str) else json.dumps(val)
-        return json.dumps({"error": result.error or "Tool execution failed"})
+        # Failed ToolResult: prefer the recorded error/error_type, otherwise
+        # fall back to a clear default — never the ambiguous original
+        # "Tool execution failed" with no context.
+        error_text = result.error or "tool execution failed (no error message)"
+        if result.error_type and result.error_type not in error_text:
+            error_text = f"{result.error_type}: {error_text}"
+        return json.dumps({"error": error_text})
 
     # Build the wrapper with proper annotations for AF
     # AF inspects __name__, __doc__, and __annotations__ to generate schemas.

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -11,6 +11,18 @@ tools and instructions via ``SessionContext.extend_tools`` /
 ``extend_instructions`` keyed by a unique ``source_id``; AF merges them
 without conflict.
 
+Two retrieval modes are supported:
+
+- ``query_strategy="per_run"`` (default, back-compatible): retrieval happens
+  once at the start of each ``agent.run(...)``. Tool selection is fixed for
+  the whole reasoning loop.
+- ``query_strategy="per_call"``: retrieval re-runs on every chat-completion
+  round. Use this for multi-step agents whose tool needs evolve as they
+  reason. The provider exposes a chat middleware via
+  :meth:`GantryContextProvider.as_chat_middleware` that the integrator
+  attaches to the same agent — AF context providers cannot themselves hook
+  per-round events, so the middleware is the canonical extension point.
+
 Why a context provider rather than (only) the existing
 :class:`~agent_gantry.integrations.agent_framework_bridge.GantryToolBridge`?
 The bridge is excellent for *static* tool sets — pre-bake once, pass to
@@ -29,19 +41,23 @@ Both APIs coexist intentionally:
     tools = bridge.wrap_tools(my_defs)
     agent = Agent(client, "...", tools=tools)
 
-    # Dynamic — per-turn semantic retrieval:
+    # Dynamic per-run — top-k driven by the initial user message:
     provider = GantryContextProvider(gantry, top_k=5)
     agent = Agent(client, "...", context_providers=[provider])
 
-    # Mixed — pinned static + dynamic top-up + AF skills, all in one agent:
+    # Dynamic per-call — top-k re-selected every chat round:
+    from agent_gantry.query import last_tool_result, fallback_chain, last_user_text
+    provider = GantryContextProvider(
+        gantry,
+        top_k=3,
+        query_strategy="per_call",
+        query_generator=fallback_chain(last_tool_result, last_user_text),
+    )
     agent = Agent(
         client,
         "...",
-        tools=bridge.wrap_tools(pinned_defs),
-        context_providers=[
-            GantryContextProvider(gantry, top_k=3, skills=True),
-            SkillsProvider(skills=[my_af_skill]),
-        ],
+        context_providers=[provider],
+        middleware=[provider.as_chat_middleware()],
     )
 
 The provider also flows transparently through every AF orchestration
@@ -52,10 +68,13 @@ primitive (``WorkflowBuilder``, ``SequentialBuilder``, ``HandoffBuilder``,
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+from agent_gantry.query import last_user_text as _default_query_generator
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -63,6 +82,10 @@ if TYPE_CHECKING:
     from agent_gantry.schema.tool import ToolDefinition
 
 logger = logging.getLogger(__name__)
+
+
+class MissingRequiredToolError(LookupError):
+    """Raised when a tool listed in ``required=[...]`` is not present in the gantry."""
 
 
 def _import_context_provider() -> type:
@@ -82,20 +105,32 @@ def _import_context_provider() -> type:
     return ContextProvider
 
 
-def _last_user_text(messages: list[Any]) -> str:
-    """Return the text of the most recent user message, or empty string.
+def _import_chat_middleware() -> Any:
+    """Lazily import :func:`agent_framework.chat_middleware`."""
+    try:
+        from agent_framework import chat_middleware
+    except ImportError as exc:  # pragma: no cover - depends on install
+        raise ImportError(
+            "GantryContextProvider.as_chat_middleware() requires the "
+            "'agent-framework' package. Install with: "
+            "pip install 'agent-gantry[agent-frameworks]'"
+        ) from exc
+    return chat_middleware
 
-    AF stores incoming user turns in ``SessionContext.input_messages``.
-    We pick the most recent ``user``-role message — that's the query
-    Gantry should retrieve tools against.
-    """
-    for msg in reversed(messages or []):
-        role = getattr(msg, "role", None)
-        if role is None or str(role) == "user":
-            text = getattr(msg, "text", None)
-            if text:
-                return text
-    return ""
+
+def _tool_name(tool: Any) -> str:
+    return (
+        getattr(tool, "name", None)
+        or getattr(tool, "__name__", None)
+        or ""
+    )
+
+
+async def _maybe_await(value: Any) -> Any:
+    """Await ``value`` if it's awaitable, else return it as-is."""
+    if inspect.isawaitable(value):
+        return await value
+    return value
 
 
 class GantryContextProvider:
@@ -109,10 +144,21 @@ class GantryContextProvider:
     Args:
         gantry: The :class:`~agent_gantry.core.gantry.AgentGantry` instance
             providing semantic retrieval and execution.
-        top_k: Maximum number of dynamically retrieved tools per ``agent.run``
-            call. Defaults to ``5``.
+        top_k: Maximum number of dynamically retrieved tools per chat-completion
+            round (or per ``agent.run`` call in ``per_run`` mode). Defaults
+            to ``5``.
         score_threshold: Minimum semantic relevance score for retrieved
             tools. Defaults to ``0.3``.
+        query_strategy: ``"per_run"`` (default) refreshes the tool selection
+            once at the start of ``agent.run()``. ``"per_call"`` re-runs
+            retrieval on every chat-completion round; pair this mode with
+            :meth:`as_chat_middleware` to install the per-round refresher.
+        query_generator: Callable used to derive the retrieval query string
+            from the conversation messages. Defaults to
+            :func:`agent_gantry.query.last_user_text`. Sync or async are both
+            accepted. See :mod:`agent_gantry.query` for built-in alternatives
+            (``last_tool_result``, ``last_assistant_text``, ``concatenate_recent``,
+            ``fallback_chain``).
         skills: When ``True``, every invocation also injects the union of
             tools bound to all registered Gantry skills (from the supplied
             ``skill_registry`` if any, else the registry attached to the
@@ -126,7 +172,15 @@ class GantryContextProvider:
             warning and skips skill tools.
         always_include: Optional list of Gantry tool names to inject on
             every invocation (in addition to the dynamic top-k). Useful
-            for pinning utility tools the LLM should always see.
+            for pinning utility tools the LLM should always see. Missing
+            names log a WARNING and are skipped.
+        required: Optional list of Gantry tool names that **must** be
+            available in the registry. The provider validates these at
+            construction time and raises :class:`MissingRequiredToolError`
+            if any are missing. They are also injected on every invocation
+            (treated as ``always_include`` once present). Use this when a
+            workflow is broken if the tool isn't surfaced (typo / dropped
+            registration).
         as_function_tool: Forwarded to the underlying
             :class:`GantryToolBridge`. ``None`` (default) auto-detects;
             ``True`` forces ``agent_framework.FunctionTool`` wrapping;
@@ -146,21 +200,26 @@ class GantryContextProvider:
 
             from agent_framework import Agent, SkillsProvider
             from agent_framework.openai import OpenAIChatClient
-            from agent_gantry import AgentGantry
-            from agent_gantry.integrations import GantryContextProvider
+            from agent_gantry import AgentGantry, GantryContextProvider
+            from agent_gantry.query import last_tool_result
 
             gantry = AgentGantry()
             # ... register tools, sync ...
 
+            provider = GantryContextProvider(
+                gantry,
+                top_k=3,
+                query_strategy="per_call",
+                query_generator=last_tool_result,
+                required=["validate_boundaries"],
+            )
+
             agent = Agent(
                 OpenAIChatClient(),
                 "You are a helpful assistant.",
-                context_providers=[
-                    GantryContextProvider(gantry, top_k=5, skills=True),
-                    SkillsProvider(skill_paths="./skills"),
-                ],
+                context_providers=[provider, SkillsProvider(skill_paths="./skills")],
+                middleware=[provider.as_chat_middleware()],
             )
-            await agent.run("Book a flight to Tokyo")  # flight tools auto-injected
     """
 
     def __new__(
@@ -169,14 +228,22 @@ class GantryContextProvider:
         *,
         top_k: int = 5,
         score_threshold: float = 0.3,
+        query_strategy: str = "per_run",
+        query_generator: Callable[..., Any] | None = None,
         skills: bool = False,
         skill_registry: SkillRegistry | None = None,
         always_include: list[str] | None = None,
+        required: list[str] | None = None,
         as_function_tool: bool | None = None,
         source_id: str = "agent_gantry",
         bridge: GantryToolBridge | None = None,
         **query_kwargs: Any,
     ) -> Any:
+        if query_strategy not in ("per_run", "per_call"):
+            raise ValueError(
+                f"query_strategy must be 'per_run' or 'per_call', got {query_strategy!r}"
+            )
+
         context_provider_cls = _import_context_provider()
 
         bridge = bridge or GantryToolBridge(
@@ -185,6 +252,37 @@ class GantryContextProvider:
             as_function_tool=as_function_tool,
         )
         always_include = list(always_include or [])
+        required = list(required or [])
+        query_generator = query_generator or _default_query_generator
+
+        if required:
+            registry = getattr(gantry, "_registry", None)
+            missing = []
+            for name in required:
+                tool_def = None
+                if registry is not None:
+                    lookup = getattr(registry, "get_tool_by_name", None)
+                    if callable(lookup):
+                        tool_def = lookup(name)
+                    if tool_def is None:
+                        lookup = getattr(registry, "get_tool", None)
+                        if callable(lookup):
+                            tool_def = lookup(name)
+                if tool_def is None:
+                    missing.append(name)
+            if missing:
+                raise MissingRequiredToolError(
+                    f"GantryContextProvider: required tool(s) not found in gantry: "
+                    f"{missing}. Did you forget to register them, or is there a typo?"
+                )
+
+        # Combine for "always inject" set; required is a strict superset.
+        always_include_effective: list[str] = []
+        seen_ai: set[str] = set()
+        for n in (*required, *always_include):
+            if n not in seen_ai:
+                seen_ai.add(n)
+                always_include_effective.append(n)
 
         class _GantryContextProviderImpl(context_provider_cls):  # type: ignore[misc,valid-type]
             """Concrete ContextProvider subclass; see :class:`GantryContextProvider`."""
@@ -195,11 +293,46 @@ class GantryContextProvider:
                 self._bridge = bridge
                 self._top_k = top_k
                 self._score_threshold = score_threshold
+                self._query_strategy = query_strategy
+                self._query_generator = query_generator
                 self._skills_enabled = skills
                 self._skill_registry = skill_registry
-                self._always_include = always_include
+                self._always_include = always_include_effective
+                self._declared_always_include = list(always_include)
+                self._required = list(required)
                 self._query_kwargs = dict(query_kwargs)
+                self._source_id = source_id
 
+            # ----- Public, read-only configuration accessors --------------
+            @property
+            def top_k(self) -> int:
+                return self._top_k
+
+            @property
+            def score_threshold(self) -> float:
+                return self._score_threshold
+
+            @property
+            def query_strategy(self) -> str:
+                return self._query_strategy
+
+            @property
+            def always_include(self) -> tuple[str, ...]:
+                return tuple(self._declared_always_include)
+
+            @property
+            def required(self) -> tuple[str, ...]:
+                return tuple(self._required)
+
+            @property
+            def gantry(self) -> AgentGantry:
+                return self._gantry
+
+            @property
+            def bridge(self) -> GantryToolBridge:
+                return self._bridge
+
+            # ----- AF lifecycle ------------------------------------------
             async def before_run(
                 self,
                 *,
@@ -208,52 +341,166 @@ class GantryContextProvider:
                 context: Any,
                 state: dict[str, Any],
             ) -> None:
-                query = _last_user_text(context.input_messages)
+                # In per_call mode, the chat_middleware does the dynamic
+                # retrieval per LLM round; we still inject always_include /
+                # skill tools at run-start so they are present even if the
+                # middleware is not attached.
+                tools, seen = await self._collect_tools(
+                    context.input_messages,
+                    include_dynamic=(self._query_strategy == "per_run"),
+                )
+                if tools:
+                    context.extend_tools(self._source_id, tools)
+                    logger.debug(
+                        "GantryContextProvider: injected %d tools at run start "
+                        "(strategy=%s)",
+                        len(tools),
+                        self._query_strategy,
+                    )
+
+            # ----- Per-call middleware factory ---------------------------
+            def as_chat_middleware(self) -> Any:
+                """Return an AF chat_middleware that refreshes tools each round.
+
+                Use with ``Agent(middleware=[provider.as_chat_middleware()])``
+                in conjunction with ``query_strategy="per_call"``. The
+                returned middleware reads ``context.messages`` (or
+                ``context.options`` as appropriate), runs the configured
+                query generator, retrieves a fresh top-k from the gantry,
+                and updates the tool list before the LLM call. If retrieval
+                fails it logs the exception and leaves the existing tools
+                unchanged — retrieval must never break the agent run.
+                """
+                chat_middleware_decorator = _import_chat_middleware()
+                provider = self
+
+                @chat_middleware_decorator
+                async def _per_call_retrieval(context: Any, call_next: Any) -> None:
+                    try:
+                        await provider._refresh_tools_on_chat_context(context)
+                    except Exception:
+                        logger.exception(
+                            "GantryContextProvider: per-call retrieval failed; "
+                            "continuing with existing tools."
+                        )
+                    await call_next()
+
+                return _per_call_retrieval
+
+            async def _refresh_tools_on_chat_context(self, context: Any) -> None:
+                """Mutate ``context.options['tools']`` for the current round."""
+                options = getattr(context, "options", None)
+                existing = []
+                if isinstance(options, dict):
+                    existing = list(options.get("tools") or [])
+
+                # Preserve tools contributed by other providers / static tools.
+                # We only swap out the slice we previously injected, recognised
+                # by name match against everything we'd produce now.
+                messages = (
+                    getattr(context, "messages", None)
+                    or getattr(context, "input_messages", None)
+                    or []
+                )
+                fresh, seen = await self._collect_tools(messages, include_dynamic=True)
+                fresh_names = {_tool_name(t) for t in fresh if _tool_name(t)}
+
+                # Preserve everything that wasn't ours; replace ours with fresh.
+                preserved = []
+                for t in existing:
+                    name = _tool_name(t)
+                    if name and name in fresh_names:
+                        continue
+                    preserved.append(t)
+
+                combined: list[Any] = []
+                seen_combined: set[str] = set()
+                for t in preserved + fresh:
+                    name = _tool_name(t)
+                    if name and name in seen_combined:
+                        continue
+                    if name:
+                        seen_combined.add(name)
+                    combined.append(t)
+
+                if isinstance(options, dict):
+                    new_options = dict(options)
+                    new_options["tools"] = combined
+                    try:
+                        context.options = new_options
+                    except AttributeError:
+                        # Some AF versions expose options as a read-only attr;
+                        # mutate in place as a fallback.
+                        options.clear()
+                        options.update(new_options)
+
+                logger.debug(
+                    "GantryContextProvider: refreshed tools per-call "
+                    "(%d preserved + %d gantry = %d total)",
+                    len(preserved),
+                    len(fresh),
+                    len(combined),
+                )
+
+            # ----- Tool assembly -----------------------------------------
+            async def _collect_tools(
+                self,
+                messages: Any,
+                *,
+                include_dynamic: bool,
+            ) -> tuple[list[Any], set[str]]:
                 tools: list[Any] = []
                 seen: set[str] = set()
 
-                # 1) Dynamic semantic retrieval against the latest user turn.
-                if query:
-                    try:
-                        retrieved = await self._bridge.get_tools(
-                            query,
-                            limit=self._top_k,
-                            score_threshold=self._score_threshold,
-                            **self._query_kwargs,
-                        )
-                    except Exception:
-                        # Tool retrieval should never break the agent run.
-                        logger.exception(
-                            "GantryContextProvider: semantic retrieval failed; "
-                            "continuing without dynamic tools."
-                        )
-                        retrieved = []
-                    for t in retrieved:
-                        name = getattr(t, "name", None) or getattr(t, "__name__", None)
-                        if name and name in seen:
-                            continue
-                        if name:
-                            seen.add(name)
-                        tools.append(t)
+                if include_dynamic:
+                    query = await self._build_query(messages)
+                    if query:
+                        try:
+                            retrieved = await self._bridge.get_tools(
+                                query,
+                                limit=self._top_k,
+                                score_threshold=self._score_threshold,
+                                **self._query_kwargs,
+                            )
+                        except Exception:
+                            logger.exception(
+                                "GantryContextProvider: semantic retrieval failed; "
+                                "continuing without dynamic tools."
+                            )
+                            retrieved = []
+                        for t in retrieved:
+                            name = _tool_name(t)
+                            if name and name in seen:
+                                continue
+                            if name:
+                                seen.add(name)
+                            tools.append(t)
 
-                # 2) Skills: always-on tools bound to registered Gantry skills.
+                # Skills: always-on tools bound to registered Gantry skills.
                 if self._skills_enabled:
                     skill_tool_names = self._collect_skill_tool_names()
-                    extra = self._wrap_named(skill_tool_names, seen)
+                    extra = self._wrap_named(skill_tool_names, seen, source="skill")
                     tools.extend(extra)
 
-                # 3) Explicit always_include pins.
+                # Explicit always_include / required pins.
                 if self._always_include:
-                    extra = self._wrap_named(self._always_include, seen)
+                    extra = self._wrap_named(
+                        self._always_include, seen, source="always_include"
+                    )
                     tools.extend(extra)
 
-                if tools:
-                    context.extend_tools(self.source_id, tools)
-                    logger.debug(
-                        "GantryContextProvider: injected %d tools (query=%r)",
-                        len(tools),
-                        query[:60],
+                return tools, seen
+
+            async def _build_query(self, messages: Any) -> str:
+                try:
+                    result = self._query_generator(messages)
+                    return await _maybe_await(result) or ""
+                except Exception:
+                    logger.exception(
+                        "GantryContextProvider: query_generator raised; falling "
+                        "back to last_user_text."
                     )
+                    return _default_query_generator(messages)
 
             def _resolve_skill_registry(self) -> SkillRegistry | None:
                 if self._skill_registry is not None:
@@ -282,22 +529,26 @@ class GantryContextProvider:
                 return names
 
             def _wrap_named(
-                self, names: list[str], seen: set[str]
+                self, names: list[str], seen: set[str], *, source: str
             ) -> list[Any]:
                 wrapped: list[Any] = []
+                missing: list[str] = []
                 for name in names:
                     if name in seen:
                         continue
                     tool_def = self._lookup_tool_def(name)
                     if tool_def is None:
-                        logger.warning(
-                            "GantryContextProvider: tool %r not found in "
-                            "registry; skipping.",
-                            name,
-                        )
+                        missing.append(name)
                         continue
                     wrapped.append(self._bridge.wrap_single(tool_def))
                     seen.add(name)
+                if missing:
+                    logger.warning(
+                        "GantryContextProvider: %s tool(s) not found in registry "
+                        "and will be skipped: %s",
+                        source,
+                        missing,
+                    )
                 return wrapped
 
             def _lookup_tool_def(self, name: str) -> ToolDefinition | None:
@@ -317,4 +568,4 @@ class GantryContextProvider:
         return _GantryContextProviderImpl()
 
 
-__all__ = ["GantryContextProvider"]
+__all__ = ["GantryContextProvider", "MissingRequiredToolError"]

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -68,10 +68,10 @@ primitive (``WorkflowBuilder``, ``SequentialBuilder``, ``HandoffBuilder``,
 
 from __future__ import annotations
 
-import asyncio
 import inspect
 import logging
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
 from agent_gantry.query import last_user_text as _default_query_generator

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -256,20 +256,11 @@ class GantryContextProvider:
         query_generator = query_generator or _default_query_generator
 
         if required:
-            registry = getattr(gantry, "_registry", None)
-            missing = []
-            for name in required:
-                tool_def = None
-                if registry is not None:
-                    lookup = getattr(registry, "get_tool_by_name", None)
-                    if callable(lookup):
-                        tool_def = lookup(name)
-                    if tool_def is None:
-                        lookup = getattr(registry, "get_tool", None)
-                        if callable(lookup):
-                            tool_def = lookup(name)
-                if tool_def is None:
-                    missing.append(name)
+            known = gantry.list_tools_sync()
+            available = {t.name for t in known} | {
+                f"{t.namespace}.{t.name}" for t in known
+            }
+            missing = [name for name in required if name not in available]
             if missing:
                 raise MissingRequiredToolError(
                     f"GantryContextProvider: required tool(s) not found in gantry: "
@@ -345,7 +336,7 @@ class GantryContextProvider:
                 # retrieval per LLM round; we still inject always_include /
                 # skill tools at run-start so they are present even if the
                 # middleware is not attached.
-                tools, seen = await self._collect_tools(
+                tools, _ = await self._collect_tools(
                     context.input_messages,
                     include_dynamic=(self._query_strategy == "per_run"),
                 )
@@ -388,28 +379,39 @@ class GantryContextProvider:
                 return _per_call_retrieval
 
             async def _refresh_tools_on_chat_context(self, context: Any) -> None:
-                """Mutate ``context.options['tools']`` for the current round."""
+                """Mutate ``context.options['tools']`` for the current round.
+
+                Strategy: drop **all** tools whose names are known to the
+                gantry registry (these are tools we — or another provider
+                bridging the same gantry — could have injected). Anything
+                else in ``existing`` is foreign (skills from another
+                provider, AF-native tools added at construction time) and
+                is preserved. Then append the freshly retrieved top-k plus
+                always_include / skill pins. This guarantees the per-round
+                top-k stays bounded and stale dynamic selections from
+                earlier rounds do not accumulate.
+                """
                 options = getattr(context, "options", None)
                 existing = []
                 if isinstance(options, dict):
                     existing = list(options.get("tools") or [])
 
-                # Preserve tools contributed by other providers / static tools.
-                # We only swap out the slice we previously injected, recognised
-                # by name match against everything we'd produce now.
                 messages = (
                     getattr(context, "messages", None)
                     or getattr(context, "input_messages", None)
                     or []
                 )
-                fresh, seen = await self._collect_tools(messages, include_dynamic=True)
-                fresh_names = {_tool_name(t) for t in fresh if _tool_name(t)}
+                fresh, _ = await self._collect_tools(
+                    messages, include_dynamic=True
+                )
+                gantry_names = self._all_known_tool_names()
 
-                # Preserve everything that wasn't ours; replace ours with fresh.
                 preserved = []
+                dropped = 0
                 for t in existing:
                     name = _tool_name(t)
-                    if name and name in fresh_names:
+                    if name and name in gantry_names:
+                        dropped += 1
                         continue
                     preserved.append(t)
 
@@ -436,11 +438,31 @@ class GantryContextProvider:
 
                 logger.debug(
                     "GantryContextProvider: refreshed tools per-call "
-                    "(%d preserved + %d gantry = %d total)",
+                    "(%d preserved + %d gantry, %d stale dropped, %d total)",
                     len(preserved),
                     len(fresh),
+                    dropped,
                     len(combined),
                 )
+
+            def _all_known_tool_names(self) -> set[str]:
+                """Return every tool name registered in the gantry.
+
+                Used to identify which entries in ``context.options['tools']``
+                were produced by this gantry (or any other provider sharing
+                it) so they can be dropped before re-injecting the fresh
+                per-round selection.
+                """
+                registry = getattr(self._gantry, "_registry", None)
+                if registry is None:
+                    return set()
+                lister = getattr(registry, "list_tools", None)
+                if not callable(lister):
+                    return set()
+                try:
+                    return {t.name for t in lister() if getattr(t, "name", None)}
+                except Exception:
+                    return set()
 
             # ----- Tool assembly -----------------------------------------
             async def _collect_tools(

--- a/agent_gantry/query/__init__.py
+++ b/agent_gantry/query/__init__.py
@@ -1,0 +1,61 @@
+"""
+Query generation strategies for semantic tool retrieval.
+
+When Agent-Gantry retrieves tools per chat round (via the
+``query_strategy="per_call"`` mode of
+:class:`agent_gantry.GantryContextProvider`), it needs a way to derive a
+retrieval query from the *current* conversation state — not just the original
+user message. This module ships the common deterministic strategies; an
+opt-in :mod:`agent_gantry.query.llm` submodule adds LLM-based rewriters.
+
+A "query generator" is any sync or async callable that takes the conversation
+messages list and returns a string (empty string falls back to the conversation
+tail handled by the caller). The signature is:
+
+.. code-block:: python
+
+    def my_generator(messages: list[Any]) -> str: ...
+    async def my_generator(messages: list[Any]) -> str: ...
+
+Built-in strategies:
+
+- :func:`last_user_text` — most recent user-role message (default).
+- :func:`last_assistant_text` — most recent assistant-role message
+  (the model's latest planning).
+- :func:`last_tool_result` — most recent tool/function-role message
+  (best for fixed multi-step workflows where the next decision is driven by
+  what the previous tool produced).
+- :func:`concatenate_recent` — last N turns concatenated.
+- :func:`fallback_chain` — try each generator in order until one returns
+  non-empty text. Useful for "tool-result then assistant then user".
+
+Example:
+
+.. code-block:: python
+
+    from agent_gantry.query import last_tool_result, fallback_chain, last_user_text
+
+    provider = GantryContextProvider(
+        gantry,
+        query_strategy="per_call",
+        query_generator=fallback_chain(last_tool_result, last_user_text),
+    )
+"""
+
+from __future__ import annotations
+
+from agent_gantry.query.strategies import (
+    concatenate_recent,
+    fallback_chain,
+    last_assistant_text,
+    last_tool_result,
+    last_user_text,
+)
+
+__all__ = [
+    "concatenate_recent",
+    "fallback_chain",
+    "last_assistant_text",
+    "last_tool_result",
+    "last_user_text",
+]

--- a/agent_gantry/query/strategies.py
+++ b/agent_gantry/query/strategies.py
@@ -1,0 +1,171 @@
+"""
+Built-in deterministic query-generation strategies.
+
+These work over any iterable of message-like objects. Each message is
+expected to expose at minimum ``role`` and ``text`` attributes; alternative
+content fields (``content``) are tried as a fallback. This matches both the
+Microsoft Agent Framework message type and the lighter-weight dict-shaped
+messages used by other frameworks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+
+def _msg_text(msg: Any) -> str:
+    """Pull plain text out of a message-like object.
+
+    Tries ``.text`` first (AF native), falls back to ``.content`` (OpenAI
+    dialect), then ``str()``. Returns the empty string if nothing is found.
+    """
+    text = getattr(msg, "text", None)
+    if isinstance(text, str) and text.strip():
+        return text
+    content = getattr(msg, "content", None)
+    if isinstance(content, str) and content.strip():
+        return content
+    if isinstance(msg, dict):
+        for key in ("text", "content"):
+            value = msg.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    return ""
+
+
+def _msg_role(msg: Any) -> str:
+    """Get the role of a message as a lowercase string."""
+    role = getattr(msg, "role", None)
+    if role is None and isinstance(msg, dict):
+        role = msg.get("role")
+    return str(role).lower() if role is not None else ""
+
+
+def _msg_name(msg: Any) -> str:
+    """Best-effort tool/author name for a tool-role message."""
+    for attr in ("author_name", "name", "tool_name"):
+        value = getattr(msg, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    if isinstance(msg, dict):
+        for key in ("author_name", "name", "tool_name"):
+            value = msg.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return ""
+
+
+def last_user_text(messages: Iterable[Any] | None) -> str:
+    """Return the most recent user-role message text (or empty string)."""
+    if not messages:
+        return ""
+    for msg in reversed(list(messages)):
+        if _msg_role(msg) in ("user", ""):
+            text = _msg_text(msg)
+            if text.strip():
+                return text.strip()
+    return ""
+
+
+def last_assistant_text(messages: Iterable[Any] | None) -> str:
+    """Return the most recent assistant-role message text (or empty string).
+
+    Useful when the next retrieval should be driven by the model's most
+    recent reasoning rather than the original user input.
+    """
+    if not messages:
+        return ""
+    for msg in reversed(list(messages)):
+        if _msg_role(msg) == "assistant":
+            text = _msg_text(msg)
+            if text.strip():
+                return text.strip()
+    return ""
+
+
+def last_tool_result(
+    messages: Iterable[Any] | None,
+    *,
+    max_chars: int = 500,
+) -> str:
+    """Return a description of the most recent tool/function result.
+
+    For fixed multi-step workflows this often produces the best retrieval
+    signal: after one tool returns, the next tool to surface should match
+    the *content* of that result, not the original user prompt.
+
+    Args:
+        messages: Conversation history (most recent last).
+        max_chars: Cap on characters of the tool result included in the
+            generated query, to keep embeddings focused. Defaults to 500.
+
+    Returns:
+        A string of the form ``"result of <tool>: <text>"`` (or just
+        ``"tool result: <text>"`` if the tool name is not available), or
+        the empty string if no tool message was found.
+    """
+    if not messages:
+        return ""
+    for msg in reversed(list(messages)):
+        if _msg_role(msg) in ("tool", "function"):
+            text = _msg_text(msg)
+            if not text.strip():
+                continue
+            snippet = text.strip()[:max_chars]
+            tool_name = _msg_name(msg)
+            if tool_name:
+                return f"result of {tool_name}: {snippet}"
+            return f"tool result: {snippet}"
+    return ""
+
+
+def concatenate_recent(
+    messages: Iterable[Any] | None,
+    *,
+    n: int = 3,
+    separator: str = "\n",
+) -> str:
+    """Concatenate the text of the last ``n`` messages.
+
+    Args:
+        messages: Conversation history.
+        n: Number of trailing messages to include. Defaults to 3.
+        separator: String used to join the messages. Defaults to newline.
+
+    Returns:
+        The joined non-empty texts, or the empty string if none were found.
+    """
+    if not messages:
+        return ""
+    msgs = list(messages)[-n:]
+    parts = [t for t in (_msg_text(m) for m in msgs) if t.strip()]
+    return separator.join(p.strip() for p in parts)
+
+
+def fallback_chain(
+    *generators: Callable[[Iterable[Any] | None], str],
+) -> Callable[[Iterable[Any] | None], str]:
+    """Compose multiple generators, returning the first non-empty result.
+
+    .. code-block:: python
+
+        from agent_gantry.query import (
+            fallback_chain, last_tool_result, last_assistant_text, last_user_text,
+        )
+
+        gen = fallback_chain(last_tool_result, last_assistant_text, last_user_text)
+        query = gen(messages)
+
+    Returns:
+        A callable with the same shape as the inputs.
+    """
+
+    def _composed(messages: Iterable[Any] | None) -> str:
+        for gen in generators:
+            text = gen(messages)
+            if text and text.strip():
+                return text
+        return ""
+
+    return _composed

--- a/agent_gantry/query/strategies.py
+++ b/agent_gantry/query/strategies.py
@@ -17,8 +17,9 @@ from typing import Any
 def _msg_text(msg: Any) -> str:
     """Pull plain text out of a message-like object.
 
-    Tries ``.text`` first (AF native), falls back to ``.content`` (OpenAI
-    dialect), then ``str()``. Returns the empty string if nothing is found.
+    Tries ``.text`` first (AF native), then ``.content`` (OpenAI dialect),
+    and for dict-shaped messages checks ``"text"`` and ``"content"``.
+    Returns the empty string if no non-empty string content is found.
     """
     text = getattr(msg, "text", None)
     if isinstance(text, str) and text.strip():

--- a/tests/test_durable_worker_integration.py
+++ b/tests/test_durable_worker_integration.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from typing import Any
+from typing import Any, Callable, Coroutine
 
 import pytest
 
@@ -40,6 +40,40 @@ af = pytest.importorskip("agent_framework")
 from agent_gantry import AgentGantry
 from agent_gantry.adapters.embedders.simple import SimpleEmbedder
 from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+
+def _run_on_worker_loop(coro_factory: Callable[[], Coroutine[Any, Any, Any]]) -> Any:
+    """Run ``coro_factory()`` on a fresh event loop inside a worker thread.
+
+    All loop creation and teardown happens off the main thread for two
+    reasons. (1) pytest-asyncio's auto-managed loop policy on the main
+    thread can collide with our own ``asyncio.run`` calls, especially on
+    macOS + Python 3.10 where the kqueue selector's lifecycle is fragile.
+    (2) ``DurableAIAgentWorker`` actually executes its
+    ``asyncio.run(self._agent_entity.run(request))`` calls on a thread-
+    pool worker, not on the main thread — so this is also more faithful
+    to the integration we're testing.
+    """
+    box: dict[str, Any] = {}
+
+    def _runner() -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            try:
+                box["result"] = loop.run_until_complete(coro_factory())
+            except BaseException as exc:  # noqa: BLE001 - propagate to test
+                box["error"] = exc
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=_runner, daemon=True)
+    t.start()
+    t.join(timeout=60.0)
+    assert not t.is_alive(), "worker thread hung"
+    if "error" in box:
+        raise box["error"]
+    return box["result"]
 
 
 class _FakeChatClient(af.FunctionInvocationLayer, af.BaseChatClient):  # type: ignore[misc]
@@ -115,7 +149,7 @@ def module_gantry() -> AgentGantry:
         await asyncio.sleep(0.01)
         return x + 1
 
-    asyncio.run(g.sync())
+    _run_on_worker_loop(g.sync)
     return g
 
 
@@ -125,7 +159,10 @@ def function_tools(module_gantry: AgentGantry) -> list[Any]:
     would (e.g. fetched at startup or via a context provider's
     ``before_run`` hook)."""
     bridge = GantryToolBridge(module_gantry, as_function_tool=True)
-    return list(asyncio.run(bridge.get_tools("add", limit=2, score_threshold=0.0)))
+    tools = _run_on_worker_loop(
+        lambda: bridge.get_tools("add", limit=2, score_threshold=0.0)
+    )
+    return list(tools)
 
 
 def _extract_tool_results(resp: Any) -> list[Any]:
@@ -143,11 +180,9 @@ def _run_agent_request(
     function_tools: list[Any],
 ) -> list[Any]:
     """One DurableAIAgentWorker-style request: build the agent fresh,
-    drive it via the fake client, return the tool results.
-
-    Wrapped in an ``async def`` so the *caller* picks the loop policy
-    (``asyncio.run`` for the in-process case, fresh loop in a thread for
-    the worker-pool case).
+    drive it via the fake client, return the tool results. Each call
+    constructs a fresh event loop on a worker thread — exactly how
+    ``DurableAIAgentWorker._handle_request`` runs each request.
     """
     client = _FakeChatClient(tool_name, arguments_per_call)
     agent = af.RawAgent(
@@ -158,7 +193,7 @@ def _run_agent_request(
         resp = await agent.run("please call the tool")
         return _extract_tool_results(resp)
 
-    return asyncio.run(_go())
+    return _run_on_worker_loop(_go)
 
 
 # ---------------------------------------------------------------------------
@@ -204,53 +239,34 @@ def test_async_tool_with_parallel_calls_across_loops(
 
 def test_request_runs_in_worker_thread(function_tools: list[Any]) -> None:
     """``DurableAIAgentWorker`` runs requests on a thread-pool worker.
-    Mirror that: spin up a worker thread, give it a fresh event loop,
-    run the request via ``asyncio.run``. The module-level gantry — built
-    on the main thread with no running loop — must work cleanly.
+    Confirm the smoke test: ``_run_agent_request`` (which already uses a
+    fresh worker-thread loop) returns the expected results.
     """
-    box: dict[str, Any] = {}
-
-    def _runner() -> None:
-        try:
-            box["results"] = _run_agent_request(
-                "slow_add",
-                [{"x": 7}, {"x": 8}, {"x": 9}],
-                function_tools=function_tools,
-            )
-        except BaseException as exc:  # noqa: BLE001
-            box["error"] = exc
-
-    t = threading.Thread(target=_runner, daemon=True)
-    t.start()
-    t.join(timeout=30.0)
-    assert not t.is_alive(), "worker thread hung"
-    assert "error" not in box, f"worker raised: {box.get('error')!r}"
-    assert box["results"] == ["8", "9", "10"], box["results"]
+    results = _run_agent_request(
+        "slow_add",
+        [{"x": 7}, {"x": 8}, {"x": 9}],
+        function_tools=function_tools,
+    )
+    assert results == ["8", "9", "10"], results
 
 
-def test_worker_thread_followed_by_main_thread(function_tools: list[Any]) -> None:
-    """Cross-thread, cross-loop sequencing: run a request from a worker
-    thread first (binding any cross-loop primitives to that loop), then
-    run another from the main thread. Both must succeed.
+def test_sequential_requests_get_distinct_loops(
+    function_tools: list[Any],
+) -> None:
+    """Cross-loop sequencing: each ``_run_agent_request`` constructs and
+    closes its own worker-thread loop. Run two back-to-back; both must
+    succeed. With the old per-Lock-eager code this was the canonical
+    failure shape.
     """
-    # Worker thread first.
-    box: dict[str, Any] = {}
+    first = _run_agent_request(
+        "slow_add", [{"x": 1}, {"x": 2}], function_tools=function_tools
+    )
+    assert first == ["2", "3"]
 
-    def _runner() -> None:
-        box["worker"] = _run_agent_request(
-            "slow_add", [{"x": 1}, {"x": 2}], function_tools=function_tools
-        )
-
-    t = threading.Thread(target=_runner, daemon=True)
-    t.start()
-    t.join(timeout=30.0)
-    assert box.get("worker") == ["2", "3"]
-
-    # Main thread immediately after — separate ``asyncio.run`` = separate loop.
-    main_results = _run_agent_request(
+    second = _run_agent_request(
         "slow_add", [{"x": 10}, {"x": 11}], function_tools=function_tools
     )
-    assert main_results == ["11", "12"]
+    assert second == ["11", "12"]
 
 
 def test_no_function_failed_envelope_in_results(function_tools: list[Any]) -> None:

--- a/tests/test_durable_worker_integration.py
+++ b/tests/test_durable_worker_integration.py
@@ -1,0 +1,271 @@
+"""
+End-to-end integration test: real ``agent_framework`` agent driving real
+gantry-wrapped tools, executed via ``asyncio.run`` per request to mirror
+the loop topology of ``agent_framework_durabletask.DurableAIAgentWorker``.
+
+``DurableAIAgentWorker._handle_request`` calls
+``asyncio.run(self._agent_entity.run(request))`` for every inbound request,
+which constructs and tears down a fresh event loop each time. A
+module-level :class:`AgentGantry` therefore sees N distinct loops over its
+lifetime — the exact topology that previously surfaced as
+``"Error: Function failed."`` for integrators.
+
+This test does the full thing without mocks of the gantry surface:
+
+1. Build an ``AgentGantry`` at module scope (no running loop).
+2. Build a real :class:`agent_framework.RawAgent` driven by a small
+   :class:`agent_framework.BaseChatClient` subclass that emits one or
+   more ``function_call`` items on the first turn and final text on the
+   second turn — exercising AF's actual tool-invocation pipeline,
+   ``GantryToolBridge``'s wrappers, the gantry executor, the rate
+   limiter, and the registered handlers.
+3. Drive the agent via ``asyncio.run`` repeatedly (and from a worker
+   thread), asserting the tool results come back with the expected
+   values rather than the AF catch-all error string.
+
+``agent_framework`` is an optional dependency; the entire module is
+``importorskip``-gated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+import pytest
+
+af = pytest.importorskip("agent_framework")
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+
+class _FakeChatClient(af.FunctionInvocationLayer, af.BaseChatClient):  # type: ignore[misc]
+    """Minimal ``BaseChatClient`` that drives a deterministic tool-call loop.
+
+    First turn: emit ``num_calls`` ``function_call`` content items targeting
+    ``tool_name`` with the supplied per-call arguments. Second turn: emit a
+    final ``"done"`` text message. AF's ``FunctionInvocationLayer`` handles
+    the round-trip in between, invoking each tool wrapper and feeding the
+    ``function_result`` content back.
+    """
+
+    def __init__(self, tool_name: str, arguments_per_call: list[dict[str, Any]]) -> None:
+        super().__init__()
+        self._tool_name = tool_name
+        self._arguments_per_call = arguments_per_call
+        self._n = 0
+
+    def _inner_get_response(  # type: ignore[override]
+        self,
+        *,
+        messages: Any,
+        stream: bool,
+        options: Any,
+        **kwargs: Any,
+    ) -> Any:
+        async def _go() -> af.ChatResponse:
+            self._n += 1
+            if self._n == 1:
+                contents = [
+                    af.Content.from_function_call(
+                        call_id=f"c{i}", name=self._tool_name, arguments=args
+                    )
+                    for i, args in enumerate(self._arguments_per_call)
+                ]
+                return af.ChatResponse(
+                    messages=[af.Message("assistant", contents)],
+                    finish_reason="tool_calls",
+                )
+            return af.ChatResponse(
+                messages=[af.Message("assistant", [af.Content("text", text="done")])],
+                finish_reason="stop",
+            )
+
+        return _go()
+
+
+# ---------------------------------------------------------------------------
+# Module-scope gantry — mirrors the integrator's pattern of building the
+# gantry at import time so the durable worker can register the instance.
+# Tools are registered up front; ``sync()`` is called from a throwaway loop
+# (also matches the documented "build at startup" pattern).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def module_gantry() -> AgentGantry:
+    g = AgentGantry(embedder=SimpleEmbedder())
+
+    @g.register
+    def add_one(x: int) -> int:
+        """Returns ``x + 1``; sync handler exercising the to_thread path."""
+        return x + 1
+
+    @g.register
+    async def slow_add(x: int) -> int:
+        """Awaits briefly then returns ``x + 1``; async handler.
+
+        The ``await`` makes parallel invocations actually overlap on the
+        executor side, which is the realistic shape for tools that talk
+        to a database or remote API.
+        """
+        await asyncio.sleep(0.01)
+        return x + 1
+
+    asyncio.run(g.sync())
+    return g
+
+
+@pytest.fixture(scope="module")
+def function_tools(module_gantry: AgentGantry) -> list[Any]:
+    """Pre-resolve the wrapped tools once, the way an integrator typically
+    would (e.g. fetched at startup or via a context provider's
+    ``before_run`` hook)."""
+    bridge = GantryToolBridge(module_gantry, as_function_tool=True)
+    return list(asyncio.run(bridge.get_tools("add", limit=2, score_threshold=0.0)))
+
+
+def _extract_tool_results(resp: Any) -> list[Any]:
+    return [
+        c.result
+        for m in resp.messages
+        for c in m.contents
+        if getattr(c, "type", None) == "function_result"
+    ]
+
+
+def _run_agent_request(
+    tool_name: str,
+    arguments_per_call: list[dict[str, Any]],
+    function_tools: list[Any],
+) -> list[Any]:
+    """One DurableAIAgentWorker-style request: build the agent fresh,
+    drive it via the fake client, return the tool results.
+
+    Wrapped in an ``async def`` so the *caller* picks the loop policy
+    (``asyncio.run`` for the in-process case, fresh loop in a thread for
+    the worker-pool case).
+    """
+    client = _FakeChatClient(tool_name, arguments_per_call)
+    agent = af.RawAgent(
+        client=client, instructions="exec tools", tools=function_tools
+    )
+
+    async def _go() -> list[Any]:
+        resp = await agent.run("please call the tool")
+        return _extract_tool_results(resp)
+
+    return asyncio.run(_go())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_sync_tool_executes_across_repeated_asyncio_run(
+    function_tools: list[Any],
+) -> None:
+    """Sequential ``asyncio.run`` requests, sync handler, single tool call.
+
+    Each iteration tears down its event loop. The same module-level
+    gantry must keep working — exercising the executor's ``to_thread``
+    path on a fresh loop every time.
+    """
+    for i in range(5):
+        results = _run_agent_request(
+            "add_one", [{"x": i + 100}], function_tools=function_tools
+        )
+        assert results == [str(i + 101)], f"iteration {i} got {results}"
+
+
+def test_async_tool_with_parallel_calls_across_loops(
+    function_tools: list[Any],
+) -> None:
+    """Multiple parallel ``function_call`` items per request → AF dispatches
+    them concurrently → real overlap on the rate limiter's lock and the
+    executor pipeline. Run multiple such requests via ``asyncio.run`` so
+    each request gets a fresh loop.
+    """
+    for i in range(3):
+        seeds = list(range(i * 4, i * 4 + 4))
+        results = _run_agent_request(
+            "slow_add",
+            [{"x": s} for s in seeds],
+            function_tools=function_tools,
+        )
+        assert results == [str(s + 1) for s in seeds], (
+            f"iteration {i} got {results}"
+        )
+
+
+def test_request_runs_in_worker_thread(function_tools: list[Any]) -> None:
+    """``DurableAIAgentWorker`` runs requests on a thread-pool worker.
+    Mirror that: spin up a worker thread, give it a fresh event loop,
+    run the request via ``asyncio.run``. The module-level gantry — built
+    on the main thread with no running loop — must work cleanly.
+    """
+    box: dict[str, Any] = {}
+
+    def _runner() -> None:
+        try:
+            box["results"] = _run_agent_request(
+                "slow_add",
+                [{"x": 7}, {"x": 8}, {"x": 9}],
+                function_tools=function_tools,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            box["error"] = exc
+
+    t = threading.Thread(target=_runner, daemon=True)
+    t.start()
+    t.join(timeout=30.0)
+    assert not t.is_alive(), "worker thread hung"
+    assert "error" not in box, f"worker raised: {box.get('error')!r}"
+    assert box["results"] == ["8", "9", "10"], box["results"]
+
+
+def test_worker_thread_followed_by_main_thread(function_tools: list[Any]) -> None:
+    """Cross-thread, cross-loop sequencing: run a request from a worker
+    thread first (binding any cross-loop primitives to that loop), then
+    run another from the main thread. Both must succeed.
+    """
+    # Worker thread first.
+    box: dict[str, Any] = {}
+
+    def _runner() -> None:
+        box["worker"] = _run_agent_request(
+            "slow_add", [{"x": 1}, {"x": 2}], function_tools=function_tools
+        )
+
+    t = threading.Thread(target=_runner, daemon=True)
+    t.start()
+    t.join(timeout=30.0)
+    assert box.get("worker") == ["2", "3"]
+
+    # Main thread immediately after — separate ``asyncio.run`` = separate loop.
+    main_results = _run_agent_request(
+        "slow_add", [{"x": 10}, {"x": 11}], function_tools=function_tools
+    )
+    assert main_results == ["11", "12"]
+
+
+def test_no_function_failed_envelope_in_results(function_tools: list[Any]) -> None:
+    """Belt-and-braces: ensure none of the returned tool results contain
+    AF's catch-all ``"Error: Function failed."`` string. If a future
+    regression makes ``gantry.execute`` raise, the bridge wrapper now
+    surfaces a JSON ``{"error": ...}`` envelope, which would also fail
+    this assertion.
+    """
+    results = _run_agent_request(
+        "slow_add",
+        [{"x": 1}, {"x": 2}, {"x": 3}, {"x": 4}],
+        function_tools=function_tools,
+    )
+    for r in results:
+        text = r if isinstance(r, str) else str(r)
+        assert "Function failed" not in text, text
+        assert '"error"' not in text, text

--- a/tests/test_executor_cross_loop.py
+++ b/tests/test_executor_cross_loop.py
@@ -263,3 +263,61 @@ async def test_bridge_wrapper_surfaces_executor_failure_as_json(
     assert "error" in payload
     assert "simulated cross-loop failure" in payload["error"]
     assert "RuntimeError" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# High-fidelity DurableAIAgentWorker simulation:
+# ``agent_framework_durabletask.DurableAIAgentWorker`` calls
+# ``asyncio.run(self._agent_entity.run(request))`` per inbound request, which
+# constructs and tears down a fresh event loop every time. A module-level
+# gantry therefore sees N distinct loops over its lifetime — the exact
+# scenario where eager ``asyncio.Lock`` binding fails.
+# ---------------------------------------------------------------------------
+
+
+def test_module_level_gantry_survives_asyncio_run_per_request():
+    """Smoke-test ``DurableAIAgentWorker``'s per-request ``asyncio.run``
+    pattern: ``DurableAIAgentWorker.process_request`` calls
+    ``asyncio.run(self._agent_entity.run(request))`` per inbound request,
+    constructing and tearing down a fresh event loop every time.
+
+    A single ``AgentGantry`` is constructed at "module load" (no running
+    loop), then driven via ``asyncio.run`` repeatedly. This exercises
+    the full wrapper → executor → rate-limiter path on N distinct loops.
+
+    Note: in Python 3.11 ``asyncio.Lock`` only binds to a loop on the
+    contended slow path (``_get_loop().create_future()``), so this smoke
+    test alone does not reliably reproduce the cross-loop bug — see
+    :func:`test_rate_limiter_lock_is_bound_to_running_loop_under_contention`
+    for the targeted regression test. This one guards against new
+    cross-loop primitives sneaking into the per-request path.
+    """
+    gantry = _build_gantry_no_loop()
+    bridge = GantryToolBridge(gantry, as_function_tool=False)
+    sync_wrapper = bridge.wrap_single(
+        next(t for t in gantry.list_tools_sync() if t.name == "constant_tool")
+    )
+    async_wrapper = bridge.wrap_single(
+        next(t for t in gantry.list_tools_sync() if t.name == "async_constant_tool")
+    )
+
+    async def _one_request(seed: int) -> list[str]:
+        # Three concurrent invocations within a single request force
+        # contention on the rate limiter's lock — the slow path that
+        # actually binds ``asyncio.Lock`` to the current loop.
+        outs = await asyncio.gather(
+            sync_wrapper(seed=seed),
+            async_wrapper(seed=seed),
+            sync_wrapper(seed=seed + 1),
+        )
+        return list(outs)
+
+    for i in range(5):
+        results = asyncio.run(_one_request(i))
+        # No JSON-error envelopes — every wrapper call must succeed cleanly.
+        for r in results:
+            assert not r.startswith("{") or '"error"' not in r, (
+                f"iteration {i}: wrapper surfaced an error: {r}"
+            )
+        assert any(f"ok-{i}" in r for r in results)
+        assert any(f"async-ok-{i}" in r for r in results)

--- a/tests/test_executor_cross_loop.py
+++ b/tests/test_executor_cross_loop.py
@@ -1,0 +1,265 @@
+"""
+Cross-event-loop integration tests for the executor and rate limiter.
+
+These tests reproduce the scenario described by integrators using
+``agent_framework.DurableAIAgentWorker``: the :class:`AgentGantry` is built
+in one context (often module import time, often with no running loop) and
+then driven from a *different* event loop running on a worker thread. With
+synchronisation primitives that bind eagerly to a loop, this previously
+surfaced as ``RuntimeError: ... is bound to a different event loop`` and
+the bridge wrapper turned the failure into AF's opaque
+``"Error: Function failed."`` string.
+
+The fixes exercised here:
+
+- ``RateLimiter`` keeps one ``asyncio.Lock`` per running loop
+  (:meth:`RateLimiter._lock_for_running_loop`).
+- ``ExecutionEngine._execute_with_timeout`` dispatches sync handlers via
+  ``asyncio.to_thread`` instead of ``asyncio.get_event_loop().run_in_executor``,
+  removing the deprecated cross-loop API call.
+- ``GantryToolBridge``'s wrapper catches exceptions from
+  ``gantry.execute(...)`` and surfaces them as a structured JSON error,
+  so any future cross-loop regression yields a debuggable error string.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from typing import Any
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+from agent_gantry.schema.execution import ToolCall
+
+
+def _build_gantry_no_loop() -> AgentGantry:
+    """Build a populated gantry with no running event loop.
+
+    Mirrors the integrator's setup where ``AgentGantry`` is constructed at
+    module import time so a durable worker can register the instance
+    correctly. We use ``SimpleEmbedder`` to avoid touching the network.
+    """
+    g = AgentGantry(embedder=SimpleEmbedder())
+
+    @g.register
+    def constant_tool(seed: int) -> str:
+        """Return a fixed message; verifies the executor wires up correctly."""
+        return f"ok-{seed}"
+
+    @g.register
+    async def async_constant_tool(seed: int) -> str:
+        """Async variant — verifies the coroutine branch of the executor."""
+        await asyncio.sleep(0)
+        return f"async-ok-{seed}"
+
+    return g
+
+
+def _run_in_worker_loop(coro_factory: Any) -> Any:
+    """Run ``coro_factory()`` on a brand-new loop in a worker thread.
+
+    Returns the coroutine's result (or re-raises the exception). This is
+    the same shape ``DurableAIAgentWorker`` produces — a different loop
+    from the one (if any) that constructed the gantry.
+    """
+    box: dict[str, Any] = {}
+
+    def _runner() -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            try:
+                box["result"] = loop.run_until_complete(coro_factory())
+            except BaseException as exc:  # noqa: BLE001 - propagate to test
+                box["error"] = exc
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=_runner, daemon=True)
+    t.start()
+    t.join(timeout=30.0)
+    assert not t.is_alive(), "worker thread hung"
+    if "error" in box:
+        raise box["error"]
+    return box["result"]
+
+
+# ---------------------------------------------------------------------------
+# Direct executor: gantry built without a running loop, executed from a
+# worker-thread loop. Both sync and async handlers must succeed.
+# ---------------------------------------------------------------------------
+
+
+def test_sync_handler_executes_on_worker_loop():
+    g = _build_gantry_no_loop()
+
+    async def _do() -> Any:
+        return await g.execute(
+            ToolCall(tool_name="constant_tool", arguments={"seed": 7})
+        )
+
+    result = _run_in_worker_loop(_do)
+    assert result.status.value == "success"
+    assert result.result == "ok-7"
+
+
+def test_async_handler_executes_on_worker_loop():
+    g = _build_gantry_no_loop()
+
+    async def _do() -> Any:
+        return await g.execute(
+            ToolCall(tool_name="async_constant_tool", arguments={"seed": 9})
+        )
+
+    result = _run_in_worker_loop(_do)
+    assert result.status.value == "success"
+    assert result.result == "async-ok-9"
+
+
+# ---------------------------------------------------------------------------
+# RateLimiter: same instance acquired/released on two distinct loops in
+# sequence. With the per-loop lock fix, both succeed.
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limiter_lock_is_bound_to_running_loop_under_contention():
+    """Verify per-loop lock isolation under genuine contention.
+
+    ``asyncio.Lock`` only binds to the current loop when contention forces
+    a waiter through ``_get_loop()`` (the uncontended fast path skips it
+    entirely). We reproduce that here by holding the lock across an
+    ``await`` while a second task waits on it. With the old single eager
+    ``asyncio.Lock``, loop B then trips
+    ``RuntimeError: ... is bound to a different event loop`` on its first
+    contended acquire. The per-loop fix gives each loop its own lock.
+    """
+    g = _build_gantry_no_loop()
+    rate_limiter = g._rate_limiter
+    assert rate_limiter is not None, "rate limiter should be enabled by default"
+
+    async def _force_contention() -> str:
+        lock = rate_limiter._lock_for_running_loop()
+
+        await lock.acquire()
+        # Spawn a waiter that must traverse the slow path
+        # (``_get_loop().create_future()``) and bind the lock to *this*
+        # loop. Without this overlap, the integrator's bug is masked.
+        async def _waiter() -> None:
+            await lock.acquire()
+            lock.release()
+
+        waiter_task = asyncio.create_task(_waiter())
+        await asyncio.sleep(0.05)  # let waiter actually wait
+        lock.release()
+        await waiter_task
+        return "loop-ok"
+
+    # Loop A: bind the loop A lock under contention.
+    a = asyncio.new_event_loop()
+    try:
+        a_result = a.run_until_complete(_force_contention())
+    finally:
+        a.close()
+    assert a_result == "loop-ok"
+
+    # Loop B in a worker thread — different loop, same RateLimiter
+    # instance. With the old code this raises on the first contended
+    # acquire because the single eager lock is still bound to (the
+    # now-closed) loop A. With the per-loop fix loop B gets its own lock.
+    b_result = _run_in_worker_loop(_force_contention)
+    assert b_result == "loop-ok"
+
+
+def test_rate_limiter_full_acquire_release_works_across_loops():
+    """End-to-end ``acquire``/``release`` on the public RateLimiter API.
+
+    Mirrors the realistic integrator path where the limiter is exercised
+    indirectly via :class:`AgentGantry.execute` from a worker-thread loop.
+    """
+    g = _build_gantry_no_loop()
+    rate_limiter = g._rate_limiter
+    assert rate_limiter is not None
+
+    async def _do() -> str:
+        await rate_limiter.acquire("constant_tool", "default")
+        await rate_limiter.release("constant_tool", "default")
+        return "loop-ok"
+
+    # Loop A first (no contention here — just establishes prior usage).
+    a = asyncio.new_event_loop()
+    try:
+        assert a.run_until_complete(_do()) == "loop-ok"
+    finally:
+        a.close()
+
+    # Loop B from a worker thread.
+    assert _run_in_worker_loop(_do) == "loop-ok"
+
+
+# ---------------------------------------------------------------------------
+# Bridge wrapper: a handler that raises must surface a structured error,
+# not let the exception propagate up to AF as the opaque "Function failed".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bridge_wrapper_surfaces_handler_exception_as_json():
+    g = AgentGantry(embedder=SimpleEmbedder())
+
+    @g.register
+    def boom(x: int) -> str:
+        """Always raises so the wrapper's error path is exercised."""
+        raise ValueError(f"intentional failure with x={x}")
+
+    await g.sync()
+
+    bridge = GantryToolBridge(g, as_function_tool=False)
+    tools = await bridge.get_tools("trigger boom", limit=1, score_threshold=0.0)
+    assert tools, "expected at least one tool"
+    boom_wrapper = next(
+        t for t in tools if (getattr(t, "__name__", None) == "boom")
+    )
+
+    out = await boom_wrapper(x=3)
+    payload = json.loads(out)
+    assert "error" in payload
+    # The actual exception text should reach the integrator's logs.
+    assert "intentional failure" in payload["error"]
+    assert "ValueError" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_bridge_wrapper_surfaces_executor_failure_as_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exceptions raised *inside* gantry.execute (not just inside the
+    handler) are also wrapped — guarding against the cross-loop scenario
+    where the rate limiter or any other infrastructure layer fails before
+    the handler runs."""
+    g = AgentGantry(embedder=SimpleEmbedder())
+
+    @g.register
+    def some_tool(x: int) -> str:
+        """A tool used to exercise the wrapper error path."""
+        return str(x)
+
+    await g.sync()
+
+    async def _broken_execute(_call: ToolCall) -> Any:
+        raise RuntimeError("simulated cross-loop failure")
+
+    monkeypatch.setattr(g, "execute", _broken_execute)
+
+    bridge = GantryToolBridge(g, as_function_tool=False)
+    wrapper = bridge.wrap_single(g.list_tools_sync()[0])
+
+    out = await wrapper(x=1)
+    payload = json.loads(out)
+    assert "error" in payload
+    assert "simulated cross-loop failure" in payload["error"]
+    assert "RuntimeError" in payload["error"]

--- a/tests/test_executor_cross_loop.py
+++ b/tests/test_executor_cross_loop.py
@@ -159,15 +159,16 @@ def test_rate_limiter_lock_is_bound_to_running_loop_under_contention():
         await waiter_task
         return "loop-ok"
 
-    # Loop A: bind the loop A lock under contention.
-    a = asyncio.new_event_loop()
-    try:
-        a_result = a.run_until_complete(_force_contention())
-    finally:
-        a.close()
+    # Loop A: bind the loop A lock under contention. Run in a worker
+    # thread (with its own fresh loop) rather than constructing a loop on
+    # the main thread, because pytest-asyncio's auto-managed policy on
+    # macOS + Python 3.10 + kqueue gets confused if we manipulate the main
+    # thread's event loop directly. The semantics are identical — we just
+    # need *some* distinct loop to bind the lock to.
+    a_result = _run_in_worker_loop(_force_contention)
     assert a_result == "loop-ok"
 
-    # Loop B in a worker thread — different loop, same RateLimiter
+    # Loop B in another worker thread — different loop, same RateLimiter
     # instance. With the old code this raises on the first contended
     # acquire because the single eager lock is still bound to (the
     # now-closed) loop A. With the per-loop fix loop B gets its own lock.
@@ -191,13 +192,10 @@ def test_rate_limiter_full_acquire_release_works_across_loops():
         return "loop-ok"
 
     # Loop A first (no contention here — just establishes prior usage).
-    a = asyncio.new_event_loop()
-    try:
-        assert a.run_until_complete(_do()) == "loop-ok"
-    finally:
-        a.close()
+    # Worker thread keeps the main thread's pytest-asyncio policy clean.
+    assert _run_in_worker_loop(_do) == "loop-ok"
 
-    # Loop B from a worker thread.
+    # Loop B from a separate worker thread → distinct loop.
     assert _run_in_worker_loop(_do) == "loop-ok"
 
 
@@ -313,7 +311,11 @@ def test_module_level_gantry_survives_asyncio_run_per_request():
         return list(outs)
 
     for i in range(5):
-        results = asyncio.run(_one_request(i))
+        # Run each "request" on a fresh worker-thread loop. This mirrors
+        # ``DurableAIAgentWorker`` more faithfully than calling
+        # ``asyncio.run`` on the main thread, and avoids tripping
+        # pytest-asyncio's loop policy on macOS + Python 3.10.
+        results = _run_in_worker_loop(lambda i=i: _one_request(i))
         # No JSON-error envelopes — every wrapper call must succeed cleanly.
         for r in results:
             assert not r.startswith("{") or '"error"' not in r, (

--- a/tests/test_query_strategies.py
+++ b/tests/test_query_strategies.py
@@ -1,0 +1,243 @@
+"""
+Tests for :mod:`agent_gantry.query` strategies and the
+``preview`` / ``list_tools_sync`` helpers exposed on
+:class:`agent_gantry.AgentGantry`.
+
+These tests intentionally avoid importing ``agent_framework`` so they run
+in any environment.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.query import (
+    concatenate_recent,
+    fallback_chain,
+    last_assistant_text,
+    last_tool_result,
+    last_user_text,
+)
+
+
+class _Msg:
+    def __init__(self, role: str, text: str = "", *, name: str = "") -> None:
+        self.role = role
+        self.text = text
+        self.author_name = name
+
+
+# ---------------------------------------------------------------------------
+# Query strategies
+# ---------------------------------------------------------------------------
+
+
+def test_last_user_text_picks_most_recent_user_message():
+    msgs = [
+        _Msg("user", "first user"),
+        _Msg("assistant", "asst reply"),
+        _Msg("user", "second user"),
+        _Msg("assistant", "asst reply 2"),
+    ]
+    assert last_user_text(msgs) == "second user"
+
+
+def test_last_assistant_text_picks_most_recent_assistant_message():
+    msgs = [
+        _Msg("user", "u"),
+        _Msg("assistant", "first asst"),
+        _Msg("tool", "tool out"),
+        _Msg("assistant", "latest asst"),
+    ]
+    assert last_assistant_text(msgs) == "latest asst"
+
+
+def test_last_tool_result_includes_tool_name_and_caps_content():
+    big = "x" * 1000
+    msgs = [
+        _Msg("user", "go"),
+        _Msg("tool", big, name="find_markers"),
+    ]
+    out = last_tool_result(msgs, max_chars=50)
+    assert out.startswith("result of find_markers: ")
+    # 24 prefix chars + 50 content chars
+    assert len(out) == len("result of find_markers: ") + 50
+
+
+def test_last_tool_result_falls_back_to_generic_label_when_no_name():
+    msgs = [_Msg("tool", "raw output")]
+    assert last_tool_result(msgs) == "tool result: raw output"
+
+
+def test_concatenate_recent_returns_last_n_texts():
+    msgs = [
+        _Msg("user", "a"),
+        _Msg("assistant", "b"),
+        _Msg("tool", "c"),
+        _Msg("assistant", "d"),
+    ]
+    out = concatenate_recent(msgs, n=2, separator=" | ")
+    assert out == "c | d"
+
+
+def test_concatenate_recent_skips_empty_messages():
+    msgs = [_Msg("user", "  "), _Msg("assistant", "real text")]
+    assert concatenate_recent(msgs, n=2) == "real text"
+
+
+def test_fallback_chain_returns_first_non_empty_result():
+    chain = fallback_chain(last_tool_result, last_assistant_text, last_user_text)
+    msgs = [_Msg("user", "u"), _Msg("assistant", "a")]
+    # No tool message -> falls through to last_assistant_text
+    assert chain(msgs) == "a"
+
+
+def test_strategies_handle_empty_input():
+    assert last_user_text(None) == ""
+    assert last_user_text([]) == ""
+    assert last_tool_result([]) == ""
+    assert concatenate_recent([], n=3) == ""
+
+
+def test_strategies_accept_dict_messages():
+    msgs = [
+        {"role": "user", "content": "hello"},
+        {"role": "tool", "content": "out", "name": "fn"},
+    ]
+    assert last_user_text(msgs) == "hello"
+    assert "result of fn:" in last_tool_result(msgs)
+
+
+# ---------------------------------------------------------------------------
+# AgentGantry.list_tools_sync + preview
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tools_sync_reads_registry_without_async():
+    g = AgentGantry()
+
+    @g.register
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    @g.register(namespace="math")
+    def mul(a: int, b: int) -> int:
+        """Multiply two numbers."""
+        return a * b
+
+    # Note: no await on sync().
+    all_tools = g.list_tools_sync()
+    assert {t.name for t in all_tools} == {"add", "mul"}
+
+    only_math = g.list_tools_sync(namespace="math")
+    assert [t.name for t in only_math] == ["mul"]
+
+
+@pytest.mark.asyncio
+async def test_preview_returns_ranked_pairs():
+    g = AgentGantry()
+
+    @g.register
+    def add(a: int, b: int) -> int:
+        """Sum two integers."""
+        return a + b
+
+    @g.register
+    def divide(a: int, b: int) -> float:
+        """Divide two integers."""
+        return a / b
+
+    await g.sync()
+    ranked = await g.preview("add two numbers", limit=10, score_threshold=0.0)
+    assert len(ranked) >= 1
+    names = [n for n, _ in ranked]
+    assert all(name.startswith("default.") for name in names)
+    # Scores should be sorted descending.
+    scores = [s for _, s in ranked]
+    assert scores == sorted(scores, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_simple_embedder_warning_on_threshold():
+    """SimpleEmbedder + non-zero threshold should emit a UserWarning once."""
+    from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+    SimpleEmbedder._warned_about_threshold = False  # reset test-local
+
+    g = AgentGantry()
+
+    @g.register
+    def some_tool(x: int) -> int:
+        """A tool that does something with the input value."""
+        return x
+
+    await g.sync()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await g.preview("anything", score_threshold=0.5)
+    msgs = [str(w.message) for w in caught]
+    assert any("SimpleEmbedder" in m for m in msgs), msgs
+
+
+# ---------------------------------------------------------------------------
+# register() accepts FunctionTool-like wrappers
+# ---------------------------------------------------------------------------
+
+
+def test_register_accepts_function_tool_like_object():
+    """``gantry.register`` should unwrap ``.func`` / ``.name`` wrappers
+    such as ``agent_framework.tool``-decorated FunctionTool objects."""
+    g = AgentGantry()
+
+    def real_handler(x: int) -> int:
+        """Doubles the input."""
+        return x * 2
+
+    class FakeFunctionTool:
+        # Matches the AF FunctionTool surface that lacks ``__name__``.
+        def __init__(self) -> None:
+            self.func = real_handler
+            self.name = "doubler"
+            self.description = "Doubles."
+
+    ft = FakeFunctionTool()
+    returned = g.register(ft)
+
+    assert returned is ft  # the wrapper is passed through unchanged
+    pending_names = [t.name for t in g._pending_tools]
+    assert "doubler" in pending_names
+    # The handler under the registered name should be the bare callable.
+    assert g._tool_handlers["doubler"] is real_handler
+
+
+# ---------------------------------------------------------------------------
+# Adapter re-exports
+# ---------------------------------------------------------------------------
+
+
+def test_embedders_module_exposes_optional_classes_via_dir():
+    import agent_gantry.adapters.embedders as em
+
+    listed = set(dir(em))
+    expected = {
+        "EmbeddingAdapter",
+        "SimpleEmbedder",
+        "SentenceTransformersEmbedder",
+        "NomicEmbedder",
+        "OpenAIEmbedder",
+        "AzureOpenAIEmbedder",
+    }
+    assert expected.issubset(listed)
+
+
+def test_rerankers_module_exposes_optional_classes_via_dir():
+    import agent_gantry.adapters.rerankers as rk
+
+    listed = set(dir(rk))
+    expected = {"RerankerAdapter", "CohereReranker", "CrossEncoderReranker"}
+    assert expected.issubset(listed)

--- a/tests/test_query_strategies.py
+++ b/tests/test_query_strategies.py
@@ -169,7 +169,10 @@ async def test_simple_embedder_warning_on_threshold():
 
     SimpleEmbedder._warned_about_threshold = False  # reset test-local
 
-    g = AgentGantry()
+    # Pin SimpleEmbedder explicitly: without this the default config selects
+    # ``sentence_transformers`` whenever that extra is installed, which
+    # bypasses the SimpleEmbedder-specific warning code path.
+    g = AgentGantry(embedder=SimpleEmbedder())
 
     @g.register
     def some_tool(x: int) -> int:


### PR DESCRIPTION
## Summary

This PR adds dynamic per-chat-round semantic tool retrieval to `GantryContextProvider`, introduces a new `agent_gantry.query` module with deterministic query-generation strategies, and exposes configuration introspection on the provider. It also adds validation for required tools and improves the embedder/reranker module structure with lazy imports.

## Key Changes

### Per-Call Retrieval & Query Strategies
- **New `query_strategy` parameter** on `GantryContextProvider`: `"per_run"` (default, back-compatible) refreshes tools once at run start; `"per_call"` re-runs retrieval on every chat-completion round
- **New `query_generator` parameter**: accepts sync or async callables to derive retrieval queries from conversation state (defaults to `last_user_text`)
- **New `agent_gantry.query` module** with built-in strategies:
  - `last_user_text` — most recent user message (default)
  - `last_assistant_text` — model's latest reasoning
  - `last_tool_result` — previous tool output (best for multi-step workflows)
  - `concatenate_recent` — last N turns joined
  - `fallback_chain` — compose strategies with fallback logic
- **`as_chat_middleware()` method** on provider: returns an AF chat middleware for wiring per-round refresh into `Agent(middleware=[...])`

### Provider Configuration & Validation
- **New `required` parameter**: hard-pins a set of tool names; raises `MissingRequiredToolError` at construction if any are missing (catches typos/dropped registrations early)
- **Public read-only properties**: `top_k`, `score_threshold`, `query_strategy`, `always_include`, `required`, `gantry`, `bridge` for external observability
- **New `MissingRequiredToolError` exception** exported from main package

### Gantry Inspection & Calibration
- **`AgentGantry.list_tools_sync()`**: synchronous, in-memory tool listing (no `await`, no vector store round-trip) for telemetry and validation
- **`AgentGantry.preview(query, ...)`**: returns `(qualified_name, score)` pairs for calibrating `score_threshold` and `top_k` without spinning up an agent

### Adapter Module Improvements
- **Lazy imports in `agent_gantry.adapters.embedders`**: `SentenceTransformersEmbedder`, `OpenAIEmbedder`, `AzureOpenAIEmbedder` now accessible via `__getattr__` alongside eager imports
- **Lazy imports in `agent_gantry.adapters.rerankers`**: `CohereReranker`, `CrossEncoderReranker` follow the same pattern
- **Updated `__all__` exports** to include all lazy-loaded names

### Tool Registration & Wrapping
- **`AgentGantry.register()` now unwraps AF `FunctionTool` wrappers**: accepts objects with `.func` and `.name` attributes (e.g., `@tool`-decorated callables), extracts the underlying handler, and preserves the wrapper in the return value
- **Improved error messages** when tool name cannot be determined

### SimpleEmbedder Warnings
- **Added `_warned_about_threshold` class flag** to emit a one-time `UserWarning` when `SimpleEmbedder` is paired with a non-zero `score_threshold` (which typically filters all tools out due to hash-based scoring)

## Implementation Details

- Per-call retrieval is implemented via a chat middleware decorator that reads the current message context, runs the query generator, retrieves fresh tools, and updates the context before the LLM call
- Query generators work over any iterable of message-like objects (AF messages, dicts, or anything with `role`/`text`/`content` attributes)
- The `required` validation happens at provider construction time by introspecting the gantry's registry
- `list_tools_sync()` reads from in-memory registry and pending tools without triggering async sync
- All new code includes comprehensive doc

https://claude.ai/code/session_01KTxoboiHbz4r2JU99vL2Ru