### PR TITLE
May 2026 modernisation audit: fix deprecated model IDs and docs

### DIFF
--- a/AUDIT_2026-05.md
+++ b/AUDIT_2026-05.md
@@ -1,0 +1,333 @@
+# Agent-Gantry Modernisation Audit — May 2026
+
+**Auditor**: Claude (Sonnet 4.6) operating as repository maintainer  
+**Branch**: `claude/elegant-clarke-CJu56`  
+**Date**: 2026-05-01  
+**Scope**: Full compatibility and modernisation audit against latest stable LLM provider SDKs, provider API standards, and agent framework patterns.
+
+---
+
+## 1. Executive Summary
+
+The repository is in good health following the April 2026 audit. However, this audit identified **five must-change-now issues** and **four good-next-step improvements**. The April audit correctly addressed most provider API concerns, but missed three documentation regressions that are now fixed. The most urgent items are two live code examples in `README.md` referencing deprecated model identifiers that will cease to function on **15 June 2026** (45 days away).
+
+### Must-Change Now
+
+| # | Finding | Files Affected | Risk |
+|---|---------|---------------|------|
+| 1 | `README.md` uses `claude-sonnet-4-20250514` (retiring 15 Jun 2026) | `README.md` | Breaking on retirement date |
+| 2 | `README.md` uses `gemini-2.0-flash` (deprecated, shutdown imminent) | `README.md` | Breaking — service interruption |
+| 3 | `docs/reference/llm_sdk_compatibility.md` — OpenRouter section still pins `openai>=1.0.0` (should be `>=2.33.0`) | `docs/reference/llm_sdk_compatibility.md` | Documentation error |
+| 4 | `docs/reference/llm_sdk_compatibility.md` — Anthropic "Tool Format Conversion" appendix still shows the deprecated manual `to_anthropic_tools()` function; main integration section was fixed in April but the appendix was missed | `docs/reference/llm_sdk_compatibility.md` | Documentation regression |
+| 5 | `google-genai` floor at `>=1.0.0` while latest stable is 1.74.0 — 74 minor versions behind | `pyproject.toml` | Resolver picks stale version in constrained environments |
+
+**Status**: All five are fixed in this commit.
+
+### Good Next-Step Improvements
+
+| # | Finding | Files Affected |
+|---|---------|---------------|
+| 6 | `langchain` floor at `>=1.2.16`; latest stable is 1.2.17 | `pyproject.toml` |
+| 7 | `AnthropicFeatures.enable_extended_thinking` docstring does not warn that `claude-opus-4-7` does not support extended thinking (only adaptive) | `agent_gantry/integrations/anthropic_features.py` |
+| 8 | `docs/reference/llm_sdk_compatibility.md` — Vertex AI integration example uses manual field access from OpenAI format instead of `to_dialect("gemini")` | `docs/reference/llm_sdk_compatibility.md` |
+| 9 | Mistral 2.x migration (`mistralai>=2.0.0`) remains pending — `LLMClient` needs restructuring to per-call context manager | `agent_gantry/adapters/llm_client.py`, `pyproject.toml` |
+
+**Status**: Items 6, 7, and 8 are fixed in this commit. Item 9 is an existing documented pending task.
+
+---
+
+## 2. Dependency Upgrade Plan
+
+### Packages Changed in This Audit
+
+| Package | Was | Now | Breaking changes | `uv` command | Risk |
+|---------|-----|-----|-----------------|-------------|------|
+| `google-genai` | `>=1.0.0` | **`>=1.74.0`** | None for existing usage patterns (`client.aio.models.generate_content` remains stable) | `uv lock --upgrade-package google-genai` | Safe internal |
+| `langchain` | `>=1.2.16` | **`>=1.2.17`** | None | `uv lock --upgrade-package langchain` | Safe internal |
+
+**Source**: PyPI JSON API — https://pypi.org/pypi/google-genai/json, https://pypi.org/pypi/langchain/json
+
+### Already-Current Packages (No Action Required)
+
+| Package | Pin | Latest stable | Status |
+|---------|-----|--------------|--------|
+| `agent-framework` | `>=1.2.2,<2.0.0` | 1.2.2 | ✅ Current |
+| `openai` | `>=2.33.0` | 2.33.0 | ✅ Current |
+| `anthropic` | `>=0.97.0` | 0.97.0 | ✅ Current |
+| `autogen-agentchat` | `>=0.7.5` | 0.7.5 | ✅ Current |
+| `langgraph` | `>=1.1.10` | 1.1.10 | ✅ Current |
+| `llama-index-core` | `>=0.14.21` | 0.14.21 | ✅ Current |
+| `groq` | `>=1.2.0` | 1.2.0 | ✅ Current |
+
+**Source**: PyPI JSON API for each package listed above.
+
+### Packages Deliberately Held (Conflict Analysis Unchanged)
+
+| Package | Current pin | Latest stable | Reason held |
+|---------|------------|---------------|-------------|
+| `mistralai` | `>=1.0.0,<2.0.0` | 2.4.4 | 2.x requires per-call `async with Mistral(...) as client:` — `LLMClient` restructuring pending |
+| `crewai` | `>=1.6.1` | 1.14.4 | `crewai>=1.12.0` pins `opentelemetry-api<1.35`, conflicting with `agent-framework>=1.2.1` (`>=1.39.0`) |
+| `google-adk` | `>=1.14.1` | 1.31.1 | Same opentelemetry conflict on Python 3.13/Windows |
+| `semantic-kernel` | `>=1.30.0` | latest | Same opentelemetry conflict on some platform splits |
+
+---
+
+## 3. Provider API Refactors
+
+### 3.1 OpenAI
+
+**Status: No action required.**
+
+No Assistants API usage found anywhere. All call sites use Chat Completions (`client.chat.completions.create`) or the Responses API (`client.responses.create`). The Assistants API sunset deadline (26 August 2026) does not affect this codebase.
+
+**Source**: https://platform.openai.com/docs/api-reference/responses
+
+### 3.2 Anthropic
+
+**Status: Two documentation fixes applied; one docstring improvement applied.**
+
+#### 3.2.1 README.md — deprecated model ID (applied)
+
+**File**: `README.md`, line 205
+
+```diff
+-        model="claude-sonnet-4-20250514",
++        model="claude-sonnet-4-6",
+```
+
+**Rationale**: `claude-sonnet-4-20250514` is listed as deprecated in the Anthropic docs and will be retired on **15 June 2026**. The replacement is `claude-sonnet-4-6`.  
+**Risk**: Breaking on retirement date (15 June 2026, 45 days away).  
+**Source**: https://platform.claude.com/docs/en/docs/about-claude/models
+
+#### 3.2.2 `AnthropicFeatures` docstring — extended thinking not supported on Opus 4.7 (applied)
+
+**File**: `agent_gantry/integrations/anthropic_features.py`
+
+The Anthropic model table (verified against the live docs) shows:
+
+| Model | Extended thinking | Adaptive thinking |
+|-------|:-----------------:|:-----------------:|
+| `claude-opus-4-7` | ❌ | ✅ |
+| `claude-sonnet-4-6` | ✅ | ✅ |
+| `claude-haiku-4-5` | ✅ | ❌ |
+
+`AnthropicFeatures.enable_extended_thinking` and the `AnthropicClient` class docstring did not warn that `claude-opus-4-7` does not support extended thinking. Passing `thinking={"type": "enabled", "budget_tokens": N}` to Opus 4.7 will return an API error. The docstrings now explicitly call this out.
+
+**Risk**: Safe internal — no functional change, docstring only.
+
+### 3.3 Gemini
+
+**Status: One critical fix applied (README.md). Documentation pattern improved.**
+
+#### 3.3.1 README.md — deprecated model ID (applied)
+
+**File**: `README.md`, line 222
+
+```diff
+-        model="gemini-2.0-flash",
++        model="gemini-2.5-flash",
+```
+
+**Rationale**: According to the official Google Gemini documentation, `gemini-2.0-flash` is deprecated and scheduled for shutdown. The replacement is `gemini-2.5-flash`.  
+**Risk**: Breaking — service interruption when shutdown occurs.  
+**Source**: https://ai.google.dev/gemini-api/docs/models
+
+#### 3.3.2 All other Gemini references checked — no further action needed
+
+`docs/reference/llm_sdk_compatibility.md` and all Python files under `agent_gantry/` and `examples/` already use `gemini-2.5-flash` (updated in the April 2026 audit). The only stale reference was in `README.md`.
+
+### 3.4 Mistral
+
+**Status: No code change. Migration plan unchanged from April 2026 audit.**
+
+`mistralai` remains pinned to `<2.0.0`. The migration to the 2.x per-call context-manager pattern is documented in `pyproject.toml` and `CHANGELOG.md`.
+
+Latest stable is 2.4.4 (was 2.4.3 at April audit time).
+
+### 3.5 Groq
+
+**Status: No action required.** Already at `>=1.2.0` (latest stable).
+
+---
+
+## 4. Framework Integration Refactors
+
+### 4.1 Microsoft Agent Framework
+
+**Status: No action required — already at latest stable 1.2.2.**
+
+Verified against https://github.com/microsoft/agent-framework/releases. There are no releases beyond 1.2.2 as of 2026-05-01. The `agent-framework>=1.2.2,<2.0.0` pin is current.
+
+The full AF integration (bridge, middleware, context provider, workflow builders) was validated in the April 2026 audit and remains correct for 1.2.2:
+
+- `GantryToolBridge` correctly uses `agent_framework.tool`, `Agent`, `AgentExecutor`, `WorkflowBuilder`, `SequentialBuilder`, `HandoffBuilder`, `ConcurrentBuilder`.
+- `GantryContextProvider` correctly subclasses `agent_framework.ContextProvider` with lazy import.
+- `GantryApprovalMiddleware` / `GantryObservabilityMiddleware` correctly fall back from `FunctionMiddleware` to `ChatMiddlewareLayer` when the former is absent.
+- `MiddlewareTermination` usage is correct.
+
+**No AutoGen-to-MAF migration required.** The existing AutoGen (AG2 0.7.5) integration is a separate, non-deprecated track. The codebase correctly maintains both integrations independently.
+
+### 4.2 AutoGen (AG2)
+
+**Status: No action required.** Already at `>=0.7.5` (latest stable 0.7.5).
+
+`autogen_example.py` correctly uses the AG2 0.7.x API:
+- `autogen_agentchat.agents.AssistantAgent`
+- `autogen_ext.models.openai.OpenAIChatCompletionClient(model="gpt-4o")`
+- `Console(assistant.run_stream(task=...))`
+
+### 4.3 LangChain / LangGraph
+
+**Status: Minor floor bump applied.**
+
+`langchain` floor bumped from `>=1.2.16` to `>=1.2.17` (latest stable). All framework patterns (`langgraph.prebuilt.create_react_agent`, etc.) remain correct.
+
+### 4.4 CrewAI
+
+**Status: Held at `>=1.6.1` — opentelemetry conflict unchanged.**
+
+Latest is 1.14.4. Upgrading past 1.12.0 requires a separate environment without `agent-framework`. This is documented in `pyproject.toml`.
+
+---
+
+## 5. Universal Tool-Calling Design
+
+**Status: No structural changes required. Documentation pattern improved.**
+
+The seven-adapter `ToolSpecAdapter` architecture (`OpenAIAdapter`, `OpenAIResponsesAdapter`, `AnthropicAdapter`, `GeminiAdapter`, `MistralAdapter`, `GroqAdapter`, `AgentFrameworkAdapter`) is sound and verified against current provider documentation.
+
+The one change in this section is a documentation improvement: the `docs/reference/llm_sdk_compatibility.md` "Tool Format Conversion" appendix previously showed a manual `to_anthropic_tools()` function (missed by the April audit). This has been replaced with the canonical `to_dialect("anthropic")` pattern, consistent with the main integration examples.
+
+The Vertex AI format example has also been updated to use `to_dialect("gemini")` with `**` unpacking into `FunctionDeclaration`, eliminating the manual field extraction from the intermediate OpenAI format.
+
+---
+
+## 6. Documentation and Example Updates
+
+### 6.1 `README.md` — Changes Applied
+
+| Location | Was | Now | Rationale |
+|----------|-----|-----|-----------|
+| Anthropic example (line 205) | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` | Retiring 15 Jun 2026 |
+| Google Gemini example (line 222) | `gemini-2.0-flash` | `gemini-2.5-flash` | Deprecated, shutdown imminent |
+
+**Source**: https://platform.claude.com/docs/en/docs/about-claude/models, https://ai.google.dev/gemini-api/docs/models
+
+### 6.2 `docs/reference/llm_sdk_compatibility.md` — Changes Applied
+
+| Location | Was | Now | Rationale |
+|----------|-----|-----|-----------|
+| OpenRouter install (line 646) | `pip install openai>=1.0.0` | `>=2.33.0` | Missed in April audit; aligns with current pin |
+| Tool Format Conversion → Anthropic (lines 770–779) | Manual `to_anthropic_tools()` function | `to_dialect("anthropic")` canonical pattern | April audit fixed main sections but missed appendix |
+| Tool Format Conversion → Vertex AI | Manual field access from OpenAI format | `to_dialect("gemini")` + `**` unpacking into `FunctionDeclaration` | Consistent with `GeminiAdapter` contract; eliminates indirect two-step conversion |
+| Vertex AI integration example | `openai_tools = await gantry.retrieve_tools(...)` + manual field extraction | `gantry.retrieve(ToolQuery(...))` + `to_dialect("gemini")` | Same rationale as above |
+
+### 6.3 `agent_gantry/integrations/anthropic_features.py` — Changes Applied
+
+- `AnthropicFeatures.enable_extended_thinking` field comment: added explicit warning that `claude-opus-4-7` does not support extended thinking.
+- `AnthropicClient` class docstring: updated extended-thinking and adaptive-thinking bullet points to list current model compatibility per the live Anthropic docs.
+- `create_anthropic_client` docstring: `enable_thinking` parameter description updated to note Opus 4.7 does not support `"extended"` mode.
+
+### 6.4 Items Checked and Not Changed
+
+- `QUICK_REFERENCE.md` — no stale model names or API patterns.
+- All `examples/agent_frameworks/*.py` — correct; no deprecated model names.
+- `examples/llm_integration/*.py` — `anthropic_demo.py` and `google_genai_demo.py` already use `claude-sonnet-4-6` and `gemini-2.5-flash` respectively.
+- `agent_gantry/adapters/llm_client.py` — `classify_intent()` uses `client.chat.completions.create` for OpenAI; appropriate for utility classification, no Responses API migration needed.
+- `agent_gantry/integrations/agent_framework_bridge.py` — `GeminiChatClient` already documented; no change needed.
+- `agent_gantry/integrations/agent_framework_provider.py` — `GantryContextProvider` logic verified correct for AF 1.2.2.
+
+---
+
+## 7. Test and Migration Plan
+
+### 7.1 Tests to Add
+
+| Test | File | Priority | Rationale |
+|------|------|----------|-----------|
+| `test_create_message_opus47_no_extended_thinking` — assert that passing `enable_extended_thinking=True` with model `claude-opus-4-7` raises a clear `ValueError` before the API call | `tests/test_anthropic_features.py` | Medium | Prevents a confusing 400 API error for users who upgrade to Opus 4.7 |
+| `test_gemini_adapter_to_dialect_for_vertex_ai` — verify `to_dialect("gemini")` output unpacks cleanly into `FunctionDeclaration(**...)` (dict key set matches constructor) | `tests/test_tool_spec_adapters.py` | Low | Regression guard for the updated Vertex AI doc example |
+
+**Note**: No VCR recordings, golden responses, or fixture regeneration is required for any change in this audit. All fixes are documentation-level or docstring-level. The existing test suite fully covers the adapter and integration code.
+
+### 7.2 Changelog-Ready Migration Notes
+
+```markdown
+### Fixed
+
+- **`README.md`**: Updated deprecated model identifiers in quick-start examples:
+  - `claude-sonnet-4-20250514` → `claude-sonnet-4-6` (retiring 15 June 2026).
+  - `gemini-2.0-flash` → `gemini-2.5-flash` (deprecated; service shutdown imminent).
+  *Risk: none — documentation only.*
+
+- **`docs/reference/llm_sdk_compatibility.md`**:
+  - OpenRouter section: corrected `pip install openai>=1.0.0` → `>=2.33.0` (missed
+    in April 2026 audit).
+  - Tool Format Conversion → Anthropic: replaced deprecated manual
+    `to_anthropic_tools()` helper with the canonical `to_dialect("anthropic")`
+    pattern (appendix section was missed in April 2026 audit).
+  - Tool Format Conversion → Vertex AI and Vertex AI integration example: use
+    `to_dialect("gemini")` + `**`-unpacking into `FunctionDeclaration`, eliminating
+    the indirect two-step conversion from OpenAI format.
+
+### Changed
+
+- **Dependency: `google-genai` floor bumped to `>=1.74.0`** (was `>=1.0.0`). The
+  floor was 74 minor versions behind the latest stable release (1.74.0). Bumping
+  ensures constrained resolver environments select a supported SDK version.
+  The `client.aio.models.generate_content` API used by `LLMClient` is stable across
+  this range.
+  *Risk: safe internal — no API changes required.*
+
+- **Dependency: `langchain` floor bumped to `>=1.2.17`** (was `>=1.2.16`). Minor
+  patch release.
+  *Risk: safe internal.*
+
+### Documentation
+
+- **`agent_gantry/integrations/anthropic_features.py`**: Clarified that
+  `claude-opus-4-7` does **not** support extended thinking (only adaptive thinking).
+  Updated `AnthropicFeatures`, `AnthropicClient`, and `create_anthropic_client`
+  docstrings accordingly.
+  *Source: https://platform.claude.com/docs/en/docs/about-claude/models*
+```
+
+---
+
+## Must-Change Now (All Applied in This Commit)
+
+1. ✅ **`README.md`** — `claude-sonnet-4-20250514` → `claude-sonnet-4-6` (retiring 15 June 2026).
+2. ✅ **`README.md`** — `gemini-2.0-flash` → `gemini-2.5-flash` (deprecated; shutdown imminent).
+3. ✅ **`docs/reference/llm_sdk_compatibility.md`** — OpenRouter `pip install openai>=1.0.0` → `>=2.33.0`.
+4. ✅ **`docs/reference/llm_sdk_compatibility.md`** — Manual `to_anthropic_tools()` appendix replaced with `to_dialect("anthropic")`.
+5. ✅ **`pyproject.toml`** — `google-genai` floor `>=1.0.0` → `>=1.74.0`.
+
+## Good Next-Step Improvements (Items 6–8 Applied; Item 9 Deferred)
+
+6. ✅ **`pyproject.toml`** — `langchain` floor `>=1.2.16` → `>=1.2.17`.
+7. ✅ **`agent_gantry/integrations/anthropic_features.py`** — Extended thinking docstrings updated for Opus 4.7 compatibility.
+8. ✅ **`docs/reference/llm_sdk_compatibility.md`** — Vertex AI example updated to use `to_dialect("gemini")`.
+9. ⏳ **Mistral 2.x migration** — `LLMClient` restructuring to per-call context manager. Blocked on `<2.0.0` cap until sprint is scheduled.
+
+---
+
+## Appendix — Verification URLs
+
+| Claim | URL Fetched |
+|-------|-------------|
+| `agent-framework` latest stable is 1.2.2 | https://pypi.org/pypi/agent-framework/json |
+| `openai` latest stable is 2.33.0 | https://pypi.org/pypi/openai/json |
+| `anthropic` latest stable is 0.97.0 | https://pypi.org/pypi/anthropic/json |
+| `google-genai` latest stable is 1.74.0 | https://pypi.org/pypi/google-genai/json |
+| `autogen-agentchat` latest stable is 0.7.5 | https://pypi.org/pypi/autogen-agentchat/json |
+| `langchain` latest stable is 1.2.17 | https://pypi.org/pypi/langchain/json |
+| `langgraph` latest stable is 1.1.10 | https://pypi.org/pypi/langgraph/json |
+| `groq` latest stable is 1.2.0 | https://pypi.org/pypi/groq/json |
+| `mistralai` latest stable is 2.4.4 | https://pypi.org/pypi/mistralai/json |
+| `crewai` latest stable is 1.14.4 | https://pypi.org/pypi/crewai/json |
+| `llama-index-core` latest stable is 0.14.21 | https://pypi.org/pypi/llama-index-core/json |
+| AF no releases beyond 1.2.2 | https://github.com/microsoft/agent-framework/releases |
+| `claude-sonnet-4-20250514` deprecated, retiring 15 Jun 2026 | https://platform.claude.com/docs/en/docs/about-claude/models |
+| `claude-opus-4-7` does not support extended thinking | https://platform.claude.com/docs/en/docs/about-claude/models |
+| `gemini-2.0-flash` deprecated, shutdown imminent | https://ai.google.dev/gemini-api/docs/models |
+| `gemini-2.5-flash` is the recommended replacement | https://ai.google.dev/gemini-api/docs/models |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (May 2026 Modernisation Audit)
+
+- **`README.md`**: Updated deprecated model identifiers in quick-start examples:
+  `claude-sonnet-4-20250514` → `claude-sonnet-4-6` (retiring 15 June 2026);
+  `gemini-2.0-flash` → `gemini-2.5-flash` (deprecated; service shutdown imminent).
+  *Source: https://platform.claude.com/docs/en/docs/about-claude/models,
+  https://ai.google.dev/gemini-api/docs/models*
+  *Risk: none — documentation only.*
+
+- **`docs/reference/llm_sdk_compatibility.md`**:
+  - OpenRouter section: corrected `pip install openai>=1.0.0` → `>=2.33.0` (missed
+    in April 2026 audit).
+  - Tool Format Conversion → Anthropic: replaced deprecated manual
+    `to_anthropic_tools()` helper with the canonical `to_dialect("anthropic")`
+    pattern (appendix section was missed in April 2026 audit).
+  - Tool Format Conversion → Vertex AI and the Vertex AI integration example:
+    now use `to_dialect("gemini")` + `**`-unpacking into `FunctionDeclaration`,
+    eliminating the indirect two-step conversion from OpenAI format.
+
+### Changed (May 2026 Modernisation Audit)
+
+- **Dependency: `google-genai` floor bumped to `>=1.74.0`** (was `>=1.0.0`). The
+  previous floor was 74 minor versions behind the latest stable release (1.74.0).
+  Bumping ensures constrained resolver environments select a supported SDK version.
+  The `client.aio.models.generate_content` API used by `LLMClient` is stable.
+  *Risk: safe internal — no API changes required.*
+
+- **Dependency: `langchain` floor bumped to `>=1.2.17`** (was `>=1.2.16`). Minor
+  patch release. *Risk: safe internal.*
+
+### Documentation (May 2026 Modernisation Audit)
+
+- **`agent_gantry/integrations/anthropic_features.py`**: Clarified that
+  `claude-opus-4-7` does **not** support extended thinking (only adaptive thinking).
+  Updated `AnthropicFeatures`, `AnthropicClient`, and `create_anthropic_client`
+  docstrings accordingly.
+  *Source: https://platform.claude.com/docs/en/docs/about-claude/models*
+
 ### Fixed
 
 - **Cross-event-loop failures with `DurableAIAgentWorker` and similar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,37 +7,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed (May 2026 Modernisation Audit)
+### Added
 
-- **`README.md`**: Updated deprecated model identifiers in quick-start examples:
-  `claude-sonnet-4-20250514` → `claude-sonnet-4-6` (retiring 15 June 2026);
-  `gemini-2.0-flash` → `gemini-2.5-flash` (deprecated; service shutdown imminent).
-  *Source: https://platform.claude.com/docs/en/docs/about-claude/models,
-  https://ai.google.dev/gemini-api/docs/models*
-  *Risk: none — documentation only.*
+- **`agent_gantry.query` module** — built-in deterministic query-generation
+  strategies for semantic retrieval: `last_user_text` (default),
+  `last_assistant_text`, `last_tool_result`, `concatenate_recent`, and
+  `fallback_chain`. Strategies operate on AF messages, dicts, or anything
+  exposing `role` + `text`/`content`.
+- **`GantryContextProvider` per-call retrieval** — new
+  `query_strategy="per_call"` (default `"per_run"` is back-compat) plus
+  `query_generator=...` parameter for per-chat-round semantic refresh.
+  `provider.as_chat_middleware()` returns the AF chat middleware that wires
+  the per-round refresh into `Agent(middleware=[...])`. Solves the
+  "tool selection is fixed for the whole `agent.run()`" limitation flagged
+  by integrators of multi-step workflows.
+- **`required=[...]` parameter on `GantryContextProvider`** — hard pins a
+  set of tools and raises `MissingRequiredToolError` at construction time
+  if any are missing from the gantry. Catches typos / dropped registrations
+  earlier than runtime agent failure.
+- **Public read-only properties on `GantryContextProvider`** — `top_k`,
+  `score_threshold`, `query_strategy`, `always_include`, `required`,
+  `gantry`, `bridge`. External observability code can read configuration
+  without poking at private attributes.
+- **`AgentGantry.preview(query, ...)`** — read-only ranking helper that
+  returns `(qualified_name, score)` pairs, useful for calibrating
+  `score_threshold` without spinning up an agent.
+- **`AgentGantry.list_tools_sync()`** — sync, in-memory inspection of
+  registered tools (no `await`, no vector store round-trip). Complements
+  the existing async `list_tools()`.
+- **`agent_gantry.adapters.embedders` re-exports `SentenceTransformersEmbedder`,
+  `OpenAIEmbedder`, `AzureOpenAIEmbedder`** alongside `NomicEmbedder` and
+  `SimpleEmbedder`, all behind lazy imports — you can write
+  `from agent_gantry.adapters.embedders import SentenceTransformersEmbedder`
+  without knowing the deep submodule path. Same pattern applied to
+  `agent_gantry.adapters.rerankers` (`CohereReranker`, `CrossEncoderReranker`).
+- **Tests** — `tests/test_query_strategies.py` covers the new query module,
+  `preview`, `list_tools_sync`, the `SimpleEmbedder` warning, FunctionTool
+  registration, and adapter re-exports.
 
-- **`docs/reference/llm_sdk_compatibility.md`**:
-  - OpenRouter section: corrected `pip install openai>=1.0.0` → `>=2.33.0` (missed
-    in April 2026 audit).
-  - Tool Format Conversion → Anthropic: replaced deprecated manual
-    `to_anthropic_tools()` helper with the canonical `to_dialect("anthropic")`
-    pattern (appendix section was missed in April 2026 audit).
-  - Tool Format Conversion → Vertex AI and the Vertex AI integration example:
-    now use `to_dialect("gemini")` + `**`-unpacking into `FunctionDeclaration`,
-    eliminating the indirect two-step conversion from OpenAI format.
-
-### Changed (May 2026 Modernisation Audit)
+### Changed
 
 - **Dependency: `google-genai` floor bumped to `>=1.74.0`** (was `>=1.0.0`). The
   previous floor was 74 minor versions behind the latest stable release (1.74.0).
   Bumping ensures constrained resolver environments select a supported SDK version.
   The `client.aio.models.generate_content` API used by `LLMClient` is stable.
   *Risk: safe internal — no API changes required.*
-
 - **Dependency: `langchain` floor bumped to `>=1.2.17`** (was `>=1.2.16`). Minor
   patch release. *Risk: safe internal.*
+- **`AgentGantry.register()` now accepts `agent_framework.tool`-decorated
+  FunctionTool objects** (or any wrapper exposing `.name` / `.func`).
+  Previously raised `AttributeError: 'FunctionTool' object has no attribute
+  '__name__'`. Bare callables continue to work unchanged.
+- **`SimpleEmbedder` warns when paired with `score_threshold > 0.0`** —
+  hash-based similarity scores cluster tightly regardless of relevance, so
+  a non-zero threshold typically returns 0 tools silently. The first
+  retrieval call now emits a `UserWarning` recommending a real embedder.
+- **`SimpleEmbedder` docstring** updated to lead with "for testing only —
+  produces near-uniform similarity scores", to make its non-production
+  nature obvious from `help(SimpleEmbedder)`.
+- **`EmbeddingAdapter` docstring** corrected: lists actual implementations
+  (`SimpleEmbedder`, `NomicEmbedder`, `SentenceTransformersEmbedder`,
+  `OpenAIEmbedder`, `AzureOpenAIEmbedder`) instead of the old typo'd
+  `SentenceTransformerEmbedder` (singular).
+- **`SentenceTransformersEmbedder` no longer triggers a `FutureWarning`**
+  on first init — calls `get_embedding_dimension()` when available and
+  falls back to the deprecated `get_sentence_embedding_dimension()` only
+  on older releases.
 
-### Documentation (May 2026 Modernisation Audit)
+### Documentation
 
 - **`agent_gantry/integrations/anthropic_features.py`**: Clarified that
   `claude-opus-4-7` does **not** support extended thinking (only adaptive thinking).
@@ -47,6 +84,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`README.md`**: Updated deprecated model identifiers in quick-start examples:
+  `claude-sonnet-4-20250514` → `claude-sonnet-4-6` (retiring 15 June 2026);
+  `gemini-2.0-flash` → `gemini-2.5-flash` (deprecated; service shutdown imminent).
+  *Source: https://platform.claude.com/docs/en/docs/about-claude/models,
+  https://ai.google.dev/gemini-api/docs/models*
+  *Risk: none — documentation only.*
+- **`docs/reference/llm_sdk_compatibility.md`**:
+  - OpenRouter section: corrected `pip install openai>=1.0.0` → `>=2.33.0` (missed
+    in April 2026 audit).
+  - Tool Format Conversion → Anthropic: replaced deprecated manual
+    `to_anthropic_tools()` helper with the canonical `to_dialect("anthropic")`
+    pattern (appendix section was missed in April 2026 audit).
+  - Tool Format Conversion → Vertex AI and the Vertex AI integration example:
+    now use `to_dialect("gemini")` + `**`-unpacking into `FunctionDeclaration`,
+    eliminating the indirect two-step conversion from OpenAI format.
 - **Cross-event-loop failures with `DurableAIAgentWorker` and similar
   worker-thread loops.** When a gantry was constructed in one context
   (often module import time) and then driven from a different event
@@ -95,66 +147,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   worker-thread execution; and worker-thread → main-thread
   sequencing. Tools are pre-resolved once at "module load" via
   :class:`GantryToolBridge`, mirroring the integrator pattern.
-
-### Added
-
-- **`agent_gantry.query` module** — built-in deterministic query-generation
-  strategies for semantic retrieval: `last_user_text` (default),
-  `last_assistant_text`, `last_tool_result`, `concatenate_recent`, and
-  `fallback_chain`. Strategies operate on AF messages, dicts, or anything
-  exposing `role` + `text`/`content`.
-- **`GantryContextProvider` per-call retrieval** — new
-  `query_strategy="per_call"` (default `"per_run"` is back-compat) plus
-  `query_generator=...` parameter for per-chat-round semantic refresh.
-  `provider.as_chat_middleware()` returns the AF chat middleware that wires
-  the per-round refresh into `Agent(middleware=[...])`. Solves the
-  "tool selection is fixed for the whole `agent.run()`" limitation flagged
-  by integrators of multi-step workflows.
-- **`required=[...]` parameter on `GantryContextProvider`** — hard pins a
-  set of tools and raises `MissingRequiredToolError` at construction time
-  if any are missing from the gantry. Catches typos / dropped registrations
-  earlier than runtime agent failure.
-- **Public read-only properties on `GantryContextProvider`** — `top_k`,
-  `score_threshold`, `query_strategy`, `always_include`, `required`,
-  `gantry`, `bridge`. External observability code can read configuration
-  without poking at private attributes.
-- **`AgentGantry.preview(query, ...)`** — read-only ranking helper that
-  returns `(qualified_name, score)` pairs, useful for calibrating
-  `score_threshold` without spinning up an agent.
-- **`AgentGantry.list_tools_sync()`** — sync, in-memory inspection of
-  registered tools (no `await`, no vector store round-trip). Complements
-  the existing async `list_tools()`.
-- **`agent_gantry.adapters.embedders` re-exports `SentenceTransformersEmbedder`,
-  `OpenAIEmbedder`, `AzureOpenAIEmbedder`** alongside `NomicEmbedder` and
-  `SimpleEmbedder`, all behind lazy imports — you can write
-  `from agent_gantry.adapters.embedders import SentenceTransformersEmbedder`
-  without knowing the deep submodule path. Same pattern applied to
-  `agent_gantry.adapters.rerankers` (`CohereReranker`, `CrossEncoderReranker`).
-- **Tests** — `tests/test_query_strategies.py` covers the new query module,
-  `preview`, `list_tools_sync`, the `SimpleEmbedder` warning, FunctionTool
-  registration, and adapter re-exports.
-
-### Changed
-
-- **`AgentGantry.register()` now accepts `agent_framework.tool`-decorated
-  FunctionTool objects** (or any wrapper exposing `.name` / `.func`).
-  Previously raised `AttributeError: 'FunctionTool' object has no attribute
-  '__name__'`. Bare callables continue to work unchanged.
-- **`SimpleEmbedder` warns when paired with `score_threshold > 0.0`** —
-  hash-based similarity scores cluster tightly regardless of relevance, so
-  a non-zero threshold typically returns 0 tools silently. The first
-  retrieval call now emits a `UserWarning` recommending a real embedder.
-- **`SimpleEmbedder` docstring** updated to lead with "for testing only —
-  produces near-uniform similarity scores", to make its non-production
-  nature obvious from `help(SimpleEmbedder)`.
-- **`EmbeddingAdapter` docstring** corrected: lists actual implementations
-  (`SimpleEmbedder`, `NomicEmbedder`, `SentenceTransformersEmbedder`,
-  `OpenAIEmbedder`, `AzureOpenAIEmbedder`) instead of the old typo'd
-  `SentenceTransformerEmbedder` (singular).
-- **`SentenceTransformersEmbedder` no longer triggers a `FutureWarning`**
-  on first init — calls `get_embedding_dimension()` when available and
-  falls back to the deprecated `get_sentence_embedding_dimension()` only
-  on older releases.
 
 ## [0.2.0] - 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ client = AsyncAnthropic()
 @with_semantic_tools(dialect="anthropic", limit=3)
 async def chat(messages, *, tools=None):
     return await client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-4-6",
         messages=messages,
         tools=tools,  # Automatically converted to Anthropic format
         max_tokens=1024
@@ -219,7 +219,7 @@ client = genai.Client()
 @with_semantic_tools(dialect="gemini", limit=3)
 async def chat(prompt, *, tools=None):
     return client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=prompt,
         tools=tools  # Automatically converted to Gemini format
     )

--- a/agent_gantry/integrations/anthropic_features.py
+++ b/agent_gantry/integrations/anthropic_features.py
@@ -29,10 +29,15 @@ class AnthropicFeatures:
     """Configuration for Anthropic beta features."""
 
     enable_interleaved_thinking: bool = False
+    # Extended thinking: fixed budget via budget_tokens. Not supported on claude-opus-4-7
+    # (which only supports adaptive thinking). Supported on claude-sonnet-4-6,
+    # claude-opus-4-6, claude-haiku-4-5, and earlier Claude 4 models.
+    # Source: https://platform.claude.com/docs/en/docs/about-claude/models
     enable_extended_thinking: bool = False
     thinking_budget_tokens: int | None = None
-    # Adaptive thinking: model self-regulates depth; recommended for Opus 4.6+, Sonnet 4.6+,
-    # Opus 4.7. Mutually exclusive with enable_extended_thinking.
+    # Adaptive thinking: model self-regulates depth; recommended for Opus 4.7, Opus 4.6+,
+    # Sonnet 4.6+. Not available on claude-haiku-4-5.
+    # Mutually exclusive with enable_extended_thinking.
     adaptive_thinking_effort: Literal["low", "medium", "high"] | None = None
     # Controls whether thinking blocks appear in the response content.
     # "summarized" — thinking is condensed; "omitted" — thinking is hidden but its
@@ -49,12 +54,13 @@ class AnthropicClient:
     - Interleaved thinking (``interleaved-thinking-2025-05-14`` beta header; required for
       Opus 4.5 / Sonnet 4.5 and earlier Claude 4 models; silently ignored on Opus 4.6+,
       Sonnet 4.6+, and Opus 4.7 where adaptive thinking is automatic)
-    - Extended thinking (``thinking={type: "enabled", budget_tokens: N}`` in the request
-      body; no beta header required on any current model)
+    - Extended thinking (``thinking={type: "enabled", budget_tokens: N}``; supported on
+      claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5, and earlier Claude 4 models;
+      **not supported on claude-opus-4-7** — use adaptive thinking instead)
     - Adaptive thinking (``thinking={type: "adaptive", effort: "medium"}``; recommended
-      for Opus 4.6+, Sonnet 4.6+, Opus 4.7; set ``adaptive_thinking_effort`` in
-      ``AnthropicFeatures`` or use ``enable_thinking="adaptive"`` in
-      ``create_anthropic_client``)
+      for claude-opus-4-7, claude-opus-4-6, claude-sonnet-4-6; not available on
+      claude-haiku-4-5; set ``adaptive_thinking_effort`` in ``AnthropicFeatures`` or use
+      ``enable_thinking="adaptive"`` in ``create_anthropic_client``)
     - Automatic tool retrieval and execution
     """
 
@@ -294,9 +300,9 @@ async def create_anthropic_client(
         api_key: Anthropic API key
         gantry: AgentGantry instance
         enable_thinking: Type of thinking to enable — ``"interleaved"`` (beta header, pre-4.6
-            models), ``"extended"`` (fixed budget via ``thinking_budget_tokens``), or
-            ``"adaptive"`` (model self-regulates depth; recommended for Opus 4.6+, Sonnet 4.6+,
-            Opus 4.7)
+            models), ``"extended"`` (fixed budget via ``thinking_budget_tokens``; not supported
+            on claude-opus-4-7), or ``"adaptive"`` (model self-regulates depth; supported on
+            claude-opus-4-7, claude-opus-4-6, claude-sonnet-4-6; recommended for Opus 4.7+)
         thinking_budget_tokens: Budget for extended thinking (ignored for other modes)
         adaptive_effort: Effort level for adaptive thinking — ``"low"``, ``"medium"`` (default),
             or ``"high"`` (ignored unless ``enable_thinking="adaptive"``)

--- a/docs/reference/llm_sdk_compatibility.md
+++ b/docs/reference/llm_sdk_compatibility.md
@@ -477,17 +477,15 @@ def get_stock_price(symbol: str) -> str:
 
 await gantry.sync()
 
-# Retrieve tools and convert for Vertex AI
-openai_tools = await gantry.retrieve_tools("stock price")
+# Retrieve tools in Gemini format and unpack directly into FunctionDeclaration.
+from agent_gantry.schema.query import ConversationContext, ToolQuery
 
-# Convert to Vertex AI FunctionDeclaration format
+retrieval = await gantry.retrieve(
+    ToolQuery(context=ConversationContext(query="stock price"), limit=5)
+)
 vertex_functions = [
-    FunctionDeclaration(
-        name=tool["function"]["name"],
-        description=tool["function"]["description"],
-        parameters=tool["function"]["parameters"]
-    )
-    for tool in openai_tools
+    FunctionDeclaration(**t.tool.to_dialect("gemini"))
+    for t in retrieval.tools
 ]
 
 model = GenerativeModel(
@@ -643,7 +641,7 @@ OpenRouter and other OpenAI-compatible providers (DeepSeek, Perplexity, Together
 
 ### Package
 ```bash
-pip install openai>=1.0.0
+pip install openai>=2.33.0
 ```
 
 ### Client Initialization
@@ -767,30 +765,30 @@ tools = await gantry.retrieve_tools("query", dialect="openai_responses")
 
 ### Anthropic Format
 ```python
-def to_anthropic_tools(openai_tools):
-    return [
-        {
-            "name": tool["function"]["name"],
-            "description": tool["function"]["description"],
-            "input_schema": tool["function"]["parameters"]
-        }
-        for tool in openai_tools
-    ]
+# Use Agent-Gantry's built-in dialect converter — avoids manual field-mapping errors.
+from agent_gantry.schema.query import ConversationContext, ToolQuery
+
+retrieval = await gantry.retrieve(
+    ToolQuery(context=ConversationContext(query="your query"), limit=5)
+)
+anthropic_tools = [t.tool.to_dialect("anthropic") for t in retrieval.tools]
+# Each entry: {"name": "...", "description": "...", "input_schema": {...}}
 ```
 
 ### Vertex AI Format
 ```python
 from vertexai.generative_models import FunctionDeclaration
+from agent_gantry.schema.query import ConversationContext, ToolQuery
 
-def to_vertex_functions(openai_tools):
-    return [
-        FunctionDeclaration(
-            name=tool["function"]["name"],
-            description=tool["function"]["description"],
-            parameters=tool["function"]["parameters"]
-        )
-        for tool in openai_tools
-    ]
+retrieval = await gantry.retrieve(
+    ToolQuery(context=ConversationContext(query="your query"), limit=5)
+)
+# to_dialect("gemini") returns {"name": ..., "description": ..., "parameters": ...}
+# which maps directly onto FunctionDeclaration's constructor.
+vertex_functions = [
+    FunctionDeclaration(**t.tool.to_dialect("gemini"))
+    for t in retrieval.tools
+]
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ agent-frameworks = [
     # introduces the incompatibility. To use crewai>=1.12.0, install it in a
     # separate environment without agent-framework.
     "crewai>=1.6.1",
-    "langchain>=1.2.16",
+    "langchain>=1.2.17",
     "langchain-openai>=1.2.1",
     "langgraph>=1.1.10",
     "llama-index-core>=0.14.21",
@@ -150,7 +150,7 @@ anthropic = [
     "anthropic>=0.97.0",
 ]
 google-genai = [
-    "google-genai>=1.0.0",
+    "google-genai>=1.74.0",
 ]
 google-vertexai = [
     "google-cloud-aiplatform>=1.70.0",

--- a/uv.lock
+++ b/uv.lock
@@ -664,13 +664,13 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'a2a'", specifier = ">=0.104.0" },
     { name = "google-adk", marker = "extra == 'agent-frameworks'", specifier = ">=1.14.1" },
     { name = "google-cloud-aiplatform", marker = "extra == 'google-vertexai'", specifier = ">=1.70.0" },
-    { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=1.0.0" },
+    { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=1.74.0" },
     { name = "groq", marker = "extra == 'groq'", specifier = ">=1.2.0" },
     { name = "httpx", marker = "extra == 'a2a'", specifier = ">=0.24.0" },
     { name = "huggingface-hub", extras = ["hf-xet"], marker = "extra == 'example-tools'", specifier = ">=0.36.0" },
     { name = "jsonschema", specifier = ">=4.18.0" },
     { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.4.0" },
-    { name = "langchain", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.16" },
+    { name = "langchain", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.17" },
     { name = "langchain-openai", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.1" },
     { name = "langgraph", marker = "extra == 'agent-frameworks'", specifier = ">=1.1.10" },
     { name = "llama-index-core", marker = "extra == 'agent-frameworks'", specifier = ">=0.14.21" },
@@ -2949,7 +2949,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.73.0"
+version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2963,9 +2963,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/5f/b293b1a78a547b0dd061642a3f6087f0a52c1b723eafa58f94ccdc3e0d2a/google_genai-1.73.0.tar.gz", hash = "sha256:569395b2c225e12bcd8758b8affe1af480e0a1b1c71d652d38c705677057e05f", size = 530812, upload-time = "2026-04-13T20:40:02.642Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/c8/4a8f1de0a3268d526a345b8c74456b3e1e6ffd200982626326cf7ca83e5b/google_genai-1.74.0.tar.gz", hash = "sha256:c4c473cebdeb6e5adbb0639326de66a3a85a2209e0d32de7d66bf05c698abae8", size = 536772, upload-time = "2026-04-29T22:16:35.881Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/73/fb36ced456688c9b95a8ab49a1f408f5b3e69a589788f3eb25016002dd7a/google_genai-1.73.0-py3-none-any.whl", hash = "sha256:dfb0214b834bf977e3841de512cfb651d2fe76309f85064b80c2bc11da99d76b", size = 786072, upload-time = "2026-04-13T20:40:00.365Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/2b/539c328b66f7bfef2df869371a1789361228e5a7694ba02a642608367b46/google_genai-1.74.0-py3-none-any.whl", hash = "sha256:87d0b311c67d4b2a0ca741e9fc6891330c29defae81d46d8db41079aa1a3d80a", size = 790433, upload-time = "2026-04-29T22:16:33.979Z" },
 ]
 
 [[package]]
@@ -3820,16 +3820,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.16"
+version = "1.2.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/34/47318136a1995aed51455a243db135eb244c5af97a9f5232f5f5f505da21/langchain-1.2.16.tar.gz", hash = "sha256:8a091122418a2b2ea12cf2a4ddc47f51012ee5ec3f9a93b5f351eeb8d1bc9c70", size = 577003, upload-time = "2026-04-29T21:02:44.666Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/35/322d13339acb61d7a733d03a73a9ade968c64ac0eb982f497d24e22a998f/langchain-1.2.17.tar.gz", hash = "sha256:c30b578c0eebbde8bec9247dbbbae1a791128557b99b65c8be1e007040975d09", size = 577779, upload-time = "2026-04-30T20:25:34.626Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/0c/1cafab69a16b7d949b71bde9b5ea8e7bfd5ad082718389bb47a2284e3787/langchain-1.2.16-py3-none-any.whl", hash = "sha256:d2cef7452fe54a12d587dbac93daf37b7bbfde0719e8a47a79fe576e1411c28c", size = 112903, upload-time = "2026-04-29T21:02:42.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/b183dba8667f7b6d1be546fb8089a3bc3bc12b514f551f5317ae03815770/langchain-1.2.17-py3-none-any.whl", hash = "sha256:ff881cdfbe90e0b6afac42eea7999657c282cc73db059c910d803f4e9f8ff305", size = 113131, upload-time = "2026-04-30T20:25:32.895Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This commit applies fixes from the May 2026 modernisation audit, addressing five must-change-now issues and three good-next-step improvements. The primary focus is correcting deprecated LLM model identifiers in live code examples and updating documentation to reflect current provider APIs and best practices.

## Key Changes

### Critical Fixes (Breaking Changes Prevented)
- **README.md**: Updated `claude-sonnet-4-20250514` → `claude-sonnet-4-6` (retiring 15 June 2026)
- **README.md**: Updated `gemini-2.0-flash` → `gemini-2.5-flash` (deprecated; shutdown imminent)
- **pyproject.toml**: Bumped `google-genai` floor from `>=1.0.0` to `>=1.74.0` (was 74 minor versions behind latest stable)

### Documentation Corrections
- **docs/reference/llm_sdk_compatibility.md**:
  - OpenRouter section: corrected `pip install openai>=1.0.0` → `>=2.33.0` (missed in April 2026 audit)
  - Tool Format Conversion → Anthropic: replaced deprecated manual `to_anthropic_tools()` helper with canonical `to_dialect("anthropic")` pattern
  - Tool Format Conversion → Vertex AI: updated to use `to_dialect("gemini")` + `**`-unpacking into `FunctionDeclaration`, eliminating indirect two-step conversion from OpenAI format
  - Vertex AI integration example: same pattern update for consistency

### Dependency Updates
- **pyproject.toml**: Bumped `langchain` floor from `>=1.2.16` to `>=1.2.17` (minor patch)

### Docstring Improvements
- **agent_gantry/integrations/anthropic_features.py**:
  - Clarified that `claude-opus-4-7` does **not** support extended thinking (only adaptive thinking)
  - Updated `AnthropicFeatures`, `AnthropicClient`, and `create_anthropic_client` docstrings with current model compatibility matrix
  - Added explicit warnings to prevent API errors when users attempt extended thinking on unsupported models

## Implementation Details

All changes are documentation-level or docstring-level with no functional code modifications. The tool dialect conversion patterns (`to_dialect()`) were already implemented; this commit standardizes their usage in examples and removes deprecated manual conversion helpers. The dependency floor bumps ensure constrained resolver environments select supported SDK versions without requiring API changes in the codebase.

**Risk Assessment**: Safe internal changes. No breaking changes to the public API or integration contracts.

https://claude.ai/code/session_01EQCtNFs5211jmbPdefmFTR