### PR TITLE
🎨 Palette: Improve search keyboard shortcut and OS awareness

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2026-05-01 - [Semantic Context for Dynamic Navigation Links]
 **Learning:** Dynamically applying visual `.active` classes to navigation items via client-side JavaScript leaves screen readers oblivious to the active state. Users relying on assistive technology will not know which link represents their current page if only visual classes are modified.
 **Action:** When conditionally applying an `.active` class to indicate the current page or step, consistently apply `link.setAttribute("aria-current", "page")` simultaneously, and ensure you `removeAttribute("aria-current")` when the active state is removed.
+
+## 2026-05-02 - [Keyboard Shortcuts Accessibility & OS Awareness]
+**Learning:** Displaying hardcoded OS-specific keyboard shortcuts (like "Ctrl+K") in placeholders confuses Mac users, who expect "⌘K". Additionally, mapping common single-key shortcuts like "/" for search focus requires careful event handling to avoid intercepting the key when the user is already typing in an input field.
+**Action:** When adding keyboard shortcuts for quick focus or actions, dynamically update visual hints (like placeholders) based on `navigator.userAgent.includes("Mac")`. Furthermore, always check `e.target.tagName` against `"INPUT"`, `"TEXTAREA"`, and `e.target.isContentEditable` before intercepting single-key shortcuts like "/".

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -211,11 +211,25 @@
   // ==================== Keyboard Shortcuts ====================
 
   function initKeyboardShortcuts() {
+    const searchInput = document.querySelector(".search-input");
+
+    // Update placeholder with OS-aware shortcut
+    if (searchInput) {
+      const isMac = navigator.userAgent.includes("Mac");
+      searchInput.placeholder = `Search documentation... (${isMac ? "⌘" : "Ctrl+"}K)`;
+    }
+
     document.addEventListener("keydown", function (e) {
-      // Cmd/Ctrl + K to focus search
-      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      // Cmd/Ctrl + K or / to focus search
+      const isFocusShortcut = ((e.metaKey || e.ctrlKey) && e.key === "k") || e.key === "/";
+
+      if (isFocusShortcut) {
+        // Prevent '/' from being intercepted if user is already typing in an input
+        if (e.key === "/" && (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA" || e.target.isContentEditable)) {
+          return;
+        }
+
         e.preventDefault();
-        const searchInput = document.querySelector(".search-input");
         if (searchInput) {
           searchInput.focus();
         }


### PR DESCRIPTION
💡 **What:** Added the `/` keyboard shortcut to focus the search bar and made the placeholder OS-aware (displays `⌘K` for Mac users, `Ctrl+K` for others).
🎯 **Why:** The `/` key is a standard web shortcut for search, reducing friction. Showing `Ctrl+K` to Mac users is confusing, so adapting the hint based on `navigator.userAgent` improves micro-UX.
📸 **Before/After:** See the attached screenshot for the updated `⌘K` placeholder in Mac environments.
♿ **Accessibility:** N/A (General UX improvement). Improved keyboard usability for all power users.

---
*PR created automatically by Jules for task [8635807334107744801](https://jules.google.com/task/8635807334107744801) started by @CodeHalwell*