### PR TITLE
docs: fix stale model names and SDK version pins

### DIFF
--- a/AUDIT_2026-05-02.md
+++ b/AUDIT_2026-05-02.md
@@ -1,0 +1,363 @@
+# Agent-Gantry Modernisation Audit — 2 May 2026
+
+**Auditor**: Claude (Sonnet 4.6) operating as repository maintainer  
+**Branch**: `claude/elegant-clarke-KJByb`  
+**Date**: 2026-05-02  
+**Scope**: Full compatibility and modernisation audit against latest stable LLM provider SDKs, provider API standards, and agent framework patterns. Incremental over the May 2026 audit (merged PR #154, branch `claude/elegant-clarke-CJu56`, 2026-05-01).
+
+---
+
+## 1. Executive Summary
+
+The repository is in excellent health following the April and May 2026 audits. This follow-up audit (one day after the May audit) identified **three must-change-now documentation inconsistencies** and **four good-next-step improvements**. No live code changes are required; all necessary code changes were made in previous audits. The three documentation fixes are applied in this commit.
+
+### Must-Change Now (All Applied in This Commit)
+
+| # | Finding | Files Affected | Risk |
+|---|---------|---------------|------|
+| 1 | `docs/reference/llm_sdk_compatibility.md` Google GenAI install snippet still pins `>=1.0.0` after `pyproject.toml` was bumped to `>=1.74.0` in the May 2026 audit — documentation inconsistency | `docs/reference/llm_sdk_compatibility.md` | Documentation error |
+| 2 | `docs/reference/llm_sdk_compatibility.md` Mistral install snippet shows `>=1.0.0` without the `<2.0.0` upper bound intentionally enforced in `pyproject.toml` — could mislead users into installing 2.x, which requires the pending async context-manager refactor | `docs/reference/llm_sdk_compatibility.md` | Documentation error (may cause a breaking installation for uninitiated users) |
+| 3 | `README.md` line 317: `model="gpt-4"` in the module-loading code example — all other README examples correctly use `gpt-4o`; this stale reference is inconsistent and points to a legacy model | `README.md` | Documentation quality — stale model name |
+
+**Status**: All three are fixed in this commit.
+
+### Good Next-Step Improvements
+
+| # | Finding | Files Affected |
+|---|---------|---------------|
+| 4 | `docs/reference/llm_sdk_compatibility.md` line 674 OpenRouter example uses `"anthropic/claude-sonnet-4"` — the current recommended Anthropic model on OpenRouter follows the same ID convention as the direct Anthropic API (`anthropic/claude-sonnet-4-6`). **Needs confirmation** against live OpenRouter catalogue before changing | `docs/reference/llm_sdk_compatibility.md` |
+| 5 | `google-adk` floor at `>=1.14.1`; latest stable released 2026-05-01 is `1.32.0`. The lock file resolves to `1.14.1`. Bumping is blocked by the same opentelemetry-api conflict as `crewai` on Python 3.13/Windows (documented in `pyproject.toml`) | `pyproject.toml` |
+| 6 | `semantic-kernel` floor at `>=1.30.0`; lock file resolves to `1.36.0`; latest stable is `1.41.3`. The floor is stale relative to the resolved version — bump the floor to `>=1.36.0` to at least match the lock | `pyproject.toml` |
+| 7 | Mistral 2.x migration remains pending — `LLMClient` needs restructuring to per-call `async with Mistral(...) as client:` (tracked since April 2026 audit) | `agent_gantry/adapters/llm_client.py`, `pyproject.toml` |
+
+**Status**: Items 4–7 are deferred. Item 4 requires live OpenRouter catalogue verification before any change. Items 5–6 require standalone-environment conflict testing. Item 7 is a pre-existing planned sprint.
+
+---
+
+## 2. Dependency Upgrade Plan
+
+### Packages Changed in This Audit
+
+No `pyproject.toml` or `uv.lock` changes in this audit. All documentation-only.
+
+### Full Package Status Table (as of 2026-05-02)
+
+All versions verified against PyPI JSON API (`https://pypi.org/pypi/{package}/json`).
+
+| Package | pyproject.toml pin | uv.lock resolved | Latest stable | Status |
+|---------|-------------------|-----------------|--------------|--------|
+| `agent-framework` | `>=1.2.2,<2.0.0` | 1.2.2 | 1.2.2 | ✅ Current |
+| `openai` | `>=2.33.0` | 2.33.0 | 2.33.0 | ✅ Current |
+| `anthropic` | `>=0.97.0` | 0.97.0 | 0.97.0 | ✅ Current |
+| `google-genai` | `>=1.74.0` | 1.74.0 | 1.74.0 | ✅ Current |
+| `autogen-agentchat` | `>=0.7.5` | 0.7.5 | 0.7.5 | ✅ Current |
+| `autogen-ext[openai]` | `>=0.7.5` | 0.7.5 | 0.7.5 | ✅ Current |
+| `langchain` | `>=1.2.17` | 1.2.17 | 1.2.17 | ✅ Current |
+| `langchain-openai` | `>=1.2.1` | 1.2.1 | 1.2.1 | ✅ Current |
+| `langgraph` | `>=1.1.10` | 1.1.10 | 1.1.10 | ✅ Current |
+| `llama-index-core` | `>=0.14.21` | 0.14.21 | 0.14.21 | ✅ Current |
+| `llama-index-llms-openai` | `>=0.7.7` | 0.7.7 | 0.7.7 | ✅ Current |
+| `groq` | `>=1.2.0` | 1.2.0 | 1.2.0 | ✅ Current |
+| `mistralai` | `>=1.0.0,<2.0.0` | (1.x series) | 2.4.4 | ⏳ Held — 2.x migration pending |
+| `crewai` | `>=1.6.1` | 1.6.1 | 1.14.4 | ⏳ Held — opentelemetry-api conflict with agent-framework |
+| `google-adk` | `>=1.14.1` | 1.14.1 | **1.32.0** | ⚠️ Floor stale; upgrade blocked by opentelemetry conflict |
+| `semantic-kernel` | `>=1.30.0` | 1.36.0 | **1.41.3** | ⚠️ Floor stale vs lock; upgrade blocked by opentelemetry conflict |
+
+**Sources**: PyPI JSON API for each package.  
+`agent-framework`: https://pypi.org/pypi/agent-framework/json  
+`openai`: https://pypi.org/pypi/openai/json  
+`anthropic`: https://pypi.org/pypi/anthropic/json  
+`google-genai`: https://pypi.org/pypi/google-genai/json  
+`autogen-agentchat`: https://pypi.org/pypi/autogen-agentchat/json  
+`langchain`: https://pypi.org/pypi/langchain/json  
+`langgraph`: https://pypi.org/pypi/langgraph/json  
+`groq`: https://pypi.org/pypi/groq/json  
+`mistralai`: https://pypi.org/pypi/mistralai/json  
+`crewai`: https://pypi.org/pypi/crewai/json  
+`google-adk`: https://pypi.org/pypi/google-adk/json  
+`semantic-kernel`: https://pypi.org/pypi/semantic-kernel/json  
+
+---
+
+## 3. Provider API Refactors
+
+### 3.1 OpenAI
+
+**Status: No action required.**
+
+No Assistants API usage anywhere in the codebase. The Assistants API sunset deadline is 26 August 2026. All call sites use Chat Completions (`client.chat.completions.create`) or the Responses API (`client.responses.create`). Both dialects are covered by `OpenAIAdapter` and `OpenAIResponsesAdapter` in `agent_gantry/adapters/tool_spec/providers.py`.
+
+The one stale model name (`"gpt-4"` in `README.md` line 317) is a documentation-only issue; see §6.1.
+
+**Source**: https://platform.openai.com/docs/api-reference/responses
+
+### 3.2 Anthropic
+
+**Status: No action required.**
+
+All Anthropic call sites use `client.messages.create(...)` with the documented `tools` field and structured content blocks. The `AnthropicAdapter` (`providers.py`) correctly produces:
+
+```python
+{
+    "name": tool.name,
+    "description": tool.description,
+    "input_schema": tool.parameters_schema,
+}
+```
+
+Tool result round-tripping (`format_tool_result`) correctly sets `"type": "tool_result"`, `"tool_use_id"`, and the optional `"is_error": True` flag.
+
+The extended-thinking / adaptive-thinking compatibility note for `claude-opus-4-7` was fixed in the May 2026 audit and remains correct:
+
+| Model | Extended thinking | Adaptive thinking |
+|-------|:-----------------:|:-----------------:|
+| `claude-opus-4-7` | ❌ | ✅ |
+| `claude-sonnet-4-6` | ✅ | ✅ |
+| `claude-haiku-4-5-20251001` | ✅ | ❌ |
+
+**Source**: https://platform.claude.com/docs/en/docs/about-claude/models/overview
+
+### 3.3 Gemini
+
+**Status: No action required.**
+
+All Gemini call sites use `google-genai` (`google.genai.Client`), `client.aio.models.generate_content`, and `to_dialect("gemini")` with `FunctionDeclaration(**...)` unpacking. The `GeminiAdapter` correctly produces the `functionDeclarations` shape. The `format_tool_result` correctly places the echo `id` inside `functionResponse` per the proto spec.
+
+As of 2026-05-02, the Gemini 3.x preview family exists (`gemini-3.1-pro-preview`, `gemini-3-flash-preview`, etc.) but remains in preview. The stable recommended model is `gemini-2.5-flash`, which is what all examples and the `LLMClient` default use.
+
+**Source**: https://ai.google.dev/gemini-api/docs/models
+
+### 3.4 Mistral
+
+**Status: No code change. Migration plan unchanged.**
+
+`mistralai` remains pinned to `<2.0.0`. Latest stable is 2.4.4. The 2.x context-manager migration is tracked in `pyproject.toml` and `CHANGELOG.md`.
+
+### 3.5 Groq
+
+**Status: No action required.** Already at `>=1.2.0` (latest stable 1.2.0).
+
+---
+
+## 4. Framework Integration Refactors
+
+### 4.1 Microsoft Agent Framework
+
+**Status: No action required — already at latest stable 1.2.2.**
+
+Verified against PyPI: https://pypi.org/pypi/agent-framework/json. No releases beyond 1.2.2.
+
+Full review confirms the AF integration is correct for 1.2.2 across every surface:
+
+- **`GantryToolBridge`** (`agent_framework_bridge.py`): Correctly imports `agent_framework.tool`, `Agent`, `AgentExecutor`, `WorkflowBuilder`, `SequentialBuilder`, `HandoffBuilder`. Lazy AF import pattern is correct. `approval_mode` mapping from `ToolCapability` is correct.
+- **`GantryContextProvider`** (`agent_framework_provider.py`): Correctly subclasses `agent_framework.ContextProvider` dynamically. `before_run` lifecycle hook, `per_call` strategy with `chat_middleware`, `required=[...]` validation — all correct for AF 1.2.
+- **`GantryApprovalMiddleware` / `GantryObservabilityMiddleware`** (`agent_framework_middleware.py`): Correctly falls back from `FunctionMiddleware` to `ChatMiddlewareLayer`. `MiddlewareTermination` usage is correct.
+- **Workflow builders**: `build_sequential_workflow` (→ `SequentialBuilder`), `build_handoff_workflow` (→ `HandoffBuilder`), `build_workflow` (→ `WorkflowBuilder` + `AgentExecutor` + `WorkflowAgent`) — all correct.
+
+No AutoGen-to-MAF migration required. The AG2 (`autogen-agentchat`) integration is maintained as a separate, parallel track (not deprecated by MAF).
+
+### 4.2 AutoGen (AG2)
+
+**Status: No action required.** Already at `>=0.7.5` (latest stable 0.7.5).
+
+`autogen_example.py` correctly uses:
+- `autogen_agentchat.agents.AssistantAgent`
+- `autogen_ext.models.openai.OpenAIChatCompletionClient(model="gpt-4o")`
+- `Console(assistant.run_stream(task=...))`
+
+### 4.3 LangChain / LangGraph
+
+**Status: No action required.**
+
+`langchain` at `>=1.2.17` (latest stable). All framework patterns (`langgraph.prebuilt.create_react_agent`, `ChatOpenAI`, etc.) remain correct. `langgraph` at `>=1.1.10` (latest stable).
+
+### 4.4 CrewAI
+
+**Status: Held at `>=1.6.1` — opentelemetry conflict unchanged.**
+
+Latest is 1.14.4. Upgrading past 1.12.0 requires a separate environment without `agent-framework`. Documented in `pyproject.toml`.
+
+### 4.5 Google ADK
+
+**Status: Held at `>=1.14.1` — opentelemetry conflict.**
+
+`google-adk` 1.32.0 was released on 2026-05-01 (the day before this audit). The lock file resolves to 1.14.1. The `pyproject.toml` comment documents the conflict: `google-adk >= 1.31.1` conflicts with `agent-framework >= 1.2.1` on Python 3.13/Windows. Upgrading requires a standalone environment.
+
+The `google_adk_example.py` correctly uses `google.adk` patterns and `model="gemini-2.5-flash"` — no changes needed.
+
+### 4.6 Semantic Kernel
+
+**Status: Floor outdated — good-next-step improvement.**
+
+`semantic-kernel>=1.30.0` in `pyproject.toml`; `1.36.0` resolved in `uv.lock`; latest stable is `1.41.3`. The floor is 6 versions behind the lock and 11 behind the latest. However, the opentelemetry conflict on some Python/platform splits blocks unconstrained upgrade alongside `agent-framework`. Recommendation: bump the floor to `>=1.36.0` to match the lock (safe internal), but test 1.41.3 in a standalone environment first.
+
+---
+
+## 5. Universal Tool-Calling Design
+
+**Status: No structural changes required.**
+
+The seven-adapter `ToolSpecAdapter` architecture is verified correct:
+
+| Adapter | Dialect | Schema shape | Tool-call ID field | Result round-trip |
+|---------|---------|-------------|-------------------|------------------|
+| `OpenAIAdapter` | `"openai"` | `{type: "function", function: {name, desc, parameters}}` | `payload.id` → `tool_call_id` | `{role: "tool", content, name, tool_call_id}` |
+| `OpenAIResponsesAdapter` | `"openai_responses"` | `{type: "function", name, desc, parameters}` | `payload.call_id` | `{type: "function_call_output", output, call_id}` |
+| `AnthropicAdapter` | `"anthropic"` | `{name, description, input_schema}` | `payload.id` → `tool_use_id` | `{type: "tool_result", content, tool_use_id, is_error?}` |
+| `GeminiAdapter` | `"gemini"` | `{name, description, parameters}` | `payload.id` (parallel calls) | `{functionResponse: {name, response, id?}}` |
+| `MistralAdapter` | `"mistral"` | OpenAI-compatible (inherits) | same as OpenAI | same as OpenAI |
+| `GroqAdapter` | `"groq"` | OpenAI-compatible (inherits) | same as OpenAI | same as OpenAI |
+| `AgentFrameworkAdapter` | `"agent_framework"` | OpenAI-compatible + optional metadata | both OpenAI and AF-internal formats | same as OpenAI |
+
+### ToolSpec contract (existing, verified)
+
+The internal `ToolDefinition` model at `agent_gantry/schema/tool.py` fulfils the provider-agnostic contract:
+
+```python
+class ToolDefinition(BaseModel):
+    name: str           # Validated: ^[a-z][a-z0-9_]*$, max 128 chars
+    description: str    # Min 10, max 2000 chars
+    parameters_schema: dict[str, Any]  # JSON Schema style
+    # ... plus capabilities, cost, health, lifecycle metadata
+```
+
+`to_dialect(dialect)` dispatches through the registry — extensible, tested, and consistent across all seven providers.
+
+**Parallel tool calls**: `GeminiAdapter` correctly echoes `id` inside `functionResponse` for parallel call correlation. `OpenAIResponsesAdapter` uses `call_id` for the same purpose. Both are verified against current provider documentation.
+
+**Sources**:  
+- Anthropic tool use: https://platform.claude.com/docs/en/api/messages  
+- Gemini function calling: https://ai.google.dev/gemini-api/docs/function-calling  
+- OpenAI Responses API: https://platform.openai.com/docs/api-reference/responses  
+
+---
+
+## 6. Documentation and Example Updates
+
+### 6.1 `README.md` — Change Applied
+
+**File**: `README.md`, line 317
+
+```diff
+-            model="gpt-4",
++            model="gpt-4o",
+```
+
+**Rationale**: `gpt-4` is a legacy model. All other README code examples already use `gpt-4o` (lines 91 and 189). This was the only remaining inconsistency. The `gpt-4o` family is the current recommended model for general-purpose usage in OpenAI documentation.  
+**Risk**: Safe internal — documentation only.
+
+### 6.2 `docs/reference/llm_sdk_compatibility.md` — Two Changes Applied
+
+**Change 1**: Google GenAI install snippet (line 338)
+
+```diff
+-pip install google-genai>=1.0.0
++pip install google-genai>=1.74.0
+```
+
+**Rationale**: The `pyproject.toml` floor was bumped to `>=1.74.0` in the May 2026 audit but the corresponding install snippet in this documentation file was missed. The snippet now matches.  
+**Risk**: Safe internal — documentation only.  
+**Source**: https://pypi.org/pypi/google-genai/json
+
+**Change 2**: Mistral install snippet (line 505)
+
+```diff
+-pip install mistralai>=1.0.0
++pip install mistralai>=1.0.0,<2.0.0
+```
+
+**Rationale**: `pyproject.toml` intentionally caps `mistralai` at `<2.0.0` because 2.x requires a per-call `async with Mistral(...) as client:` pattern that `LLMClient` does not yet support. The install snippet did not reflect this upper bound, which could mislead users into installing 2.x and hitting `AttributeError` or `RuntimeError` when `LLMClient.classify_intent()` is called.  
+**Risk**: Safe internal — documentation only. Prevents user confusion.
+
+### 6.3 Items Checked and Not Changed
+
+| File | Finding | Conclusion |
+|------|---------|-----------|
+| `QUICK_REFERENCE.md` | No stale model names or deprecated API patterns | ✅ No change |
+| `examples/agent_frameworks/*.py` | All use current model IDs (`gpt-4o`, `gemini-2.5-flash`) | ✅ No change |
+| `examples/llm_integration/anthropic_demo.py` | Uses `claude-sonnet-4-6` | ✅ No change |
+| `examples/llm_integration/google_genai_demo.py` | Uses `gemini-2.5-flash` | ✅ No change |
+| `examples/llm_integration/openai_demo.py` | Uses `gpt-4.1` and `gpt-4o` | ✅ No change |
+| `agent_gantry/adapters/llm_client.py` | `client.aio.models.generate_content` is stable for `google-genai>=1.74.0` | ✅ No change |
+| `agent_gantry/integrations/anthropic_features.py` | Opus 4.7 extended thinking caveat correctly documented | ✅ No change |
+| `agent_gantry/integrations/agent_framework_bridge.py` | All AF 1.2.2 imports verified | ✅ No change |
+| `agent_gantry/integrations/agent_framework_provider.py` | `GantryContextProvider` logic verified for AF 1.2.2 | ✅ No change |
+| `docs/reference/llm_sdk_compatibility.md` line 674 | OpenRouter `"anthropic/claude-sonnet-4"` — **needs confirmation** against live OpenRouter catalogue before changing | ⚠️ Deferred |
+
+---
+
+## 7. Test and Migration Plan
+
+### 7.1 Tests Recommended
+
+No code-level changes in this audit; existing test suite requires no updates. The following new tests are recommended for completeness:
+
+| Test | File | Priority | Rationale |
+|------|------|----------|-----------|
+| `test_google_genai_install_floor` — assert that `google-genai` resolves to `>=1.74.0` in tests requiring it | `tests/test_llm_sdk_compatibility.py` | Low | Guards against the floor regressing in a future `uv lock --upgrade` |
+| `test_mistral_version_upper_bound` — assert `mistralai.__version__` is `< "2.0.0"` in the installed environment | `tests/test_llm_sdk_compatibility.py` | Low | Catches an inadvertent `<2.0.0` cap removal before it breaks `LLMClient.classify_intent` |
+| `test_openrouter_model_id` — verify the correct OpenRouter Claude model ID once the OpenRouter catalogue is confirmed | `tests/test_llm_sdk_compatibility.py` | Low | Guards against stale OpenRouter model reference in docs |
+
+**No VCR recordings, golden responses, or fixture regeneration** is required for this audit. All changes are documentation-level.
+
+### 7.2 Changelog-Ready Migration Notes
+
+```markdown
+### Fixed
+
+- **`README.md`**: Updated stale `model="gpt-4"` in the module-loading
+  code example to `model="gpt-4o"`, consistent with all other README
+  examples. `gpt-4` is a legacy model; `gpt-4o` is the current
+  recommended general-purpose model.
+  *Risk: none — documentation only.*
+
+- **`docs/reference/llm_sdk_compatibility.md`**:
+  - Google GenAI install snippet: updated `pip install google-genai>=1.0.0`
+    to `>=1.74.0`, matching the `pyproject.toml` floor bumped in the
+    May 2026 audit (the documentation had not been updated in sync).
+  - Mistral install snippet: updated `pip install mistralai>=1.0.0`
+    to `>=1.0.0,<2.0.0`, accurately reflecting the intentional upper
+    bound that prevents the incompatible 2.x series from being installed
+    until the `LLMClient` context-manager migration is complete.
+  *Risk: none — documentation only.*
+```
+
+---
+
+## Must-Change Now (All Applied in This Commit)
+
+1. ✅ **`docs/reference/llm_sdk_compatibility.md` line 338** — `google-genai>=1.0.0` → `>=1.74.0`.
+2. ✅ **`docs/reference/llm_sdk_compatibility.md` line 505** — `mistralai>=1.0.0` → `>=1.0.0,<2.0.0`.
+3. ✅ **`README.md` line 317** — `model="gpt-4"` → `model="gpt-4o"`.
+
+## Good Next-Step Improvements (Deferred)
+
+4. ⚠️ **`docs/reference/llm_sdk_compatibility.md` line 674** — OpenRouter `"anthropic/claude-sonnet-4"` model ID. Needs live catalogue confirmation before changing.
+5. ⏳ **`pyproject.toml`** — `google-adk` floor `>=1.14.1` → `>=1.32.0` (new release 2026-05-01). Blocked by opentelemetry conflict on Python 3.13/Windows with `agent-framework`.
+6. ⏳ **`pyproject.toml`** — `semantic-kernel` floor `>=1.30.0` → `>=1.36.0` (matches lock file). Full upgrade to 1.41.3 blocked by opentelemetry conflict; floor update alone is safe internal.
+7. ⏳ **Mistral 2.x migration** — `LLMClient` restructuring to per-call context manager. Blocked on `<2.0.0` cap until sprint is scheduled.
+
+---
+
+## Appendix — Verification URLs
+
+| Claim | URL Fetched |
+|-------|-------------|
+| `agent-framework` latest stable is 1.2.2 | https://pypi.org/pypi/agent-framework/json |
+| `openai` latest stable is 2.33.0 | https://pypi.org/pypi/openai/json |
+| `anthropic` latest stable is 0.97.0 | https://pypi.org/pypi/anthropic/json |
+| `google-genai` latest stable is 1.74.0 | https://pypi.org/pypi/google-genai/json |
+| `autogen-agentchat` latest stable is 0.7.5 | https://pypi.org/pypi/autogen-agentchat/json |
+| `langchain` latest stable is 1.2.17 | https://pypi.org/pypi/langchain/json |
+| `langchain-openai` latest stable is 1.2.1 | https://pypi.org/pypi/langchain-openai/json |
+| `langgraph` latest stable is 1.1.10 | https://pypi.org/pypi/langgraph/json |
+| `groq` latest stable is 1.2.0 | https://pypi.org/pypi/groq/json |
+| `mistralai` latest stable is 2.4.4 | https://pypi.org/pypi/mistralai/json |
+| `crewai` latest stable is 1.14.4 | https://pypi.org/pypi/crewai/json |
+| `llama-index-core` latest stable is 0.14.21 | https://pypi.org/pypi/llama-index-core/json |
+| `semantic-kernel` latest stable is 1.41.3 | https://pypi.org/pypi/semantic-kernel/json |
+| `google-adk` latest stable is 1.32.0 | https://pypi.org/pypi/google-adk/json |
+| Claude models overview — Opus 4.7, Sonnet 4.6, Haiku 4.5 are current | https://platform.claude.com/docs/en/docs/about-claude/models/overview |
+| Claude Opus 4.7 does not support extended thinking (adaptive only) | https://platform.claude.com/docs/en/docs/about-claude/models/overview |
+| `claude-sonnet-4-20250514` deprecated, retiring 15 Jun 2026 | https://platform.claude.com/docs/en/docs/about-claude/models/overview |
+| Gemini 2.5 Flash is stable recommended; 2.0 Flash is deprecated | https://ai.google.dev/gemini-api/docs/models |

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ async def main():
     @with_semantic_tools(limit=3)
     async def generate(prompt: str, *, tools=None):
         return await client.chat.completions.create(
-            model="gpt-4",
+            model="gpt-4o",
             messages=[{"role": "user", "content": prompt}],
             tools=tools,
         )

--- a/docs/reference/llm_sdk_compatibility.md
+++ b/docs/reference/llm_sdk_compatibility.md
@@ -335,7 +335,7 @@ response = client.messages.create(
 
 ### Package
 ```bash
-pip install google-genai>=1.0.0
+pip install google-genai>=1.74.0
 ```
 
 ### Client Initialization
@@ -502,7 +502,7 @@ response = model.generate_content("What's AAPL stock price?")
 
 ### Package
 ```bash
-pip install mistralai>=1.0.0
+pip install mistralai>=1.0.0,<2.0.0
 ```
 
 ### Client Initialization


### PR DESCRIPTION
## Summary

This PR fixes three documentation inconsistencies identified in the May 2026 audit:

1. **README.md**: Updated stale `gpt-4` model reference to `gpt-4o` for consistency with other examples in the file
2. **llm_sdk_compatibility.md**: Corrected Google GenAI install snippet to match the `pyproject.toml` floor of `>=1.74.0` (was `>=1.0.0`)
3. **llm_sdk_compatibility.md**: Added upper bound `<2.0.0` to Mistral install snippet to prevent users from installing the incompatible 2.x series

## Changes

- **README.md** (line 317): `model="gpt-4"` → `model="gpt-4o"`
  - `gpt-4` is a legacy model; `gpt-4o` is the current recommended general-purpose model
  - Aligns with other code examples in the README (lines 91, 189)

- **docs/reference/llm_sdk_compatibility.md** (line 338): `pip install google-genai>=1.0.0` → `pip install google-genai>=1.74.0`
  - Matches the floor version in `pyproject.toml` (bumped in May 2026 audit)
  - Documentation was not updated in sync with the dependency change

- **docs/reference/llm_sdk_compatibility.md** (line 505): `pip install mistralai>=1.0.0` → `pip install mistralai>=1.0.0,<2.0.0`
  - Reflects the intentional upper bound in `pyproject.toml`
  - Prevents users from installing 2.x, which requires a context-manager refactor not yet implemented in `LLMClient`
  - Prevents `AttributeError` when calling `LLMClient.classify_intent()`

## Risk Assessment

All changes are documentation-only. No code logic, dependencies, or test fixtures are modified. These fixes prevent user confusion and ensure documentation accuracy.

https://claude.ai/code/session_01DxQqJjUjxKZdWC7NGtxeYq