### PR TITLE
Fix deprecated API calls and stale model names in documentation

### DIFF
--- a/AUDIT_2026-05-03.md
+++ b/AUDIT_2026-05-03.md
@@ -1,0 +1,435 @@
+# Agent-Gantry Modernisation Audit — 3 May 2026
+
+**Auditor**: Claude (Sonnet 4.6) operating as repository maintainer  
+**Branch**: `claude/elegant-clarke-5I4BF`  
+**Date**: 2026-05-03  
+**Scope**: Full compatibility and modernisation audit against latest stable LLM provider SDKs, provider API standards, and agent framework patterns. Incremental over the May 2026 audit (PR #154, branch `claude/elegant-clarke-KJByb`, 2026-05-02).
+
+---
+
+## 1. Executive Summary
+
+The repository remains structurally sound following the April and May 2026 audits. This audit identified **five must-change-now documentation issues** — four of which escaped prior audits entirely — and **two carried-over good-next-step improvements**, one of which has now been applied.
+
+### Must-Change Now (All Applied in This Commit)
+
+| # | Finding | Files Affected | Risk |
+|---|---------|---------------|------|
+| 1 | `docs/guides/vector_store_llm_integration.md` — Section 3 uses deprecated `to_openai_schema()` method; current API is `to_dialect("openai")` | `docs/guides/vector_store_llm_integration.md` | Documentation error — misleads users to deprecated API |
+| 2 | `docs/guides/vector_store_llm_integration.md` — Section 4 uses deprecated `to_gemini_schema()` method, wrong `tools=` keyword argument for `generate_content`, and obsolete `model="gemini-1.5-pro"` (Gemini 1.5 is superseded by 2.5); current API is `to_dialect("gemini")` with `types.FunctionDeclaration(**...)` and `config=types.GenerateContentConfig(tools=...)` | `docs/guides/vector_store_llm_integration.md` | Breaking — wrong keyword causes `TypeError`; stale model |
+| 3 | `docs/guides/vector_store_llm_integration.md` — Section 5 uses deprecated `to_anthropic_schema()` method and non-existent `model="claude-3.7-sonnet-async"` | `docs/guides/vector_store_llm_integration.md` | Breaking — non-existent model ID causes API error |
+| 4 | `docs/guides/semantic_tool_decorator.md` — Three OpenAI examples use `model="gpt-4"` (legacy model); Anthropic example uses `model="claude-3-opus-20240229"` (Claude 3 Opus, two generations old) | `docs/guides/semantic_tool_decorator.md` | Documentation quality — stale model names |
+| 5 | `docs/reference/llm_sdk_compatibility.md` line 674 — OpenRouter example uses `model="anthropic/claude-sonnet-4"`, which maps to `claude-sonnet-4-20250514` — a model Anthropic has deprecated and is retiring 15 June 2026; OpenRouter's current slug is `anthropic/claude-sonnet-4.6` (dot notation) | `docs/reference/llm_sdk_compatibility.md` | Breaking — model alias retires 15 June 2026; service interruption |
+
+### Good Next-Step Improvements (One Applied, One Carried Over)
+
+| # | Finding | Files Affected | Status |
+|---|---------|---------------|--------|
+| 6 | `pyproject.toml` `semantic-kernel` floor bumped from `>=1.30.0` to `>=1.36.0` — matches the `uv.lock`-resolved version; full upgrade to `1.41.3` remains blocked by `opentelemetry-api` conflict with `agent-framework` | `pyproject.toml` | ✅ Applied in this commit |
+| 7 | Mistral 2.x migration — `LLMClient` requires restructuring to per-call `async with Mistral(...) as client:` before the `<2.0.0` cap can be lifted | `agent_gantry/adapters/llm_client.py`, `pyproject.toml` | ⏳ Carried over — sprint not yet scheduled |
+
+---
+
+## 2. Dependency Upgrade Plan
+
+### Packages Changed in This Audit
+
+| Package | pyproject.toml change | Reason |
+|---------|----------------------|--------|
+| `semantic-kernel` | `>=1.30.0` → `>=1.36.0` | Floor now matches uv.lock resolution; safe internal |
+
+### Full Package Status Table (as of 2026-05-03)
+
+Versions verified against PyPI JSON API for each package.
+
+| Package | pyproject.toml pin | uv.lock resolved | Latest stable | Status |
+|---------|-------------------|-----------------|--------------|--------|
+| `agent-framework` | `>=1.2.2,<2.0.0` | 1.2.2 | 1.2.2 | ✅ Current |
+| `openai` | `>=2.33.0` | 2.33.0 | 2.33.0 | ✅ Current |
+| `anthropic` | `>=0.97.0` | 0.97.0 | 0.97.0 | ✅ Current |
+| `google-genai` | `>=1.74.0` | 1.74.0 | 1.74.0 | ✅ Current |
+| `autogen-agentchat` | `>=0.7.5` | 0.7.5 | 0.7.5 | ✅ Current |
+| `autogen-ext[openai]` | `>=0.7.5` | 0.7.5 | 0.7.5 | ✅ Current |
+| `langchain` | `>=1.2.17` | 1.2.17 | 1.2.17 | ✅ Current |
+| `langchain-openai` | `>=1.2.1` | 1.2.1 | 1.2.1 | ✅ Current |
+| `langgraph` | `>=1.1.10` | 1.1.10 | 1.1.10 | ✅ Current |
+| `llama-index-core` | `>=0.14.21` | 0.14.21 | 0.14.21 | ✅ Current |
+| `llama-index-llms-openai` | `>=0.7.7` | 0.7.7 | 0.7.7 | ✅ Current |
+| `groq` | `>=1.2.0` | 1.2.0 | 1.2.0 | ✅ Current |
+| `mistralai` | `>=1.0.0,<2.0.0` | 1.12.4 | 2.4.4 | ⏳ Held — 2.x migration pending |
+| `crewai` | `>=1.6.1` | 1.6.1 | 1.14.4 | ⏳ Held — opentelemetry-api conflict with agent-framework |
+| `google-adk` | `>=1.14.1` | 1.14.1 | 1.32.0 | ⚠️ Stale; upgrade blocked by opentelemetry conflict (Python 3.13/Windows) |
+| `semantic-kernel` | `>=1.36.0` *(was 1.30.0)* | 1.36.0 | 1.41.3 | ⚠️ Floor now matches lock; full upgrade blocked by opentelemetry conflict |
+
+**Sources**:  
+`agent-framework`: https://pypi.org/pypi/agent-framework/json  
+`openai` (release date confirmed 2026-04-28): https://pypi.org/pypi/openai/2.33.0/json  
+`anthropic` (release date confirmed 2026-04-23): https://pypi.org/pypi/anthropic/0.97.0/json  
+`google-genai`: https://pypi.org/pypi/google-genai/json  
+`autogen-agentchat`: https://pypi.org/pypi/autogen-agentchat/json  
+`langchain`: https://pypi.org/pypi/langchain/json  
+`langchain-openai`: https://pypi.org/pypi/langchain-openai/json  
+`langgraph`: https://pypi.org/pypi/langgraph/json  
+`groq`: https://pypi.org/pypi/groq/json  
+`mistralai`: https://pypi.org/pypi/mistralai/json  
+`crewai`: https://pypi.org/pypi/crewai/json  
+`llama-index-core`: https://pypi.org/pypi/llama-index-core/json  
+`semantic-kernel`: https://pypi.org/pypi/semantic-kernel/json  
+`google-adk`: https://pypi.org/pypi/google-adk/json  
+
+---
+
+## 3. Provider API Refactors
+
+### 3.1 OpenAI
+
+**Status: No code changes required.**
+
+No Assistants API usage anywhere in the codebase. All call sites use Chat Completions (`client.chat.completions.create`) or the Responses API. `OpenAIAdapter` and `OpenAIResponsesAdapter` in `agent_gantry/adapters/tool_spec/providers.py` remain correct.
+
+Documentation only: `docs/guides/semantic_tool_decorator.md` model names updated from `gpt-4` to `gpt-4o` (see §6.2).
+
+**Source**: https://platform.openai.com/docs/api-reference/responses
+
+### 3.2 Anthropic
+
+**Status: No live code changes required.**
+
+All Anthropic call sites use `client.messages.create(...)` with the `tools` field and structured content blocks. The `AnthropicAdapter` produces the correct `{"name", "description", "input_schema"}` shape. `format_tool_result` correctly sets `"type": "tool_result"`, `"tool_use_id"`, and the optional `"is_error": True` flag.
+
+**Thinking model compatibility (from official Anthropic models page):**
+
+| Model | Extended thinking | Adaptive thinking |
+|-------|:-----------------:|:-----------------:|
+| `claude-opus-4-7` | ❌ | ✅ |
+| `claude-sonnet-4-6` | ✅ | ✅ |
+| `claude-haiku-4-5-20251001` | ✅ | ❌ |
+
+This is correctly documented in `agent_gantry/integrations/anthropic_features.py`. No changes needed.
+
+**Deprecated models (retiring 15 June 2026)**:
+- `claude-sonnet-4-20250514` / alias `claude-sonnet-4-0`
+- `claude-opus-4-20250514` / alias `claude-opus-4-0`
+
+Neither deprecated model ID appears in any live Python source file in this repository. The documentation fix in §6 replaces `claude-3-opus-20240229` (Claude 3 Opus, two generations old) and `claude-3.7-sonnet-async` (non-existent) with `claude-sonnet-4-6`.
+
+**Source**: https://platform.claude.com/docs/en/docs/about-claude/models/overview
+
+### 3.3 Gemini
+
+**Status: No live code changes required. Documentation updated (see §6.1).**
+
+Stable models (from official Google AI docs):
+- `gemini-2.5-flash` — recommended; best price/performance
+- `gemini-2.5-flash-lite` — fastest/cheapest
+- `gemini-2.5-pro` — most capable stable model
+
+Deprecated:
+- `gemini-2.0-flash` — deprecated (fixed in the May 2026 audit)
+- `gemini-2.0-flash-lite` — deprecated
+- `gemini-1.5-pro` — superseded; `docs/guides/vector_store_llm_integration.md` incorrectly referenced this (fixed in this commit)
+
+Preview only (not for production):
+- `gemini-3.1-pro-preview`, `gemini-3-flash-preview`, and all Gemini 3.x models
+
+**Source**: https://ai.google.dev/gemini-api/docs/models
+
+### 3.4 Mistral
+
+**Status: No code change. Migration plan unchanged.**
+
+`mistralai` pinned to `<2.0.0`. Lock resolves to `1.12.4`. Latest stable is `2.4.4`. The 2.x context-manager migration remains tracked in `pyproject.toml` and `CHANGELOG.md`.
+
+### 3.5 Groq
+
+**Status: No action required.** At `>=1.2.0` (latest stable 1.2.0, released 2026-04-18).
+
+---
+
+## 4. Framework Integration Refactors
+
+### 4.1 Microsoft Agent Framework (MAF)
+
+**Status: No action required — already at latest stable 1.2.2.**
+
+Verified against: https://pypi.org/pypi/agent-framework/json
+
+Full review of all MAF integration surfaces confirms alignment with `agent-framework 1.2.2`:
+
+- **`GantryToolBridge`** (`agent_framework_bridge.py`): Agent construction, `HandoffBuilder`, `SequentialBuilder`, `WorkflowBuilder`, approval mode mapping from `ToolCapability` — all correct.
+- **`GantryContextProvider`** (`agent_framework_provider.py`): Subclasses `agent_framework.ContextProvider` dynamically. `before_run` lifecycle, `per_call` strategy, `required=[...]` validation — correct.
+- **`GantryApprovalMiddleware` / `GantryObservabilityMiddleware`** (`agent_framework_middleware.py`): `FunctionMiddleware` / `ChatMiddlewareLayer` fallback, `MiddlewareTermination` — correct.
+- **Workflow builders**: `SequentialBuilder`, `HandoffBuilder`, `WorkflowBuilder` + `AgentExecutor` + `WorkflowAgent` — all correct.
+- **`AgentFrameworkAdapter`** (`adapters/tool_spec/providers.py`): Handles both standard OpenAI-style and simplified AF internal payload formats; optional `include_metadata` provenance — correct.
+
+No AutoGen → MAF migration required. AG2 (`autogen-agentchat 0.7.5`) is a separate, maintained integration track.
+
+### 4.2 AutoGen (AG2)
+
+**Status: No action required.** `autogen-agentchat 0.7.5` is the latest stable (released 2025-09-30). Verified against: https://pypi.org/pypi/autogen-agentchat/json
+
+### 4.3 LangChain / LangGraph
+
+**Status: No action required.**
+
+`langchain 1.2.17` and `langgraph 1.1.10` are both current. All patterns (`create_react_agent`, `ChatOpenAI`) remain correct. `langchain-openai 1.2.1` current.
+
+### 4.4 CrewAI
+
+**Status: Held at `>=1.6.1`.** `crewai 1.14.4` latest; upgrade past 1.12.0 requires a separate environment without `agent-framework` due to `opentelemetry-api<1.35` pin. Documented in `pyproject.toml`.
+
+### 4.5 Google ADK
+
+**Status: Held at `>=1.14.1`.** `google-adk 1.32.0` released 2026-05-01; upgrade blocked by `opentelemetry-api` conflict on Python 3.13/Windows with `agent-framework`. Documented in `pyproject.toml`.
+
+### 4.6 Semantic Kernel
+
+**Status: Floor bumped from `>=1.30.0` to `>=1.36.0` (applied).** Lock resolves to `1.36.0`; latest stable is `1.41.3`. Full upgrade to `1.41.3` blocked by `opentelemetry-api` conflict; floor now matches the lock.
+
+---
+
+## 5. Universal Tool-Calling Design
+
+**Status: No structural changes required.**
+
+The seven-adapter `ToolSpecAdapter` architecture is unchanged and verified correct:
+
+| Adapter | Dialect | Schema shape | Tool-call ID field | Result round-trip |
+|---------|---------|-------------|-------------------|------------------|
+| `OpenAIAdapter` | `"openai"` | `{type: "function", function: {name, desc, parameters}}` | `payload.id` → `tool_call_id` | `{role: "tool", content, name, tool_call_id}` |
+| `OpenAIResponsesAdapter` | `"openai_responses"` | `{type: "function", name, desc, parameters}` | `payload.call_id` | `{type: "function_call_output", output, call_id}` |
+| `AnthropicAdapter` | `"anthropic"` | `{name, description, input_schema}` | `payload.id` → `tool_use_id` | `{type: "tool_result", content, tool_use_id, is_error?}` |
+| `GeminiAdapter` | `"gemini"` | `{name, description, parameters}` | `payload.id` (parallel calls) | `{functionResponse: {name, response, id?}}` |
+| `MistralAdapter` | `"mistral"` | OpenAI-compatible (inherits) | same as OpenAI | same as OpenAI |
+| `GroqAdapter` | `"groq"` | OpenAI-compatible (inherits) | same as OpenAI | same as OpenAI |
+| `AgentFrameworkAdapter` | `"agent_framework"` | OpenAI-compatible + optional metadata | both OpenAI and AF-internal formats | same as OpenAI |
+
+**Sources**:  
+- Anthropic tool use: https://platform.claude.com/docs/en/api/messages  
+- Gemini function calling: https://ai.google.dev/gemini-api/docs/function-calling  
+- OpenAI Responses API: https://platform.openai.com/docs/api-reference/responses  
+
+---
+
+## 6. Documentation and Example Updates
+
+### 6.1 `docs/guides/vector_store_llm_integration.md` — Three Changes Applied
+
+**File**: `docs/guides/vector_store_llm_integration.md`
+
+**Change 1 — Section 3 (OpenAI)**: Deprecated method
+
+```diff
+-tools = [t.tool.to_openai_schema() for t in retrieval.tools]
++tools = [t.tool.to_dialect("openai") for t in retrieval.tools]
+```
+
+**Rationale**: `to_openai_schema()` emits a `DeprecationWarning` and delegates to `to_dialect("openai")` internally. All other guides already use the current `to_dialect()` API.  
+**Risk**: Safe internal — documentation only.
+
+**Change 2 — Section 4 (Gemini)**: Deprecated method, wrong keyword, stale model
+
+```diff
+-gemini_tools = [
+-    types.Tool(function_declarations=[t.tool.to_gemini_schema() for t in retrieval.tools])
+-]
+-
+-client = genai.Client(api_key="...")  # genai SDK >= 0.8.0
+-result = client.models.generate_content(
+-    model="gemini-1.5-pro",
+-    contents="Summarize Q1 revenue and compute the tax.",
+-    tools=gemini_tools,
+-)
++gemini_tools = [
++    types.Tool(function_declarations=[
++        types.FunctionDeclaration(**t.tool.to_dialect("gemini")) for t in retrieval.tools
++    ])
++]
++
++client = genai.Client(api_key="...")  # google-genai SDK >= 1.74.0
++result = client.models.generate_content(
++    model="gemini-2.5-flash",
++    contents="Summarize Q1 revenue and compute the tax.",
++    config=types.GenerateContentConfig(tools=gemini_tools),
++)
+```
+
+**Rationale**:  
+- `to_gemini_schema()` is deprecated; `to_dialect("gemini")` is the current API.  
+- `FunctionDeclaration(**dict)` unpacking is required by `google-genai >= 1.0` (the `functionDeclarations` shape); the previous list comprehension passed a raw dict, not a `FunctionDeclaration` object, causing a `TypeError`.  
+- `model="gemini-1.5-pro"` is superseded; `gemini-2.5-flash` is the current stable recommendation.  
+- `tools=gemini_tools` at the top level of `generate_content()` was deprecated in `google-genai >= 1.0`; tools now go inside `config=GenerateContentConfig(tools=...)`.  
+**Risk**: Safe with compatibility note — corrects a `TypeError` in the existing snippet.  
+**Source**: https://ai.google.dev/gemini-api/docs/models
+
+**Change 3 — Section 5 (Anthropic)**: Deprecated method, non-existent model ID
+
+```diff
+-anthropic_tools = [t.tool.to_anthropic_schema() for t in retrieval.tools]
++anthropic_tools = [t.tool.to_dialect("anthropic") for t in retrieval.tools]
+
+ client = Anthropic(api_key="sk-ant-...")
+ message = client.messages.create(
+-    model="claude-3.7-sonnet-async",
++    model="claude-sonnet-4-6",
+     messages=[{"role": "user", "content": "Summarize Q1 revenue and compute the tax."}],
+     tools=anthropic_tools,
+ )
+```
+
+**Rationale**:  
+- `to_anthropic_schema()` emits a `DeprecationWarning`; `to_dialect("anthropic")` is current.  
+- `"claude-3.7-sonnet-async"` is not a real Anthropic model ID; it would cause an immediate API error. The current recommended model is `claude-sonnet-4-6`.  
+**Risk**: Breaking fix — corrects a runtime-breaking invalid model name.  
+**Source**: https://platform.claude.com/docs/en/docs/about-claude/models/overview
+
+### 6.2 `docs/guides/semantic_tool_decorator.md` — Four Changes Applied
+
+**File**: `docs/guides/semantic_tool_decorator.md`
+
+```diff
+-        model="gpt-4",   # ×3 occurrences (lines 43, 95, 112)
++        model="gpt-4o",
+```
+
+```diff
+-        model="claude-3-opus-20240229",
++        model="claude-sonnet-4-6",
+```
+
+**Rationale**:  
+- `gpt-4` is the legacy GPT-4 base model. `gpt-4o` is the current recommended general-purpose OpenAI model and is what all other examples in the repository use.  
+- `claude-3-opus-20240229` (Claude 3 Opus) is two model generations behind; `claude-sonnet-4-6` is the current recommended Anthropic model for general-purpose workloads.  
+**Risk**: Safe internal — documentation only.  
+**Source**: https://platform.claude.com/docs/en/docs/about-claude/models/overview
+
+### 6.3 `docs/reference/llm_sdk_compatibility.md` — One Change Applied
+
+**File**: `docs/reference/llm_sdk_compatibility.md`, previously at line 674
+
+```diff
+-    model="anthropic/claude-sonnet-4",  # OpenRouter model format
++    model="anthropic/claude-sonnet-4.6",  # OpenRouter model format
+```
+
+**Rationale**:  
+- `anthropic/claude-sonnet-4` on OpenRouter maps to `claude-sonnet-4-20250514`, which Anthropic has deprecated; retirement date is **15 June 2026** — five weeks from this audit's date. Any user following this example would have their application break imminently.  
+- OpenRouter's current identifier for Claude Sonnet 4.6 is `anthropic/claude-sonnet-4.6` (dot notation, confirmed from the OpenRouter model page at https://openrouter.ai/anthropic/claude-sonnet-4.6).  
+**Risk**: Breaking fix — prevents imminent service interruption.  
+**Source**: https://platform.claude.com/docs/en/docs/about-claude/models/overview; https://openrouter.ai/anthropic/claude-sonnet-4.6
+
+### 6.4 Items Checked and Not Changed
+
+| File | Finding | Conclusion |
+|------|---------|-----------|
+| `README.md` | All model names are current (`gpt-4o`, `gemini-2.5-flash`, `claude-sonnet-4-6`) | ✅ No change |
+| `QUICK_REFERENCE.md` | No stale model names or deprecated API patterns | ✅ No change |
+| `examples/agent_frameworks/*.py` | All use current model IDs (`gpt-4o`, `gemini-2.5-flash`) | ✅ No change |
+| `examples/llm_integration/anthropic_demo.py` | Uses `claude-sonnet-4-6` | ✅ No change |
+| `examples/llm_integration/google_genai_demo.py` | Uses `gemini-2.5-flash`, `to_dialect("gemini")`, `types.FunctionDeclaration(**...)` | ✅ No change |
+| `examples/llm_integration/openai_demo.py` | Uses `gpt-4.1` and `gpt-4o` | ✅ No change |
+| `agent_gantry/adapters/llm_client.py` | `client.aio.models.generate_content` stable for `google-genai>=1.74.0`; `mistralai` correctly pinned `<2.0.0` | ✅ No change |
+| `agent_gantry/integrations/anthropic_features.py` | Opus 4.7 extended-thinking caveat correct; adaptive-thinking model matrix correct | ✅ No change |
+| `agent_gantry/integrations/agent_framework_bridge.py` | All AF 1.2.2 imports verified | ✅ No change |
+| `agent_gantry/integrations/agent_framework_provider.py` | `GantryContextProvider` logic verified for AF 1.2.2 | ✅ No change |
+| `agent_gantry/adapters/tool_spec/providers.py` | All seven adapters verified | ✅ No change |
+| `docs/reference/llm_sdk_compatibility.md` (remainder) | No further stale references after OpenRouter fix | ✅ No change |
+| `docs/guides/local_persistence_and_skills.md` | No stale model names | ✅ No change |
+
+---
+
+## 7. Test and Migration Plan
+
+### 7.1 New Tests Recommended
+
+No live code-level changes in this audit; existing test suite requires no urgent updates. The following tests are recommended for completeness:
+
+| Test | File | Priority | Rationale |
+|------|------|----------|-----------|
+| `test_gemini_tools_to_function_declaration` — verify that `types.FunctionDeclaration(**t.tool.to_dialect("gemini"))` succeeds (no `TypeError`) for a registered tool | `tests/test_tool_spec_adapters.py` | Medium | Guards against regression where raw dicts were passed without `**` unpacking |
+| `test_vector_store_guide_gemini_snippet` — smoke-test that the corrected `GenerateContentConfig(tools=...)` keyword is accepted | `tests/test_tool_spec_adapters.py` or integration | Low | Guards against the `generate_content(tools=...)` top-level deprecation re-emerging |
+| `test_openrouter_model_slug` — assert the OpenRouter Claude Sonnet 4.6 slug is `anthropic/claude-sonnet-4.6` in the documentation | `tests/test_llm_sdk_compatibility.py` | Low | Prevents silent regression if the slug is mis-edited |
+
+**No VCR recordings, golden responses, or fixture regeneration** required. All changes are documentation-level.
+
+### 7.2 Changelog-Ready Migration Notes
+
+```markdown
+### Fixed
+
+- **`docs/guides/vector_store_llm_integration.md`**:
+  - Section 3 (OpenAI): replaced deprecated `to_openai_schema()` with
+    `to_dialect("openai")`.
+  - Section 4 (Gemini): replaced deprecated `to_gemini_schema()` with
+    `to_dialect("gemini")` + `FunctionDeclaration(**...)` unpacking;
+    corrected `tools=` top-level kwarg to `config=GenerateContentConfig(tools=...)`
+    per google-genai >= 1.0; updated `model="gemini-1.5-pro"` →
+    `"gemini-2.5-flash"` (1.5 series superseded).
+  - Section 5 (Anthropic): replaced deprecated `to_anthropic_schema()` with
+    `to_dialect("anthropic")`; replaced non-existent
+    `model="claude-3.7-sonnet-async"` with `"claude-sonnet-4-6"`.
+  *Risk: corrects runtime-breaking TypeError and invalid model ID.*
+
+- **`docs/guides/semantic_tool_decorator.md`**: Updated all OpenAI examples
+  from `model="gpt-4"` (legacy) to `"gpt-4o"`; updated Anthropic example
+  from `model="claude-3-opus-20240229"` (Claude 3, two generations old) to
+  `"claude-sonnet-4-6"`.
+  *Risk: documentation only.*
+
+- **`docs/reference/llm_sdk_compatibility.md`**: Updated OpenRouter example
+  from `model="anthropic/claude-sonnet-4"` to `"anthropic/claude-sonnet-4.6"`.
+  The former maps to `claude-sonnet-4-20250514`, which Anthropic is retiring
+  15 June 2026; the latter is the current OpenRouter slug for Claude Sonnet 4.6.
+  *Risk: prevents imminent service interruption.*
+
+### Changed
+
+- **`pyproject.toml`**: Bumped `semantic-kernel` floor from `>=1.30.0` to
+  `>=1.36.0`, matching the version already resolved by `uv.lock`. Full upgrade
+  to 1.41.3 remains blocked by `opentelemetry-api` version conflict with
+  `agent-framework` on some Python/platform combinations.
+  *Risk: safe internal — does not change the installed version.*
+```
+
+---
+
+## Must-Change Now (All Applied in This Commit)
+
+1. ✅ **`docs/guides/vector_store_llm_integration.md` — Section 3** — `to_openai_schema()` → `to_dialect("openai")`.
+2. ✅ **`docs/guides/vector_store_llm_integration.md` — Section 4** — `to_gemini_schema()` → `to_dialect("gemini")` + `FunctionDeclaration(**...)` + `GenerateContentConfig(tools=...)` + `gemini-1.5-pro` → `gemini-2.5-flash`.
+3. ✅ **`docs/guides/vector_store_llm_integration.md` — Section 5** — `to_anthropic_schema()` → `to_dialect("anthropic")` + `claude-3.7-sonnet-async` → `claude-sonnet-4-6`.
+4. ✅ **`docs/guides/semantic_tool_decorator.md`** — `gpt-4` (×3) → `gpt-4o`; `claude-3-opus-20240229` → `claude-sonnet-4-6`.
+5. ✅ **`docs/reference/llm_sdk_compatibility.md`** — `anthropic/claude-sonnet-4` → `anthropic/claude-sonnet-4.6`.
+
+## Good Next-Step Improvements
+
+6. ✅ **`pyproject.toml`** — `semantic-kernel` floor `>=1.30.0` → `>=1.36.0` (applied; matches lock).
+7. ⏳ **`agent_gantry/adapters/llm_client.py` + `pyproject.toml`** — Mistral 2.x migration; restructure `LLMClient` to per-call `async with Mistral(...) as client:` before lifting the `<2.0.0` cap.
+8. ⏳ **`pyproject.toml`** — `google-adk` floor upgrade from `>=1.14.1` → `>=1.32.0`; blocked by `opentelemetry-api` conflict with `agent-framework` on Python 3.13/Windows.
+9. ⏳ **`pyproject.toml`** — `semantic-kernel` full upgrade to `>=1.41.3`; blocked by same `opentelemetry-api` conflict. Requires standalone-environment testing.
+
+---
+
+## Appendix — Verification URLs
+
+| Claim | URL Fetched |
+|-------|-------------|
+| `agent-framework` latest stable is 1.2.2 | https://pypi.org/pypi/agent-framework/json |
+| `openai` 2.33.0 release date is 2026-04-28 | https://pypi.org/pypi/openai/2.33.0/json |
+| `anthropic` 0.97.0 release date is 2026-04-23 | https://pypi.org/pypi/anthropic/0.97.0/json |
+| `google-genai` latest stable is 1.74.0 | https://pypi.org/pypi/google-genai/json |
+| `langchain` latest stable is 1.2.17 | https://pypi.org/pypi/langchain/json |
+| `langchain-openai` latest stable is 1.2.1 | https://pypi.org/pypi/langchain-openai/json |
+| `langgraph` latest stable is 1.1.10 | https://pypi.org/pypi/langgraph/json |
+| `groq` latest stable is 1.2.0 (released 2026-04-18) | https://pypi.org/pypi/groq/json |
+| `mistralai` latest stable is 2.4.4 | https://pypi.org/pypi/mistralai/json |
+| `crewai` latest stable is 1.14.4 | https://pypi.org/pypi/crewai/json |
+| `llama-index-core` latest stable is 0.14.21 | https://pypi.org/pypi/llama-index-core/json |
+| `semantic-kernel` latest stable is 1.41.3 | https://pypi.org/pypi/semantic-kernel/json |
+| `google-adk` latest stable is 1.32.0 (released 2026-05-01) | https://pypi.org/pypi/google-adk/json |
+| Claude Opus 4.7 does not support extended thinking; Opus 4.6 and Sonnet 4.6 do | https://platform.claude.com/docs/en/docs/about-claude/models/overview |
+| `claude-sonnet-4-20250514` and `claude-opus-4-20250514` deprecated, retiring 15 June 2026 | https://platform.claude.com/docs/en/docs/about-claude/models/overview |
+| Gemini 2.5 Flash is stable; 2.0 Flash deprecated; 3.x is preview only | https://ai.google.dev/gemini-api/docs/models |
+| Gemini 1.5 Pro superseded by 2.5 series | https://ai.google.dev/gemini-api/docs/models |
+| OpenRouter slug for Claude Sonnet 4.6 is `anthropic/claude-sonnet-4.6` | https://openrouter.ai/anthropic/claude-sonnet-4.6 |
+| `anthropic/claude-sonnet-4` on OpenRouter maps to the deprecating `claude-sonnet-4-20250514` | https://openrouter.ai/anthropic/claude-sonnet-4 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`docs/guides/vector_store_llm_integration.md`**:
+  - Section 3 (OpenAI): replaced deprecated `to_openai_schema()` with
+    `to_dialect("openai")`.
+  - Section 4 (Gemini): replaced deprecated `to_gemini_schema()` with
+    `to_dialect("gemini")` + `FunctionDeclaration(**...)` unpacking; corrected
+    `tools=` top-level kwarg to `config=GenerateContentConfig(tools=...)` per
+    google-genai >= 1.0; updated stale `model="gemini-1.5-pro"` →
+    `"gemini-2.5-flash"` (1.5 series superseded by 2.5).
+  - Section 5 (Anthropic): replaced deprecated `to_anthropic_schema()` with
+    `to_dialect("anthropic")`; replaced non-existent
+    `model="claude-3.7-sonnet-async"` with `"claude-sonnet-4-6"`.
+  *Risk: corrects a runtime-breaking `TypeError` in the Gemini snippet and an
+  invalid model ID that would have caused an immediate API error.*
+
+- **`docs/guides/semantic_tool_decorator.md`**: Updated all three OpenAI
+  examples from `model="gpt-4"` (legacy) to `"gpt-4o"`; updated Anthropic
+  example from `model="claude-3-opus-20240229"` (Claude 3 Opus, two model
+  generations old) to `"claude-sonnet-4-6"`.
+  *Risk: documentation only.*
+
+- **`docs/reference/llm_sdk_compatibility.md`**: Updated OpenRouter example
+  from `model="anthropic/claude-sonnet-4"` to `"anthropic/claude-sonnet-4.6"`.
+  The old slug maps to `claude-sonnet-4-20250514`, which Anthropic has
+  deprecated and is retiring **15 June 2026**; the new slug is the current
+  OpenRouter identifier for Claude Sonnet 4.6.
+  *Risk: prevents imminent service interruption for users following the example.*
+
+### Changed
+
+- **`pyproject.toml`**: Bumped `semantic-kernel` minimum from `>=1.30.0` to
+  `>=1.36.0`, matching the version already resolved by `uv.lock`. Full upgrade
+  to 1.41.3 remains blocked by `opentelemetry-api` version conflict with
+  `agent-framework` on some Python/platform combinations; the comment in
+  `pyproject.toml` has been updated to reflect this.
+  *Risk: safe internal — does not change the installed version.*
+
 ### Added
 
 - **`agent_gantry.query` module** — built-in deterministic query-generation

--- a/docs/guides/semantic_tool_decorator.md
+++ b/docs/guides/semantic_tool_decorator.md
@@ -40,7 +40,7 @@ client = OpenAI()
 async def generate(prompt: str, *, tools: list | None = None):
     """Generate a response with automatically selected tools."""
     return client.chat.completions.create(
-        model="gpt-4",
+        model="gpt-4o",
         messages=[{"role": "user", "content": prompt}],
         tools=tools,
     )
@@ -92,7 +92,7 @@ client = OpenAI()
 async def generate(prompt: str, *, tools: list | None = None):
     """Generate a response with automatically selected tools."""
     return client.chat.completions.create(
-        model="gpt-4",
+        model="gpt-4o",
         messages=[{"role": "user", "content": prompt}],
         tools=tools,
     )
@@ -109,7 +109,7 @@ response = await generate("What's the weather in Paris?")
 async def chat(messages: list[dict], *, tools: list | None = None):
     """Chat with automatic tool selection."""
     return client.chat.completions.create(
-        model="gpt-4",
+        model="gpt-4o",
         messages=messages,
         tools=tools,
     )
@@ -133,7 +133,7 @@ client = Anthropic()
 async def claude_chat(messages: list[dict], *, tools: list | None = None):
     """Chat with Claude using automatic tool selection."""
     return client.messages.create(
-        model="claude-3-opus-20240229",
+        model="claude-sonnet-4-6",
         messages=messages,
         tools=tools,  # Tools are in Anthropic format
     )

--- a/docs/guides/vector_store_llm_integration.md
+++ b/docs/guides/vector_store_llm_integration.md
@@ -72,7 +72,7 @@ each SDK.
 ```python
 from openai import OpenAI
 
-tools = [t.tool.to_openai_schema() for t in retrieval.tools]
+tools = [t.tool.to_dialect("openai") for t in retrieval.tools]
 
 client = OpenAI(api_key="sk-...")
 response = client.chat.completions.create(
@@ -91,14 +91,16 @@ from google import genai
 from google.genai import types
 
 gemini_tools = [
-    types.Tool(function_declarations=[t.tool.to_gemini_schema() for t in retrieval.tools])
+    types.Tool(function_declarations=[
+        types.FunctionDeclaration(**t.tool.to_dialect("gemini")) for t in retrieval.tools
+    ])
 ]
 
-client = genai.Client(api_key="...")  # genai SDK >= 0.8.0
+client = genai.Client(api_key="...")  # google-genai SDK >= 1.74.0
 result = client.models.generate_content(
-    model="gemini-1.5-pro",
+    model="gemini-2.5-flash",
     contents="Summarize Q1 revenue and compute the tax.",
-    tools=gemini_tools,
+    config=types.GenerateContentConfig(tools=gemini_tools),
 )
 ```
 
@@ -107,11 +109,11 @@ result = client.models.generate_content(
 ```python
 from anthropic import Anthropic
 
-anthropic_tools = [t.tool.to_anthropic_schema() for t in retrieval.tools]
+anthropic_tools = [t.tool.to_dialect("anthropic") for t in retrieval.tools]
 
 client = Anthropic(api_key="sk-ant-...")
 message = client.messages.create(
-    model="claude-3.7-sonnet-async",
+    model="claude-sonnet-4-6",
     messages=[{"role": "user", "content": "Summarize Q1 revenue and compute the tax."}],
     tools=anthropic_tools,
 )

--- a/docs/reference/llm_sdk_compatibility.md
+++ b/docs/reference/llm_sdk_compatibility.md
@@ -671,7 +671,7 @@ client = OpenAI(
 ```python
 # Standard OpenAI-compatible chat completions
 response = client.chat.completions.create(
-    model="anthropic/claude-sonnet-4",  # OpenRouter model format
+    model="anthropic/claude-sonnet-4.6",  # OpenRouter model format
     messages=[
         {"role": "user", "content": "Hello!"}
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,9 @@ agent-frameworks = [
     # semantic-kernel>=1.41.3 conflicts with agent-framework>=1.2.1 on some
     # Python versions due to opentelemetry-api version incompatibility.
     # Upgrade semantic-kernel in a standalone environment without agent-framework.
-    "semantic-kernel>=1.30.0",
+    # Floor bumped to >=1.36.0 to match the uv.lock-resolved version; full
+    # upgrade to 1.41.3 requires standalone testing without agent-framework.
+    "semantic-kernel>=1.36.0",
     # google-adk 1.31.1 conflicts with agent-framework>=1.2.1 on Python 3.13/Windows;
     # bump this floor in a standalone (no agent-framework) environment.
     "google-adk>=1.14.1",


### PR DESCRIPTION
## Summary

This PR fixes five critical documentation issues that would cause runtime errors or imminent service interruption for users following the examples:

1. **Deprecated tool schema methods** — Replaces `to_openai_schema()`, `to_gemini_schema()`, and `to_anthropic_schema()` with the current `to_dialect()` API across vector store integration guide.

2. **Breaking Gemini API changes** — Corrects the `google-genai >= 1.0` API migration:
   - Wraps `to_dialect("gemini")` output in `types.FunctionDeclaration(**...)` unpacking (was passing raw dict, causing `TypeError`)
   - Moves `tools=` parameter from top-level to `config=GenerateContentConfig(tools=...)` (deprecated top-level kwarg)
   - Updates stale `model="gemini-1.5-pro"` to `"gemini-2.5-flash"` (1.5 series superseded)

3. **Invalid model IDs** — Replaces non-existent `model="claude-3.7-sonnet-async"` with `"claude-sonnet-4-6"` in Anthropic example.

4. **Deprecated model names** — Updates legacy `gpt-4` references to `gpt-4o` and outdated `claude-3-opus-20240229` to `claude-sonnet-4-6` in semantic tool decorator guide.

5. **Imminent service interruption** — Fixes OpenRouter example using `anthropic/claude-sonnet-4` (maps to `claude-sonnet-4-20250514`, retiring 15 June 2026) to `anthropic/claude-sonnet-4.6` (current slug).

## Changes

- **`docs/guides/vector_store_llm_integration.md`**
  - Section 3: `to_openai_schema()` → `to_dialect("openai")`
  - Section 4: `to_gemini_schema()` → `to_dialect("gemini")` with `FunctionDeclaration(**...)` unpacking; `tools=` → `config=GenerateContentConfig(tools=...)`; `gemini-1.5-pro` → `gemini-2.5-flash`
  - Section 5: `to_anthropic_schema()` → `to_dialect("anthropic")`; `claude-3.7-sonnet-async` → `claude-sonnet-4-6`

- **`docs/guides/semantic_tool_decorator.md`**
  - Updated three OpenAI examples: `gpt-4` → `gpt-4o`
  - Updated Anthropic example: `claude-3-opus-20240229` → `claude-sonnet-4-6`

- **`docs/reference/llm_sdk_compatibility.md`**
  - OpenRouter example: `anthropic/claude-sonnet-4` → `anthropic/claude-sonnet-4.6`

- **`pyproject.toml`**
  - Bumped `semantic-kernel` floor from `>=1.30.0` to `>=1.36.0` (matches `uv.lock` resolution)

- **`CHANGELOG.md`**
  - Added entries documenting all fixes and the dependency floor bump

## Risk Assessment

- **Gemini snippet fix**: Corrects a runtime `TypeError` in the existing code
- **Anthropic model fix**: Corrects an invalid model ID that would cause immediate API error
- **OpenRouter fix**: Prevents service interruption when the deprecated model is retired on 15 June 2026
- **Model name updates**: Documentation quality improvements; no code-level changes
- **Dependency floor bump**: Safe internal change; does not alter installed version

https://claude.ai/code/session_01LEJaN6xc6QPPjBq6pHUKTz