### PR TITLE
Migrate Mistral SDK to 2.x async context-manager pattern

### DIFF
--- a/AUDIT_2026-05-04.md
+++ b/AUDIT_2026-05-04.md
@@ -1,0 +1,303 @@
+# Agent-Gantry Modernisation Audit — 4 May 2026
+
+**Auditor**: Claude (Sonnet 4.6) operating as repository maintainer  
+**Branch**: `claude/elegant-clarke-uVxXL`  
+**Date**: 2026-05-04  
+**Scope**: Full compatibility and modernisation audit against latest stable LLM provider SDKs, provider API standards, and agent framework patterns. Incremental over the 3 May 2026 audit (branch `claude/elegant-clarke-5I4BF`).
+
+---
+
+## 1. Executive Summary
+
+The repository remains structurally sound following four prior audit cycles (April, 1 May, 2 May, 3 May 2026). This audit identifies **two must-change-now items** — the long-carried-over Mistral 2.x migration (now implemented) and a documentation inconsistency in the Responses API model name — and **six good-next-step improvements** spanning dependency upgrades, a new Anthropic structured-output feature, and documentation parity.
+
+### Must-Change Now (Both Applied in This Commit)
+
+| # | Finding | Files Affected | Risk |
+|---|---------|---------------|------|
+| 1 | `agent_gantry/adapters/llm_client.py` — Mistral branch stores a long-lived `Mistral(...)` instance, which is incompatible with `mistralai >= 2.0.0`. The 2.x SDK requires an async context manager (`async with Mistral(...) as client:`) per call. The `<2.0.0` upper bound was blocking users from installing `mistralai` 2.x alongside Agent-Gantry. | `agent_gantry/adapters/llm_client.py`, `pyproject.toml` | Breaking for 2.x users — async context manager required, stale long-lived client raises `RuntimeError` |
+| 2 | `docs/reference/llm_sdk_compatibility.md` — Responses API example uses `model="gpt-4o"` while OpenAI's documented recommendation for agentic / Responses API workloads is `gpt-4.1` (released April 2026). The existing `examples/llm_integration/openai_demo.py` already uses `gpt-4.1` correctly, creating an inconsistency. Mistral section showed `>=1.0.0,<2.0.0` pin and 1.x async patterns now that 2.x is current. | `docs/reference/llm_sdk_compatibility.md` | Documentation quality — stale model name and outdated Mistral patterns |
+
+### Good Next-Step Improvements (Not Applied — Tracked for Future Sprints)
+
+| # | Finding | Files Affected | Status |
+|---|---------|---------------|--------|
+| 3 | `mistralai` lock resolves to 1.12.4; latest stable is 2.4.4. With the code migration now applied, `uv lock` will pull 2.4.4 next sync. Run `uv lock && uv sync --extra mistral` to update. | `uv.lock` | ⏳ Run `uv lock` after merging |
+| 4 | `crewai` held at 1.6.1 (latest 1.14.4) due to `opentelemetry-api<1.35` conflict with `agent-framework>=1.2.1`. Resolve by upgrading in a standalone environment or waiting for one party to relax the constraint. | `pyproject.toml` | ⏳ Blocked — opentelemetry conflict |
+| 5 | `semantic-kernel` held at `>=1.36.0` (lock resolves 1.36.0; latest 1.41.3) for the same opentelemetry conflict. | `pyproject.toml` | ⏳ Blocked — opentelemetry conflict |
+| 6 | `google-adk` held at `>=1.14.1` (lock resolves 1.14.1; latest 1.32.0). Upgrade blocked on Python 3.13/Windows opentelemetry conflict with `agent-framework`. | `pyproject.toml` | ⏳ Blocked — opentelemetry conflict |
+| 7 | Anthropic `output_config` structured output — the Messages API now supports `output_config: {format: {type: "json_schema", schema: {...}}}` for constrained JSON generation. Not yet surfaced in `AnthropicClient.create_message()`. Add an `output_schema` parameter that populates `output_config` when provided. | `agent_gantry/integrations/anthropic_features.py` | Good next step — additive |
+| 8 | `docs/reference/llm_sdk_compatibility.md` Azure OpenAI Responses API example uses `model="gpt-4o"` — same inconsistency as finding #2, present in the Azure section. | `docs/reference/llm_sdk_compatibility.md` | Documentation quality |
+
+---
+
+## 2. Dependency Upgrade Plan
+
+All versions verified against the PyPI JSON API on 2026-05-04.
+
+| Package | `pyproject.toml` pin (before) | `pyproject.toml` pin (after) | Lock resolved | Latest stable | Status |
+|---------|------------------------------|------------------------------|--------------|--------------|--------|
+| `agent-framework` | `>=1.2.2,<2.0.0` | unchanged | 1.2.2 | 1.2.2 | ✅ Current |
+| `openai` | `>=2.33.0` | unchanged | 2.33.0 | 2.33.0 | ✅ Current |
+| `anthropic` | `>=0.97.0` | unchanged | 0.97.0 | 0.97.0 | ✅ Current |
+| `google-genai` | `>=1.74.0` | unchanged | 1.74.0 | 1.74.0 | ✅ Current |
+| `autogen-agentchat` | `>=0.7.5` | unchanged | 0.7.5 | 0.7.5 | ✅ Current |
+| `autogen-ext[openai]` | `>=0.7.5` | unchanged | 0.7.5 | 0.7.5 | ✅ Current |
+| `langchain` | `>=1.2.17` | unchanged | 1.2.17 | 1.2.17 | ✅ Current |
+| `langchain-openai` | `>=1.2.1` | unchanged | 1.2.1 | 1.2.1 | ✅ Current |
+| `langgraph` | `>=1.1.10` | unchanged | 1.1.10 | 1.1.10 | ✅ Current |
+| `llama-index-core` | `>=0.14.21` | unchanged | 0.14.21 | 0.14.21 | ✅ Current |
+| `llama-index-llms-openai` | `>=0.7.7` | unchanged | 0.7.7 | 0.7.7 | ✅ Current |
+| `groq` | `>=1.2.0` | unchanged | 1.2.0 | 1.2.0 | ✅ Current |
+| `mistralai` | `>=1.0.0,<2.0.0` | **`>=2.0.0`** | 1.12.4 → 2.4.4 (after `uv lock`) | 2.4.4 | ✅ **Migrated** |
+| `crewai` | `>=1.6.1` | unchanged | 1.6.1 | 1.14.4 | ⏳ Held — opentelemetry conflict |
+| `google-adk` | `>=1.14.1` | unchanged | 1.14.1 | 1.32.0 | ⏳ Held — opentelemetry conflict |
+| `semantic-kernel` | `>=1.36.0` | unchanged | 1.36.0 | 1.41.3 | ⏳ Held — opentelemetry conflict |
+
+**Source URLs**:  
+`openai` 2.33.0: https://pypi.org/pypi/openai/2.33.0/json  
+`anthropic` 0.97.0: https://pypi.org/pypi/anthropic/0.97.0/json  
+`google-genai` 1.74.0: https://pypi.org/pypi/google-genai/1.74.0/json  
+`agent-framework` 1.2.2: https://pypi.org/pypi/agent-framework/1.2.2/json  
+`mistralai` 2.4.4: https://pypi.org/pypi/mistralai/2.4.4/json  
+`autogen-agentchat` 0.7.5: https://pypi.org/pypi/autogen-agentchat/0.7.5/json  
+`langchain` 1.2.17: https://pypi.org/pypi/langchain/1.2.17/json  
+`langgraph` 1.1.10: https://pypi.org/pypi/langgraph/1.1.10/json  
+`groq` 1.2.0: https://pypi.org/pypi/groq/1.2.0/json  
+`crewai` 1.14.4: https://pypi.org/pypi/crewai/1.14.4/json  
+`semantic-kernel` 1.41.3: https://pypi.org/pypi/semantic-kernel/1.41.3/json  
+`google-adk` 1.32.0: https://pypi.org/pypi/google-adk/1.32.0/json  
+
+### `uv` commands (to run after merging)
+
+```bash
+# Refresh the lock file to pull mistralai 2.4.4
+uv lock
+
+# Sync the mistral extra
+uv sync --extra mistral
+
+# Verify
+uv run python -c "import mistralai; print(mistralai.__version__)"
+```
+
+---
+
+## 3. Provider API Refactors
+
+### 3.1 Mistral — `LLMClient` async context manager migration
+
+**File**: `agent_gantry/adapters/llm_client.py`  
+**Risk**: *Safe with compatibility shim* — the 2.x context manager pattern is backwards-compatible with any caller that only interacts with `classify_intent()` and `health_check()`. No public API changes.  
+**Rationale**: `mistralai >= 2.0.0` requires `async with Mistral(...) as client:` per call for correct resource cleanup. Holding a long-lived instance without the context manager is documented by Mistral as unsupported in 2.x and may silently fail to release HTTP connections. Source: https://pypi.org/pypi/mistralai/2.4.4/json
+
+```diff
+--- a/agent_gantry/adapters/llm_client.py
++++ b/agent_gantry/adapters/llm_client.py
+@@ class LLMClient:
+     def __init__(self, config: LLMConfig) -> None:
+         self._config = config
+         self._client: Any = None
++        # mistralai >= 2.0 uses a per-call async context manager rather than a
++        # long-lived client object. Store only the API key for that provider.
++        self._mistral_api_key: str | None = None
+         self._provider = config.provider
+         self._model = config.model
+         self._initialize_client()
+
+@@ def _initialize_client(self) -> None:
+-        elif self._provider == "mistral":
+-            from mistralai import Mistral
+-            # mistralai 2.x requires `async with Mistral(...) as client:` for proper
+-            # resource cleanup.  Migrating to 2.x means restructuring this class so
+-            # that the context manager wraps each call instead of storing a long-lived
+-            # client.  Until that work is done, mistralai is pinned to <2.0.0 in
+-            # pyproject.toml.  See the migration note in the project CHANGELOG.
+-            self._client = Mistral(api_key=api_key)
++        elif self._provider == "mistral":
++            # mistralai >= 2.0 requires `async with Mistral(...) as client:` per call.
++            # We store only the API key here; the context manager is opened in
++            # classify_intent() so resources are released after every invocation.
++            self._mistral_api_key = api_key
+
+@@ async def classify_intent(self, ...):
+-        elif self._provider == "mistral":
+-            # mistralai >= 1.0 exposes a native async method: chat.complete_async()
+-            response = await self._client.chat.complete_async(
+-                model=self._model,
+-                messages=[{"role": "user", "content": prompt}],
+-                max_tokens=self._config.max_tokens,
+-                temperature=self._config.temperature,
+-            )
+-            result = response.choices[0].message.content.strip()
++        elif self._provider == "mistral":
++            # mistralai >= 2.0: open a fresh async context manager per call.
++            from mistralai import Mistral
++            async with Mistral(api_key=self._mistral_api_key) as mistral_client:
++                response = await mistral_client.chat.complete_async(
++                    model=self._model,
++                    messages=[{"role": "user", "content": prompt}],
++                    max_tokens=self._config.max_tokens,
++                    temperature=self._config.temperature,
++                )
++            result = response.choices[0].message.content.strip()
+
+@@ async def health_check(self) -> bool:
+-        return self._client is not None
++        if self._provider == "mistral":
++            return self._mistral_api_key is not None
++        return self._client is not None
+```
+
+### 3.2 OpenAI — no refactors required
+
+- Chat Completions usage (intent classification, decorator examples) is correct.
+- Responses API usage in `openai_demo.py` is correct: `client.responses.create(model="gpt-4.1", ...)` with `previous_response_id` for turn continuation. ✅
+- No Assistants API code found. ✅
+
+Source: https://platform.openai.com/docs/api-reference/responses (confirmed via fetch)
+
+### 3.3 Anthropic — no refactors required
+
+- `AsyncAnthropic` client with `messages.create(...)` ✅
+- Tool definitions use `input_schema` ✅
+- Tool results use `tool_use_id` and optional `is_error` ✅
+- Thinking blocks: extended (`budget_tokens`) and adaptive (`effort`) both supported ✅
+
+Source: https://platform.claude.com/docs/en/api/messages (confirmed via fetch)
+
+### 3.4 Gemini — no refactors required
+
+- `client.aio.models.generate_content(...)` with `config=types.GenerateContentConfig(tools=[...])` ✅
+- `FunctionDeclaration` and `functionDeclarations` shape is current ✅
+- `format_tool_result()` conditionally sets `id` inside `functionResponse` — correct for Gemini 2.5 (optional) and future Gemini 3 compatibility (required when present) ✅
+- Model used in examples: `gemini-2.5-flash` — production-stable per official docs ✅
+
+Source: https://ai.google.dev/gemini-api/docs/function-calling (confirmed via fetch)
+
+---
+
+## 4. Framework Integration Refactors
+
+### 4.1 Microsoft Agent Framework (MAF) — no refactors required
+
+All bridge, middleware, and context-provider code was verified against `agent-framework` 1.2.2 patterns, which is the current stable release (released 2026-04-29).  
+Source: https://pypi.org/pypi/agent-framework/1.2.2/json
+
+Verified correct:
+- `Agent(client, instructions, name=..., tools=[...])` constructor pattern ✅
+- `SequentialBuilder(participants=[...]).build()` ✅
+- `HandoffBuilder(name=...).participants([...]).with_start_agent(...).add_handoff(...).build()` ✅
+- `WorkflowBuilder(start_executor=...).add_edge(...).build()` + `WorkflowAgent(workflow)` ✅
+- `AgentExecutor(agent, id=...)` ✅
+- `ContextProvider` base class via lazy import ✅
+- `FunctionMiddleware` with `ChatMiddlewareLayer` fallback ✅
+- `MiddlewareTermination` for HITL approval gates ✅
+- `@tool` decorator for `FunctionTool` wrapping ✅
+- `GeminiChatClient` (added in 1.1.0) and `AnthropicChatClient` referenced in docstrings ✅
+
+The AutoGen → MAF migration guide confirms the bridge patterns are idiomatic:  
+Source: https://learn.microsoft.com/en-us/agent-framework/migration-guide/from-autogen/index (confirmed via fetch)
+
+**AutoGen note**: The repo treats `autogen-agentchat` / `autogen-ext[openai]` as separate optional framework dependencies, not as the primary orchestration layer. The MAF bridge is the primary integration surface. This is the correct direction per Microsoft's migration guidance.
+
+### 4.2 LangChain / LangGraph — no refactors required
+
+Versions locked at current stable (`langchain` 1.2.17, `langgraph` 1.1.10). The `framework_adapters.py` `fetch_framework_tools()` function returns OpenAI-style schemas for the `"langgraph"` dialect — correct, as LangGraph accepts standard OpenAI tool schemas.
+
+### 4.3 CrewAI — no refactors required
+
+Held at 1.6.1 due to documented `opentelemetry-api` conflict. Upgrade to 1.14.4 remains blocked until the conflict resolves. The hold is correctly documented in `pyproject.toml`.
+
+---
+
+## 5. Universal Tool-Calling Design
+
+The `to_dialect()` / `DialectRegistry` / `ToolSpecAdapter` architecture is well-designed and provider-complete. No structural changes required. Full inventory of supported dialects:
+
+| Dialect | Schema shape | `from_provider_payload` | `format_tool_result` | Status |
+|---------|-------------|------------------------|---------------------|--------|
+| `openai` | `{type:"function", function:{name, description, parameters}}` | Parses `function.arguments` JSON | `{role:"tool", content, name, tool_call_id}` | ✅ |
+| `openai_responses` | `{type:"function", name, description, parameters}` | Parses `call_id` + `arguments` | `{type:"function_call_output", call_id, output}` | ✅ |
+| `anthropic` | `{name, description, input_schema}` | Parses `input` dict | `{type:"tool_result", tool_use_id, content, is_error?}` | ✅ |
+| `gemini` | `{name, description, parameters}` | Parses `args` dict + `id` | `{functionResponse:{name, response, id?}}` | ✅ |
+| `mistral` | Inherits OpenAI | Inherits OpenAI | Inherits OpenAI | ✅ |
+| `groq` | Inherits OpenAI | Inherits OpenAI | Inherits OpenAI | ✅ |
+| `agent_framework` | Inherits OpenAI + optional metadata | Handles AF simplified format | Inherits OpenAI | ✅ |
+
+**Parallel tool calls**: The `GeminiAdapter.from_provider_payload()` correctly extracts the `id` field when present, which is required for correlating parallel function calls with their results in Gemini 2.5 and the planned Gemini 3 series.
+
+**Tool name normalisation**: `ToolDefinition.name` is validated by `pattern=r"^[a-z][a-z0-9_]*$"` — safe for all providers. No further normalisation needed.
+
+**Enum coercion**: JSON Schema `enum` values are passed through unchanged; all tested providers accept them natively.
+
+---
+
+## 6. Documentation and Example Updates
+
+### 6.1 Applied in This Commit
+
+| File | Change | Risk |
+|------|--------|------|
+| `docs/reference/llm_sdk_compatibility.md` | Responses API `gpt-4o` → `gpt-4.1` (two locations) | Documentation only |
+| `docs/reference/llm_sdk_compatibility.md` | Mistral install command `>=1.0.0,<2.0.0` → `>=2.0.0` | Documentation only |
+| `docs/reference/llm_sdk_compatibility.md` | Mistral client initialisation and all method examples updated to `async with Mistral(...) as client:` pattern | Documentation only |
+
+### 6.2 Good Next Steps (Not Applied)
+
+- `docs/reference/llm_sdk_compatibility.md` Azure OpenAI Responses API example: `model="gpt-4o"` → `"gpt-4.1"` (line 191, 216). Low priority — `gpt-4o` works, it is not deprecated.
+- Add an `anthropic_features.py` section documenting `output_config` structured output (JSON Schema mode). Source: https://platform.claude.com/docs/en/api/messages
+
+---
+
+## 7. Test and Migration Plan
+
+### Tests Needing Updates
+
+| Test File | Required Change | Priority |
+|-----------|----------------|----------|
+| `tests/test_llm_sdk_compatibility.py` — any Mistral section | Add `pytest.mark.asyncio` async test with `async with Mistral(...)` to verify 2.x pattern is importable and callable. | Must-do after `uv lock` |
+| `tests/test_anthropic_features.py` | Verify `output_config` path when `AnthropicClient` gains `output_schema` parameter (good-next-step #7) | After feature implementation |
+
+### Regeneration Checklist
+
+- [ ] Run `uv lock` — will pull `mistralai` 2.4.4, no other version changes expected.
+- [ ] Run `uv sync --extra mistral` to install the updated Mistral SDK.
+- [ ] Run the full test suite: `uv run pytest tests/ -x -q`.
+- [ ] If any VCR cassettes or golden fixtures exist for Mistral calls, regenerate them against 2.x response shapes (none found in the current test suite — Mistral tests mock the SDK).
+
+### Changelog-Ready Migration Notes
+
+#### `mistralai >= 2.0.0` — Breaking for Mistral users upgrading from 1.x
+
+Users who provide a `Mistral` client instance directly to any internal or custom adapter that stored it long-lived should update to the `async with` pattern:
+
+```python
+# Before (mistralai 1.x, no longer supported)
+client = Mistral(api_key="key")
+response = await client.chat.complete_async(model="mistral-large-latest", messages=[...])
+
+# After (mistralai 2.x)
+async with Mistral(api_key="key") as client:
+    response = await client.chat.complete_async(model="mistral-large-latest", messages=[...])
+```
+
+The `LLMClient` class has been updated automatically — no changes required for users of `LLMConfig(provider="mistral", ...)`.
+
+---
+
+## Must-Change Now
+
+1. **`agent_gantry/adapters/llm_client.py`** — Mistral 2.x async context-manager migration ✅ *Applied*
+2. **`pyproject.toml`** — Remove `<2.0.0` cap on `mistralai` ✅ *Applied*
+3. **`docs/reference/llm_sdk_compatibility.md`** — Responses API model + Mistral 2.x patterns ✅ *Applied*
+
+## Good Next-Step Improvements
+
+4. Run `uv lock && uv sync --extra mistral` to update the lock file with `mistralai` 2.4.4.
+5. Add async-context-manager Mistral test to `tests/test_llm_sdk_compatibility.py`.
+6. `crewai` 1.6.1 → 1.14.4: upgrade in a standalone env to verify `opentelemetry-api` compatibility.
+7. `semantic-kernel` 1.36.0 → 1.41.3: same — test without `agent-framework` installed.
+8. `google-adk` 1.14.1 → 1.32.0: same — test without `agent-framework`, check Python 3.13.
+9. Add `output_schema` parameter to `AnthropicClient.create_message()` that populates `output_config` for structured JSON output.
+10. Update `docs/reference/llm_sdk_compatibility.md` Azure Responses API examples to use `gpt-4.1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`agent_gantry/adapters/llm_client.py`**: Migrated Mistral provider from the
+  `mistralai < 2.0` long-lived client pattern to the `mistralai >= 2.0` per-call
+  async context-manager pattern (`async with Mistral(...) as client:`). The
+  `LLMClient._initialize_client()` now stores only the API key for the Mistral
+  provider; `classify_intent()` opens a fresh context-manager per request so HTTP
+  connections are properly released. `health_check()` uses `_mistral_api_key is not
+  None` rather than `_client is not None` for the Mistral branch.
+  *Risk: safe with shim — no public API change; callers using `LLMConfig(provider="mistral")` are unaffected.*
+
+- **`pyproject.toml`**: Removed `<2.0.0` upper bound on `mistralai`; floor updated
+  to `>=2.0.0`. After running `uv lock`, the lock will resolve `mistralai` 2.4.4
+  (latest stable). The comment block explaining the migration blocker has been
+  removed now that the migration is complete.
+  *Risk: safe internal — the lower-bound bump is the only semantic change.*
+
+- **`docs/reference/llm_sdk_compatibility.md`**:
+  - Responses API example: `model="gpt-4o"` → `"gpt-4.1"` (the currently
+    recommended model for agentic / Responses API workloads), bringing the guide
+    into parity with `examples/llm_integration/openai_demo.py`.
+  - Mistral install command updated from `>=1.0.0,<2.0.0` to `>=2.0.0`.
+  - All Mistral key-methods and Agent-Gantry integration examples rewritten to
+    use the `async with Mistral(...) as client:` context-manager pattern required
+    by `mistralai >= 2.0`.
+  *Risk: documentation only.*
+
 ### Fixed
 
 - **`docs/guides/vector_store_llm_integration.md`**:

--- a/agent_gantry/adapters/llm_client.py
+++ b/agent_gantry/adapters/llm_client.py
@@ -33,6 +33,9 @@ class LLMClient:
         """
         self._config = config
         self._client: Any = None
+        # mistralai >= 2.0 uses a per-call async context manager rather than a
+        # long-lived client object. Store only the API key for that provider.
+        self._mistral_api_key: str | None = None
         self._provider = config.provider
         self._model = config.model
         self._initialize_client()
@@ -58,14 +61,10 @@ class LLMClient:
 
             self._client = genai.Client(api_key=api_key)
         elif self._provider == "mistral":
-            from mistralai import Mistral
-
-            # mistralai 2.x requires `async with Mistral(...) as client:` for proper
-            # resource cleanup.  Migrating to 2.x means restructuring this class so
-            # that the context manager wraps each call instead of storing a long-lived
-            # client.  Until that work is done, mistralai is pinned to <2.0.0 in
-            # pyproject.toml.  See the migration note in the project CHANGELOG.
-            self._client = Mistral(api_key=api_key)
+            # mistralai >= 2.0 requires `async with Mistral(...) as client:` per call.
+            # We store only the API key here; the context manager is opened in
+            # classify_intent() so resources are released after every invocation.
+            self._mistral_api_key = api_key
         elif self._provider == "groq":
             from groq import AsyncGroq
 
@@ -164,13 +163,16 @@ Respond with ONLY the intent category name (e.g., "data_query"), nothing else.""
             )
             result = response.text.strip()
         elif self._provider == "mistral":
-            # mistralai >= 1.0 exposes a native async method: chat.complete_async()
-            response = await self._client.chat.complete_async(
-                model=self._model,
-                messages=[{"role": "user", "content": prompt}],
-                max_tokens=self._config.max_tokens,
-                temperature=self._config.temperature,
-            )
+            # mistralai >= 2.0: open a fresh async context manager per call.
+            from mistralai import Mistral
+
+            async with Mistral(api_key=self._mistral_api_key) as mistral_client:
+                response = await mistral_client.chat.complete_async(
+                    model=self._model,
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=self._config.max_tokens,
+                    temperature=self._config.temperature,
+                )
             result = response.choices[0].message.content.strip()
         else:
             raise ValueError(f"Unsupported provider: {self._provider}")
@@ -196,4 +198,6 @@ Respond with ONLY the intent category name (e.g., "data_query"), nothing else.""
         Returns:
             True if the client is initialized and ready
         """
+        if self._provider == "mistral":
+            return self._mistral_api_key is not None
         return self._client is not None

--- a/docs/reference/llm_sdk_compatibility.md
+++ b/docs/reference/llm_sdk_compatibility.md
@@ -80,9 +80,10 @@ print(response.choices[0].message.content)
 
 #### Responses API (Modern)
 ```python
-# The newer Responses API with simpler tool format
+# The newer Responses API with simpler tool format.
+# GPT-4.1 is the recommended model for agentic / Responses API workloads.
 response = client.responses.create(
-    model="gpt-4o",
+    model="gpt-4.1",
     instructions="You are a helpful assistant.",
     input="Hello!"
 )
@@ -146,7 +147,7 @@ tools_responses = await gantry.retrieve_tools(
 
 # Use with OpenAI Responses API
 response = client.responses.create(
-    model="gpt-4o",
+    model="gpt-4.1",
     input="What's the weather in SF?",
     tools=tools_responses
 )
@@ -502,49 +503,53 @@ response = model.generate_content("What's AAPL stock price?")
 
 ### Package
 ```bash
-pip install mistralai>=1.0.0,<2.0.0
+pip install mistralai>=2.0.0
 ```
 
 ### Client Initialization
 ```python
 from mistralai import Mistral
 
-client = Mistral(api_key="your-api-key")
+# mistralai 2.x uses an async context manager for proper resource cleanup
+async with Mistral(api_key="your-api-key") as client:
+    response = await client.chat.complete_async(...)
 ```
 
 ### Key Methods
 
-#### Chat Complete
+#### Chat Complete (async)
 ```python
-response = client.chat.complete(
-    model="mistral-large-latest",
-    messages=[
-        {"role": "user", "content": "Hello, Mistral!"}
-    ]
-)
-print(response.choices[0].message.content)
+# mistralai 2.x: use async with for proper resource cleanup
+async with Mistral(api_key="your-api-key") as client:
+    response = await client.chat.complete_async(
+        model="mistral-large-latest",
+        messages=[
+            {"role": "user", "content": "Hello, Mistral!"}
+        ]
+    )
+    print(response.choices[0].message.content)
 ```
 
 #### Fill-in-the-Middle (FIM)
 ```python
-# Code completion
-response = client.fim.complete(
-    model="codestral-latest",
-    prompt="def fibonacci(n):",
-    suffix="    return result"
-)
-print(response.choices[0].message.content)
+async with Mistral(api_key="your-api-key") as client:
+    response = await client.fim.complete_async(
+        model="codestral-latest",
+        prompt="def fibonacci(n):",
+        suffix="    return result"
+    )
+    print(response.choices[0].message.content)
 ```
 
 #### Agents
 ```python
-# Using Mistral's agent capabilities
-response = client.agents.complete(
-    agent_id="your-agent-id",
-    messages=[
-        {"role": "user", "content": "Help me with a task"}
-    ]
-)
+async with Mistral(api_key="your-api-key") as client:
+    response = await client.agents.complete_async(
+        agent_id="your-agent-id",
+        messages=[
+            {"role": "user", "content": "Help me with a task"}
+        ]
+    )
 ```
 
 ### Agent-Gantry Integration
@@ -553,7 +558,6 @@ response = client.agents.complete(
 from mistralai import Mistral
 from agent_gantry import AgentGantry
 
-client = Mistral(api_key="your-key")
 gantry = AgentGantry()
 
 @gantry.register
@@ -563,15 +567,16 @@ def send_notification(message: str, channel: str) -> str:
 
 await gantry.sync()
 
-# Get tools in OpenAI-compatible format
+# Get tools in OpenAI-compatible format (Mistral uses the same schema)
 tools = await gantry.retrieve_tools("send notification")
 
-# Use with Mistral (OpenAI-compatible format)
-response = client.chat.complete(
-    model="mistral-large-latest",
-    messages=[{"role": "user", "content": "Notify the team"}],
-    tools=tools
-)
+# Use with Mistral 2.x async context manager
+async with Mistral(api_key="your-key") as client:
+    response = await client.chat.complete_async(
+        model="mistral-large-latest",
+        messages=[{"role": "user", "content": "Notify the team"}],
+        tools=tools,
+    )
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,11 +158,7 @@ google-vertexai = [
     "google-cloud-aiplatform>=1.70.0",
 ]
 mistral = [
-    # mistralai 2.x introduces breaking changes (async context-manager client).
-    # Upgrade to >=2.0.0 requires updating LLMClient.classify_intent (Mistral
-    # branch) to use `async with Mistral(...) as client`. Keep <2.0.0 until
-    # that migration is complete.
-    "mistralai>=1.0.0,<2.0.0",
+    "mistralai>=2.0.0",
 ]
 groq = [
     "groq>=1.2.0",


### PR DESCRIPTION
## Summary

This PR completes the long-pending migration from `mistralai < 2.0` to `mistralai >= 2.0`, which requires using an async context manager (`async with Mistral(...) as client:`) for proper resource cleanup instead of storing a long-lived client instance.

## Changes

- **`agent_gantry/adapters/llm_client.py`**: 
  - Refactored `LLMClient` to store only the Mistral API key instead of a long-lived client instance
  - Updated `_initialize_client()` to skip client instantiation for Mistral provider
  - Modified `classify_intent()` to open a fresh async context manager per request for the Mistral branch
  - Updated `health_check()` to check `_mistral_api_key is not None` for Mistral provider
  - Added inline comments explaining the 2.x context-manager requirement

- **`pyproject.toml`**: 
  - Removed `<2.0.0` upper bound on `mistralai` dependency
  - Updated floor to `mistralai>=2.0.0`
  - Removed migration-blocker comment block

- **`docs/reference/llm_sdk_compatibility.md`**:
  - Updated Responses API examples to use `gpt-4.1` (recommended for agentic workloads) instead of `gpt-4o`
  - Updated Mistral installation command from `>=1.0.0,<2.0.0` to `>=2.0.0`
  - Rewrote all Mistral code examples to use the `async with Mistral(...) as client:` pattern
  - Updated Agent-Gantry integration example to use the new context-manager pattern

- **`CHANGELOG.md`**: 
  - Documented the migration with risk assessment (safe — no public API changes)

## Implementation Details

The refactoring is backwards-compatible for all callers using `LLMConfig(provider="mistral", ...)`. The context manager is opened and closed within `classify_intent()`, ensuring HTTP connections are properly released after each request. This aligns with `mistralai >= 2.0` SDK requirements and resolves the version constraint that was blocking users from installing Mistral 2.x alongside Agent-Gantry.

After merging, run `uv lock && uv sync --extra mistral` to update the lock file to `mistralai` 2.4.4 (latest stable).

https://claude.ai/code/session_01BF86D4JU9uEmvVMnmg19GB