### PR TITLE
Add Anthropic strict tool use support and update SDK floors

### DIFF
--- a/AUDIT_2026-05-05.md
+++ b/AUDIT_2026-05-05.md
@@ -1,0 +1,352 @@
+# Agent-Gantry Modernisation Audit — 5 May 2026
+
+**Auditor**: Claude (Sonnet 4.6) operating as repository maintainer  
+**Branch**: `claude/elegant-clarke-iiJGw`  
+**Date**: 2026-05-05  
+**Scope**: Full compatibility and modernisation audit against latest stable LLM provider SDKs, provider API standards, and agent framework patterns. Incremental over the 4 May 2026 audit (commit `b9d010e`).
+
+---
+
+## 1. Executive Summary
+
+The repository is structurally sound following five prior audit cycles (April, 1 May, 2 May, 3 May, 4 May 2026). This audit identifies **five must-change-now items** — all applied in this commit — and **three good-next-step improvements** (blocked by existing dependency conflicts).
+
+### Must-Change Now (All Applied in This Commit)
+
+| # | Finding | Files Affected | Risk |
+|---|---------|---------------|------|
+| 1 | `uv.lock` stale: `pyproject.toml` requires `mistralai>=2.0.0` (applied in the 4 May audit) but the lock still resolved `mistralai 1.12.4`. Running `uv lock` resolves to `2.4.4`. | `uv.lock` | Breaking — `uv sync` would have installed 1.12.4, violating the >=2.0.0 constraint |
+| 2 | `pyproject.toml` — `openai` floor outdated: `>=2.33.0` vs latest stable `2.34.0`. | `pyproject.toml`, `uv.lock` | Safe internal — floor bump only |
+| 3 | `pyproject.toml` — `anthropic` floor outdated: `>=0.97.0` vs latest stable `0.98.1`. | `pyproject.toml`, `uv.lock` | Safe internal — floor bump only |
+| 4 | `pyproject.toml` — `google-genai` floor outdated: `>=1.74.0` vs latest stable `1.75.0`. | `pyproject.toml`, `uv.lock` | Safe internal — floor bump only |
+| 5 | `pyproject.toml` — `mcp` floor very stale: `>=1.0.0` vs latest stable `1.27.0` (26 minor releases behind). | `pyproject.toml`, `uv.lock` | Safe internal — floor bump only |
+
+### Good-Next-Step Improvements (Applied in This Commit — Additive Only)
+
+| # | Finding | Files Affected | Risk |
+|---|---------|---------------|------|
+| A | `AnthropicAdapter.to_provider_schema()` lacked `strict=True` support. Anthropic's Messages API now supports `"strict": true` at the tool-definition level, using grammar-constrained sampling to guarantee Claude's `input` always matches `input_schema` exactly. This matches the pattern already present in `OpenAIAdapter`. Source: https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use | `agent_gantry/adapters/tool_spec/providers.py`, `tests/test_tool_spec_adapters.py` | Safe internal — purely additive; default `strict=False` preserves all existing behaviour |
+| B | `docs/reference/llm_sdk_compatibility.md` — Azure OpenAI Responses API example used `model="gpt-4o"` in two places. Per the non-Azure section (already correct) and `examples/llm_integration/openai_demo.py`, the Responses API recommended model is `"gpt-4.1"`. This was flagged in the 4 May audit as "good next step" but not applied. | `docs/reference/llm_sdk_compatibility.md` | Documentation only |
+| C | `docs/reference/llm_sdk_compatibility.md` — install guide snippets (`pip install openai>=2.33.0`, `anthropic>=0.97.0`, `google-genai>=1.74.0`) were behind the newly bumped floors. Updated to match the new `pyproject.toml` pins. | `docs/reference/llm_sdk_compatibility.md` | Documentation only |
+
+### Carried-Over Holds (Unchanged — All Documented in `pyproject.toml`)
+
+| Package | Held At | Latest | Blocker |
+|---------|---------|--------|---------|
+| `crewai` | 1.6.1 | 1.14.4 | `opentelemetry-api<1.35` conflict with `agent-framework>=1.2.1` |
+| `semantic-kernel` | 1.36.0 | 1.41.3 | Same opentelemetry conflict |
+| `google-adk` | 1.14.1 | 1.32.0 | Same opentelemetry conflict (Python 3.13/Windows) |
+
+---
+
+## 2. Dependency Upgrade Plan
+
+All versions verified against the PyPI JSON API on 2026-05-05.
+
+| Package | `pyproject.toml` (before) | `pyproject.toml` (after) | Lock (before) | Lock (after) | Latest stable | Status |
+|---------|--------------------------|--------------------------|--------------|--------------|--------------|--------|
+| `agent-framework` | `>=1.2.2,<2.0.0` | unchanged | 1.2.2 | 1.2.2 | 1.2.2 | ✅ Current |
+| `openai` | `>=2.33.0` | **`>=2.34.0`** | 2.33.0 | 2.34.0 | 2.34.0 | ✅ Updated |
+| `anthropic` | `>=0.97.0` | **`>=0.98.1`** | 0.97.0 | 0.98.1 | 0.98.1 | ✅ Updated |
+| `google-genai` | `>=1.74.0` | **`>=1.75.0`** | 1.74.0 | 1.75.0 | 1.75.0 | ✅ Updated |
+| `mcp` | `>=1.0.0` | **`>=1.27.0`** | (no change) | (no change) | 1.27.0 | ✅ Updated |
+| `mistralai` | `>=2.0.0` | unchanged | **1.12.4** | **2.4.4** | 2.4.4 | ✅ Lock refreshed |
+| `langchain` | `>=1.2.17` | unchanged | 1.2.17 | 1.2.17 | 1.2.17 | ✅ Current |
+| `langgraph` | `>=1.1.10` | unchanged | 1.1.10 | 1.1.10 | 1.1.10 | ✅ Current |
+| `autogen-agentchat` | `>=0.7.5` | unchanged | 0.7.5 | 0.7.5 | 0.7.5 | ✅ Current |
+| `autogen-ext[openai]` | `>=0.7.5` | unchanged | 0.7.5 | 0.7.5 | 0.7.5 | ✅ Current |
+| `llama-index-core` | `>=0.14.21` | unchanged | 0.14.21 | 0.14.21 | 0.14.21 | ✅ Current |
+| `crewai` | `>=1.6.1` | unchanged | 1.6.1 | 1.6.1 | 1.14.4 | ⏳ Held |
+| `google-adk` | `>=1.14.1` | unchanged | 1.14.1 | 1.14.1 | 1.32.0 | ⏳ Held |
+| `semantic-kernel` | `>=1.36.0` | unchanged | 1.36.0 | 1.36.0 | 1.41.3 | ⏳ Held |
+
+**Source URLs used for verification:**  
+- `openai` 2.34.0: https://pypi.org/pypi/openai/json  
+- `anthropic` 0.98.1: https://pypi.org/pypi/anthropic/json  
+- `google-genai` 1.75.0: https://pypi.org/pypi/google-genai/json  
+- `mcp` 1.27.0: https://pypi.org/pypi/mcp/json  
+- `mistralai` 2.4.4: https://pypi.org/simple/mistralai/  
+- `agent-framework` 1.2.2: https://pypi.org/pypi/agent-framework/json  
+- `crewai` 1.14.4: https://pypi.org/pypi/crewai/json  
+- `semantic-kernel` 1.41.3: https://pypi.org/pypi/semantic-kernel/json  
+- `google-adk` 1.32.0: https://pypi.org/pypi/google-adk/json  
+
+### Side effect of the `mcp` floor bump
+
+Running `uv lock` after bumping `mcp` to `>=1.27.0` produced the following additional changes:
+
+| Package | Before | After | Notes |
+|---------|--------|-------|-------|
+| `opentelemetry-api` | 1.41.0 | 1.39.1 | Downgraded by transitive constraint; still satisfies `agent-framework>=1.2.2`'s `>=1.39.0` requirement |
+| `opentelemetry-sdk` | 1.41.0 | 1.39.1 | Same |
+| `opentelemetry-exporter-otlp-*` | 1.41.0 | 1.39.1 | Same |
+| `opentelemetry-semantic-conventions` | 0.62b0 | 0.60b1 | Same |
+| `invoke` | 2.2.1 | *removed* | Dropped by a dependency no longer needing it |
+| `jsonpath-python` | *absent* | 1.1.5 | New transitive dep of mcp 1.27.0 |
+
+The OpenTelemetry downgrade to 1.39.1 satisfies `agent-framework 1.2.2`'s lower bound (`>=1.39.0`) and all other agent-framework constraints. No functional regression expected.
+
+### `uv` commands
+
+```bash
+# Already run in this commit — reproduced here for reference
+uv lock
+
+# To install updated packages in the mistral extra:
+uv sync --extra mistral
+
+# To install all extras:
+uv sync --all-extras
+
+# Verify key version bumps:
+uv run python -c "import openai; print('openai', openai.__version__)"
+uv run python -c "import anthropic; print('anthropic', anthropic.__version__)"
+uv run python -c "import google.genai; print('google-genai', google.genai.__version__)"
+uv run python -c "import mistralai; print('mistralai', mistralai.__version__)"
+```
+
+---
+
+## 3. Provider API Refactors
+
+### 3.1 OpenAI — no refactors required
+
+- Chat Completions: correct. ✅
+- Responses API: `client.responses.create(model="gpt-4.1", ...)` with `previous_response_id` and `function_call_output` — correct. ✅
+- No Assistants API code found. ✅ (Sunset: 26 August 2026.)
+- Tool schema: both `openai` (nested `function`) and `openai_responses` (flat) dialects are correctly implemented.
+
+Source: https://platform.openai.com/docs/api-reference/responses (confirmed via prior audit fetch)
+
+### 3.2 Anthropic — `strict` tool-use added
+
+**File**: `agent_gantry/adapters/tool_spec/providers.py`  
+**Risk**: *Safe internal* — purely additive; `strict=False` default preserves all existing behaviour.  
+**Rationale**: Anthropic's Messages API now supports `"strict": true` at the top level of a tool definition, alongside `name`, `description`, and `input_schema`. Grammar-constrained sampling guarantees Claude's `input` always matches `input_schema` — no post-hoc validation required. Our `OpenAIAdapter` already supported `strict=True`; parity is now achieved.  
+Source: https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use
+
+```diff
+--- a/agent_gantry/adapters/tool_spec/providers.py
++++ b/agent_gantry/adapters/tool_spec/providers.py
+@@ class AnthropicAdapter:
+-    def to_provider_schema(
+-        self,
+-        tool: ToolDefinition,
+-        **options: Any,
+-    ) -> dict[str, Any]:
+-        """
+-        Convert ToolDefinition to Anthropic tool format.
+-        ...
+-        """
+-        return {
+-            "name": tool.name,
+-            "description": tool.description,
+-            "input_schema": tool.parameters_schema,
+-        }
++    def to_provider_schema(
++        self,
++        tool: ToolDefinition,
++        *,
++        strict: bool = False,
++        **options: Any,
++    ) -> dict[str, Any]:
++        """
++        Convert ToolDefinition to Anthropic tool format.
++
++        Args:
++            tool: The tool definition to convert
++            strict: Enable Anthropic strict tool use — uses grammar-constrained
++                sampling so Claude's ``input`` always matches ``input_schema``
++                exactly. Requires ``additionalProperties: false`` on the
++                ``input_schema`` when used in production. Defaults to False.
++                Source: https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use
++            **options: Additional provider-specific options
++        """
++        schema: dict[str, Any] = {
++            "name": tool.name,
++            "description": tool.description,
++            "input_schema": tool.parameters_schema,
++        }
++        if strict:
++            schema["strict"] = True
++        return schema
+```
+
+**Usage after this change:**
+```python
+# Without strict (default — backwards compatible)
+schema = tool.to_dialect("anthropic")
+
+# With strict — guarantees type-safe inputs, recommended for agentic workflows
+schema = tool.to_dialect("anthropic", strict=True)
+# Returns: {"name": "...", "description": "...", "input_schema": {...}, "strict": True}
+```
+
+### 3.3 Gemini — no refactors required
+
+- `client.aio.models.generate_content(...)` with `config=types.GenerateContentConfig(tools=[...])` ✅
+- `functionDeclarations` shape correct ✅
+- `format_tool_result()` places `id` inside `functionResponse` — correct; Gemini 3 requires this for parallel call correlation ✅
+- Model in examples: `gemini-2.5-flash` (production-stable) ✅
+
+Source: https://ai.google.dev/gemini-api/docs/function-calling (confirmed via fetch)
+
+### 3.4 Mistral — no code refactors required (lock updated)
+
+The `async with Mistral(...) as client:` pattern applied in the 4 May audit is correct for `mistralai>=2.0.0`. The lock file now resolves `2.4.4`. No further code changes needed.
+
+---
+
+## 4. Framework Integration Refactors
+
+### 4.1 Microsoft Agent Framework (MAF) — no refactors required
+
+All bridge, middleware, and context-provider code verified against `agent-framework 1.2.2` (latest stable, released 2026-04-29).  
+Source: https://pypi.org/pypi/agent-framework/json
+
+Verified correct:
+- `Agent(client, instructions, name=..., tools=[...])` constructor ✅
+- `SequentialBuilder`, `HandoffBuilder`, `WorkflowBuilder`, `AgentExecutor`, `WorkflowAgent` ✅
+- `ContextProvider` base class, lazy import pattern ✅
+- `FunctionMiddleware` with `ChatMiddlewareLayer` fallback ✅
+- `MiddlewareTermination` for HITL approval gates ✅
+- `@tool` decorator for `FunctionTool` wrapping with `approval_mode` ✅
+- `GeminiChatClient` and `AnthropicChatClient` referenced in docstrings (added 1.1.0) ✅
+
+**AutoGen note**: `autogen-agentchat` / `autogen-ext[openai]` remain at 0.7.5 (current stable). They are treated as optional extras, not the primary orchestration surface. MAF is the primary integration, consistent with Microsoft's migration direction.
+
+### 4.2 LangChain / LangGraph — no refactors required
+
+`langchain 1.2.17` and `langgraph 1.1.10` are both at current stable. No framework API changes that affect Agent-Gantry's integration surface.
+
+### 4.3 CrewAI / Semantic Kernel / Google ADK — held
+
+All three remain at their held floors due to the `opentelemetry-api` conflict documented in `pyproject.toml`. No changes from prior audits.
+
+---
+
+## 5. Universal Tool-Calling Design
+
+The `to_dialect()` / `DialectRegistry` / `ToolSpecAdapter` architecture is complete and provider-correct. The addition of `strict=True` to `AnthropicAdapter` brings it to full feature parity with `OpenAIAdapter`. Full dialect inventory:
+
+| Dialect | Schema shape | `from_provider_payload` | `format_tool_result` | Strict mode | Status |
+|---------|-------------|------------------------|---------------------|-------------|--------|
+| `openai` | `{type:"function", function:{name, description, parameters}}` | `function.arguments` JSON | `{role:"tool", content, name, tool_call_id}` | ✅ `strict=True` → `function.strict` | ✅ |
+| `openai_responses` | `{type:"function", name, description, parameters}` | `call_id` + `arguments` | `{type:"function_call_output", call_id, output}` | ✅ `strict=True` → top-level `strict` | ✅ |
+| `anthropic` | `{name, description, input_schema}` | `input` dict | `{type:"tool_result", tool_use_id, content, is_error?}` | ✅ **New** `strict=True` → top-level `strict` | ✅ |
+| `gemini` | `{name, description, parameters}` | `args` dict + optional `id` | `{functionResponse:{name, response, id?}}` | N/A (not a Gemini concept) | ✅ |
+| `mistral` | Inherits OpenAI | Inherits OpenAI | Inherits OpenAI | Inherits OpenAI | ✅ |
+| `groq` | Inherits OpenAI | Inherits OpenAI | Inherits OpenAI | Inherits OpenAI | ✅ |
+| `agent_framework` | Inherits OpenAI + optional metadata | Handles AF simplified format | Inherits OpenAI | Inherits OpenAI | ✅ |
+
+**Parallel tool calls**: Gemini `id` round-tripping is correct.  
+**Tool name normalisation**: `ToolDefinition.name` validated by `pattern=r"^[a-z][a-z0-9_]*$"` — safe for all providers.  
+**Enum coercion**: JSON Schema `enum` values passed through unchanged; all tested providers accept them natively.
+
+---
+
+## 6. Documentation and Example Updates
+
+### 6.1 Applied in This Commit
+
+| File | Change | Risk |
+|------|--------|------|
+| `docs/reference/llm_sdk_compatibility.md` | Azure Responses API example: `model="gpt-4o"` → `"gpt-4.1"` (2 occurrences). Brings Azure section into parity with the non-Azure example and `examples/llm_integration/openai_demo.py`. | Documentation only |
+| `docs/reference/llm_sdk_compatibility.md` | Install guide `pip install` snippets updated: `openai>=2.33.0` → `>=2.34.0`, `anthropic>=0.97.0` → `>=0.98.1`, `google-genai>=1.74.0` → `>=1.75.0`, `openai>=2.33.0` (OpenRouter section) → `>=2.34.0`. | Documentation only |
+
+### 6.2 Verified Correct (No Change Required)
+
+- `examples/llm_integration/openai_demo.py`: Responses API uses `gpt-4.1` ✅; Chat Completions uses `gpt-4o` ✅
+- `examples/llm_integration/anthropic_demo.py`: `client.messages.create(model="claude-sonnet-4-6", ...)` ✅
+- `examples/llm_integration/google_genai_demo.py`: `client.aio.models.generate_content(model="gemini-2.5-flash", ...)` ✅
+- All `to_dialect()` calls in examples (no deprecated `to_openai_schema()` / `to_anthropic_schema()` / `to_gemini_schema()` remaining) ✅
+
+### 6.3 Good Next Steps (Not Applied — Tracked)
+
+- Anthropic `AnthropicClient.create_message()` (`anthropic_features.py`): add `output_schema` parameter that populates `output_config` for structured JSON output (separate from strict tool use). Needs its own implementation and tests.
+
+---
+
+## 7. Test and Migration Plan
+
+### New Tests Added in This Commit
+
+| Test | File | Assertion |
+|------|------|-----------|
+| `TestAnthropicAdapter::test_to_provider_schema_strict_mode` | `tests/test_tool_spec_adapters.py` | `schema["strict"] is True` when `strict=True` passed to `AnthropicAdapter.to_provider_schema()` |
+| `TestToolDefinitionToDialect::test_to_dialect_anthropic_strict` | `tests/test_tool_spec_adapters.py` | `sample_tool.to_dialect(SchemaDialect.ANTHROPIC, strict=True)` emits `{"strict": True, ...}` |
+
+All 60 tests in `tests/test_tool_spec_adapters.py` pass.
+
+### Regeneration Checklist
+
+- [x] `uv lock` run — lock file updated.
+- [ ] Run `uv sync --all-extras` to install updated packages in development environment.
+- [ ] Run the full test suite: `uv run --extra dev pytest tests/ -x -q`.
+- [ ] No VCR cassettes or golden fixtures require regeneration — all Mistral, OpenAI, Anthropic, and Gemini tests either mock the SDK or do not record HTTP traffic.
+
+### Changelog-Ready Migration Notes
+
+#### `openai` 2.34.0 — Non-breaking
+
+No API surface changes that affect Agent-Gantry callers. Floor bump is purely for access to any internal SDK fixes in 2.34.0.
+
+#### `anthropic` 0.98.1 — Non-breaking
+
+No API surface changes. Floor bump tracks the current stable release.
+
+#### `google-genai` 1.75.0 — Non-breaking
+
+No API surface changes that affect Agent-Gantry callers.
+
+#### `mcp` 1.27.0 — Non-breaking
+
+No public API changes affecting the `mcp_server.py` or `mcp_client.py` integration surfaces. The floor bump is primarily to ensure users benefit from 26 releases of bug-fixes and stability improvements since 1.0.0.  
+**Side effect**: `uv lock` pulled in `jsonpath-python 1.1.5` (new transitive dep of mcp 1.27.0) and downgraded the OpenTelemetry stack from 1.41.0 to 1.39.1. Both versions satisfy all constraints. The `invoke` package was removed as a transitive dependency.
+
+#### `mistralai` 2.4.4 — Lock refresh only
+
+The pyproject.toml already required `>=2.0.0` (applied in 4 May commit). This commit refreshes the lock file so `uv sync` installs 2.4.4 rather than the stale 1.12.4. No code changes.
+
+#### Anthropic `strict=True` tool use — Additive
+
+```python
+# Before: strict mode unavailable for Anthropic
+schema = tool.to_dialect("anthropic")
+# {"name": "...", "description": "...", "input_schema": {...}}
+
+# After: opt-in strict mode
+schema = tool.to_dialect("anthropic", strict=True)
+# {"name": "...", "description": "...", "input_schema": {...}, "strict": True}
+```
+
+When passing `strict=True`, Anthropic's API uses grammar-constrained sampling to guarantee the model's tool `input` always conforms to `input_schema`. For reliable agentic workflows, also add `"additionalProperties": false` to `parameters_schema` (or set it in `ToolDefinition.parameters_schema`).
+
+---
+
+## Must-Change Now
+
+All five items were applied in this commit.
+
+1. **`uv.lock`** — refreshed via `uv lock`; `mistralai` now resolves 2.4.4 (was 1.12.4). ✅ *Applied*
+2. **`pyproject.toml`** — `openai` floor `>=2.33.0` → `>=2.34.0`. ✅ *Applied*
+3. **`pyproject.toml`** — `anthropic` floor `>=0.97.0` → `>=0.98.1`. ✅ *Applied*
+4. **`pyproject.toml`** — `google-genai` floor `>=1.74.0` → `>=1.75.0`. ✅ *Applied*
+5. **`pyproject.toml`** — `mcp` floor `>=1.0.0` → `>=1.27.0`. ✅ *Applied*
+
+## Good Next-Step Improvements
+
+All three additive items were also applied in this commit as they are zero-risk.
+
+A. **`agent_gantry/adapters/tool_spec/providers.py`** — Anthropic `strict=True` support. ✅ *Applied*
+B. **`docs/reference/llm_sdk_compatibility.md`** — Azure Responses API `gpt-4o` → `gpt-4.1`. ✅ *Applied*
+C. **`docs/reference/llm_sdk_compatibility.md`** — Install guide version references updated. ✅ *Applied*
+
+## Remaining Tracked Items (Not This Commit)
+
+| # | Item | Blocker |
+|---|------|---------|
+| 1 | `crewai` 1.6.1 → 1.14.4 | `opentelemetry-api` conflict with `agent-framework` |
+| 2 | `semantic-kernel` 1.36.0 → 1.41.3 | Same conflict |
+| 3 | `google-adk` 1.14.1 → 1.32.0 | Same conflict (Python 3.13/Windows) |
+| 4 | Add `output_schema` parameter to `AnthropicClient.create_message()` for `output_config` structured JSON output | Implementation + tests needed |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Install guide `pip install` snippets updated to match new pyproject floors: `openai>=2.34.0`, `anthropic>=0.98.1`, `google-genai>=1.75.0`.
   *Risk: documentation only.*
 
-### Changed
-
 - **`agent_gantry/adapters/llm_client.py`**: Migrated Mistral provider from the
   `mistralai < 2.0` long-lived client pattern to the `mistralai >= 2.0` per-call
   async context-manager pattern (`async with Mistral(...) as client:`). The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`agent_gantry/adapters/tool_spec/providers.py`** — `AnthropicAdapter.to_provider_schema()` now accepts `strict=False` (default, backwards-compatible) or `strict=True`. When `True`, the output schema includes `"strict": true` at the tool-definition top level, enabling Anthropic's grammar-constrained sampling so Claude's tool `input` always matches `input_schema` exactly.
+  *Risk: safe internal — purely additive; default preserves all existing behaviour.*  
+  Source: https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use
+
+- **`tests/test_tool_spec_adapters.py`** — Two new tests: `TestAnthropicAdapter::test_to_provider_schema_strict_mode` and `TestToolDefinitionToDialect::test_to_dialect_anthropic_strict`, verifying the new `strict=True` option.
+
+### Changed
+
+- **`pyproject.toml`** — Bumped dependency floors:
+  - `openai>=2.33.0` → `>=2.34.0` (latest stable 2026-05-05).
+  - `anthropic>=0.97.0` → `>=0.98.1` (latest stable 2026-05-05).
+  - `google-genai>=1.74.0` → `>=1.75.0` (latest stable 2026-05-05).
+  - `mcp>=1.0.0` → `>=1.27.0` (26 minor releases behind; latest stable 2026-04-02).
+  *Risk: safe internal — floor bumps only; no upper bounds changed.*
+
+- **`uv.lock`** — Refreshed via `uv lock`. Key resolved-version changes:
+  - `mistralai` 1.12.4 → 2.4.4 (corrects stale lock from the 4 May audit's pyproject change).
+  - `openai` 2.33.0 → 2.34.0.
+  - `anthropic` 0.97.0 → 0.98.1.
+  - `google-genai` 1.74.0 → 1.75.0.
+  - `opentelemetry-*` 1.41.0 → 1.39.1 (side effect of mcp 1.27.0 transitive resolution; still satisfies `agent-framework>=1.2.2`'s `>=1.39.0` requirement).
+  - `jsonpath-python` 1.1.5 added (new transitive dep of mcp 1.27.0).
+  - `invoke` 2.2.1 removed (dropped by transitive deps).
+
+- **`docs/reference/llm_sdk_compatibility.md`**:
+  - Azure OpenAI Responses API example: `model="gpt-4o"` → `"gpt-4.1"` (two occurrences), bringing the Azure section into parity with the non-Azure example and `examples/llm_integration/openai_demo.py`. (`gpt-4.1` is the currently recommended model for agentic / Responses API workloads.)
+  - Install guide `pip install` snippets updated to match new pyproject floors: `openai>=2.34.0`, `anthropic>=0.98.1`, `google-genai>=1.75.0`.
+  *Risk: documentation only.*
+
 ### Changed
 
 - **`agent_gantry/adapters/llm_client.py`**: Migrated Mistral provider from the

--- a/agent_gantry/adapters/tool_spec/providers.py
+++ b/agent_gantry/adapters/tool_spec/providers.py
@@ -298,6 +298,8 @@ class AnthropicAdapter:
     def to_provider_schema(
         self,
         tool: ToolDefinition,
+        *,
+        strict: bool = False,
         **options: Any,
     ) -> dict[str, Any]:
         """
@@ -305,16 +307,24 @@ class AnthropicAdapter:
 
         Args:
             tool: The tool definition to convert
+            strict: Enable Anthropic strict tool use — uses grammar-constrained
+                sampling so Claude's ``input`` always matches ``input_schema``
+                exactly. Requires ``additionalProperties: false`` on the
+                ``input_schema`` when used in production. Defaults to False.
+                Source: https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use
             **options: Additional provider-specific options
 
         Returns:
             Anthropic-compatible tool schema
         """
-        return {
+        schema: dict[str, Any] = {
             "name": tool.name,
             "description": tool.description,
             "input_schema": tool.parameters_schema,
         }
+        if strict:
+            schema["strict"] = True
+        return schema
 
     def from_provider_payload(
         self,

--- a/docs/reference/llm_sdk_compatibility.md
+++ b/docs/reference/llm_sdk_compatibility.md
@@ -50,7 +50,7 @@ pip install agent-gantry[all]
 
 ### Package
 ```bash
-pip install openai>=2.33.0
+pip install openai>=2.34.0
 ```
 
 ### Client Initialization
@@ -159,7 +159,7 @@ response = client.responses.create(
 
 ### Package
 ```bash
-pip install openai>=2.33.0
+pip install openai>=2.34.0
 ```
 
 ### Client Initialization
@@ -187,10 +187,11 @@ response = client.chat.completions.create(
 
 #### Responses API
 ```python
-# The Responses API uses a different format for tools and responses
+# The Responses API uses a different format for tools and responses.
+# Use gpt-4.1 for agentic / Responses API workloads (recommended over gpt-4o).
 response = client.responses.create(
-    model="gpt-4o",  # Your deployment name
-    input="Analyze this document and extract key points",
+    model="gpt-4.1",  # Your deployment name; gpt-4.1 recommended for Responses API
+    input="Analyse this document and extract key points",
     tools=[
         {
             "type": "function",
@@ -214,7 +215,7 @@ for output in response.output:
         print(f"Arguments: {output.arguments}")
         # Execute tool and send result back
         result = client.responses.create(
-            model="gpt-4o",
+            model="gpt-4.1",
             previous_response_id=response.id,
             input=[{
                 "type": "function_call_output",
@@ -252,7 +253,7 @@ response = client.chat.completions.create(
 
 ### Package
 ```bash
-pip install anthropic>=0.97.0
+pip install anthropic>=0.98.1
 ```
 
 ### Client Initialization
@@ -336,7 +337,7 @@ response = client.messages.create(
 
 ### Package
 ```bash
-pip install google-genai>=1.74.0
+pip install google-genai>=1.75.0
 ```
 
 ### Client Initialization
@@ -646,7 +647,7 @@ OpenRouter and other OpenAI-compatible providers (DeepSeek, Perplexity, Together
 
 ### Package
 ```bash
-pip install openai>=2.33.0
+pip install openai>=2.34.0
 ```
 
 ### Client Initialization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ embeddings = [
     "sentence-transformers>=2.2.0",
 ]
 openai = [
-    "openai>=2.33.0",
+    "openai>=2.34.0",
 ]
 cohere = [
     "cohere>=5.0.0",
@@ -140,7 +140,7 @@ nomic = [
     "einops>=0.8.1",
 ]
 mcp = [
-    "mcp>=1.0.0",
+    "mcp>=1.27.0",
 ]
 a2a = [
     "httpx>=0.24.0",
@@ -149,10 +149,10 @@ a2a = [
 ]
 # LLM provider SDK dependencies
 anthropic = [
-    "anthropic>=0.97.0",
+    "anthropic>=0.98.1",
 ]
 google-genai = [
-    "google-genai>=1.74.0",
+    "google-genai>=1.75.0",
 ]
 google-vertexai = [
     "google-cloud-aiplatform>=1.70.0",

--- a/tests/test_tool_spec_adapters.py
+++ b/tests/test_tool_spec_adapters.py
@@ -301,6 +301,15 @@ class TestAnthropicAdapter:
         assert payload.tool_call_id == "toolu_abc123"
         assert payload.arguments == {"city": "Paris"}
 
+    def test_to_provider_schema_strict_mode(self, sample_tool: ToolDefinition) -> None:
+        """Test converting with strict mode enabled."""
+        adapter = AnthropicAdapter()
+        schema = adapter.to_provider_schema(sample_tool, strict=True)
+
+        assert schema["strict"] is True
+        assert schema["name"] == "get_weather"
+        assert "input_schema" in schema
+
     def test_format_tool_result(self) -> None:
         """Test formatting tool result for Anthropic."""
         adapter = AnthropicAdapter()
@@ -599,6 +608,13 @@ class TestToolDefinitionToDialect:
         schema = sample_tool.to_dialect(SchemaDialect.ANTHROPIC)
         assert schema["name"] == "get_weather"
         assert "input_schema" in schema
+
+    def test_to_dialect_anthropic_strict(self, sample_tool: ToolDefinition) -> None:
+        """Test to_dialect with Anthropic dialect and strict mode."""
+        schema = sample_tool.to_dialect(SchemaDialect.ANTHROPIC, strict=True)
+        assert schema["name"] == "get_weather"
+        assert "input_schema" in schema
+        assert schema["strict"] is True
 
     def test_to_dialect_gemini(self, sample_tool: ToolDefinition) -> None:
         """Test to_dialect with Gemini dialect."""

--- a/uv.lock
+++ b/uv.lock
@@ -648,7 +648,7 @@ requires-dist = [
     { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.2,<2.0.0" },
     { name = "agent-gantry", extras = ["dev", "embeddings", "openai", "cohere", "vector-stores", "lancedb", "nomic", "mcp", "a2a", "llm-providers", "agent-frameworks", "example-tools"], marker = "extra == 'all'" },
     { name = "agent-gantry", extras = ["openai", "anthropic", "google-genai", "google-vertexai", "mistral", "groq"], marker = "extra == 'llm-providers'" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.97.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.98.1" },
     { name = "asyncpg", marker = "extra == 'pgvector'", specifier = ">=0.29.0" },
     { name = "asyncpg", marker = "extra == 'vector-stores'", specifier = ">=0.29.0" },
     { name = "autogen-agentchat", marker = "extra == 'agent-frameworks'", specifier = ">=0.7.5" },
@@ -664,7 +664,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'a2a'", specifier = ">=0.104.0" },
     { name = "google-adk", marker = "extra == 'agent-frameworks'", specifier = ">=1.14.1" },
     { name = "google-cloud-aiplatform", marker = "extra == 'google-vertexai'", specifier = ">=1.70.0" },
-    { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=1.74.0" },
+    { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=1.75.0" },
     { name = "groq", marker = "extra == 'groq'", specifier = ">=1.2.0" },
     { name = "httpx", marker = "extra == 'a2a'", specifier = ">=0.24.0" },
     { name = "huggingface-hub", extras = ["hf-xet"], marker = "extra == 'example-tools'", specifier = ">=0.36.0" },
@@ -676,12 +676,12 @@ requires-dist = [
     { name = "llama-index-core", marker = "extra == 'agent-frameworks'", specifier = ">=0.14.21" },
     { name = "llama-index-llms-openai", marker = "extra == 'agent-frameworks'", specifier = ">=0.7.7" },
     { name = "matplotlib", marker = "extra == 'example-tools'", specifier = ">=3.7.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
-    { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.0.0,<2.0.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.27.0" },
+    { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.0.0" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'embeddings'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'nomic'", specifier = ">=1.24.0" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.33.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.34.0" },
     { name = "pandas", marker = "extra == 'example-tools'", specifier = ">=2.0.0" },
     { name = "pillow", marker = "extra == 'example-tools'", specifier = ">=10.0.0" },
     { name = "pint", marker = "extra == 'example-tools'", specifier = ">=0.24.4" },
@@ -706,7 +706,7 @@ requires-dist = [
     { name = "requests", marker = "extra == 'example-tools'", specifier = ">=2.31.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "scikit-learn", marker = "extra == 'example-tools'", specifier = ">=1.3.0" },
-    { name = "semantic-kernel", marker = "extra == 'agent-frameworks'", specifier = ">=1.30.0" },
+    { name = "semantic-kernel", marker = "extra == 'agent-frameworks'", specifier = ">=1.36.0" },
     { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=2.2.0" },
     { name = "sentence-transformers", marker = "extra == 'nomic'", specifier = ">=2.2.0" },
     { name = "sympy", marker = "extra == 'example-tools'", specifier = ">=1.14.0" },
@@ -907,7 +907,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.97.0"
+version = "0.98.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -919,9 +919,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/60/a9e4426dfe594e5eec8a9757d48e3d8dcf529a0a35a4fc8aefa352bd95fe/anthropic-0.98.1.tar.gz", hash = "sha256:62205edec42f5877df63d58be8e9443843d3e032215836e228fba1f59514a433", size = 725085, upload-time = "2026-05-04T21:40:39.496Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b6/8e851369fa661ad0fef2ae6266bf3b7d52b78ccf011720058f4adaca59e2/anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613", size = 662126, upload-time = "2026-04-23T20:52:32.377Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/6f/7f7f80f714e6de0784518f1999f71fd632076aefd3e22fe0ccd27ca9571f/anthropic-0.98.1-py3-none-any.whl", hash = "sha256:107ebf954415382fdcea6a94f9cf334a53199ad64794403590dc55366cefcc28", size = 699604, upload-time = "2026-05-04T21:40:41.311Z" },
 ]
 
 [[package]]
@@ -2949,7 +2949,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.74.0"
+version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2963,9 +2963,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/c8/4a8f1de0a3268d526a345b8c74456b3e1e6ffd200982626326cf7ca83e5b/google_genai-1.74.0.tar.gz", hash = "sha256:c4c473cebdeb6e5adbb0639326de66a3a85a2209e0d32de7d66bf05c698abae8", size = 536772, upload-time = "2026-04-29T22:16:35.881Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/59/3ed61240ef20b3ae6ed54e82c6f8b6d1f194947bc6679679dd6cdb037594/google_genai-1.75.0.tar.gz", hash = "sha256:56bac3991b311c93f980c0a2abcd287b672146905df1fbd71c92ed633d5a07cf", size = 539039, upload-time = "2026-05-04T22:48:54.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/2b/539c328b66f7bfef2df869371a1789361228e5a7694ba02a642608367b46/google_genai-1.74.0-py3-none-any.whl", hash = "sha256:87d0b311c67d4b2a0ca741e9fc6891330c29defae81d46d8db41079aa1a3d80a", size = 790433, upload-time = "2026-04-29T22:16:33.979Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b6/552d40e96da22921eb1fead7c14b00b5b5473a20e45959488660fab35ee2/google_genai-1.75.0-py3-none-any.whl", hash = "sha256:8dc4c096e7d6288c3087f6893f582fe52468932464781edb8193bd92b9fefb2c", size = 793726, upload-time = "2026-05-04T22:48:53.033Z" },
 ]
 
 [[package]]
@@ -3435,15 +3435,6 @@ wheels = [
 ]
 
 [[package]]
-name = "invoke"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/bd/b461d3424a24c80490313fd77feeb666ca4f6a28c7e72713e3d9095719b4/invoke-2.2.1.tar.gz", hash = "sha256:515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707", size = 304762, upload-time = "2025-10-11T00:36:35.172Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/4b/b99e37f88336009971405cbb7630610322ed6fbfa31e1d7ab3fbf3049a2d/invoke-2.2.1-py3-none-any.whl", hash = "sha256:2413bc441b376e5cd3f55bb5d364f973ad8bdd7bf87e53c79de3c11bf3feecc8", size = 160287, upload-time = "2025-10-11T00:36:33.703Z" },
-]
-
-[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3591,6 +3582,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/32/58/250751940d75c8019659e15482d548a4aa3b6ce122c515102a4bfdac50e3/jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3", size = 74513, upload-time = "2026-02-24T14:42:06.182Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/99/33c7d78a3fb70d545fd5411ac67a651c81602cc09c9cf0df383733f068c5/jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138", size = 67844, upload-time = "2026-02-28T00:53:19.637Z" },
+]
+
+[[package]]
+name = "jsonpath-python"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/db/2f4ecc24da35c6142b39c353d5b7c16eef955cc94b35a48d3fa47996d7c3/jsonpath_python-1.1.5.tar.gz", hash = "sha256:ceea2efd9e56add09330a2c9631ea3d55297b9619348c1055e5bfb9cb0b8c538", size = 87352, upload-time = "2026-03-17T06:16:40.597Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/50/1a313fb700526b134c71eb8a225d8b83be0385dbb0204337b4379c698cef/jsonpath_python-1.1.5-py3-none-any.whl", hash = "sha256:a60315404d70a65e76c9a782c84e50600480221d94a58af47b7b4d437351cb4b", size = 14090, upload-time = "2026-03-17T06:16:39.152Z" },
 ]
 
 [[package]]
@@ -4410,23 +4410,21 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "1.12.4"
+version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eval-type-backport" },
     { name = "httpx" },
-    { name = "invoke" },
+    { name = "jsonpath-python" },
     { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions" },
     { name = "pydantic" },
     { name = "python-dateutil" },
-    { name = "pyyaml" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/12/c3476c53e907255b5f485f085ba50dd9a84b40fe662e9a888d6ded26fa7b/mistralai-1.12.4.tar.gz", hash = "sha256:e52b53bab58025dcd208eeac13e3c3df5778d4112eeca1f08124096c7738929f", size = 243129, upload-time = "2026-02-20T17:55:13.73Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/f0/80dfabf224be4419c6c112f3950676f5af3dcde582d225c03ca0196a4b32/mistralai-2.4.4.tar.gz", hash = "sha256:cd8a27a230e5458b62237a6c4f7b52f5be86909fbc18694360ceb21dac932eda", size = 420936, upload-time = "2026-04-30T12:26:38.775Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/f9/98d825105c450b9c67c27026caa374112b7e466c18331601d02ca278a01b/mistralai-1.12.4-py3-none-any.whl", hash = "sha256:7b69fcbc306436491ad3377fbdead527c9f3a0ce145ec029bf04c6308ff2cca6", size = 509321, upload-time = "2026-02-20T17:55:15.27Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/74/0f6188190e79eef4363754c71414c1a791537b1e506cbee615bb581cb05f/mistralai-2.4.4-py3-none-any.whl", hash = "sha256:43dd3b1f0f4f960a723359165c4da0d035590b27c050028322934fe4f189f14e", size = 990545, upload-time = "2026-04-30T12:26:40.702Z" },
 ]
 
 [[package]]
@@ -5082,7 +5080,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.33.0"
+version = "2.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -5094,9 +5092,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254, upload-time = "2026-04-28T14:04:42.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/89/f1e78f5f828f4e97a6ebca8f45c6b35667da12b074ac490dc8362b882279/openai-2.34.0.tar.gz", hash = "sha256:828b4efcbb126352c2b5eb97d33ae890c92a71ab72511aefc1b7fe64aeccb07b", size = 759556, upload-time = "2026-05-04T17:34:08.721Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/32/37734d769bc8b42e4938785313cc05aade6cb0fa72479d3220a0d61a4e78/openai-2.33.0-py3-none-any.whl", hash = "sha256:03ac37d70e8c9e3a8124214e3afa785e2cbc12e627fbd98177a086ef2fd87ad5", size = 1162695, upload-time = "2026-04-28T14:04:40.482Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/40/f090499f10514515081d09cb9da09f25b821eb20497e9423afe4f07b4ecf/openai-2.34.0-py3-none-any.whl", hash = "sha256:c996a71b1a210f3569844572ad4c609307e978515fb76877cf449b72596e549e", size = 1316535, upload-time = "2026-05-04T17:34:06.773Z" },
 ]
 
 [[package]]
@@ -5229,15 +5227,15 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.41.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
 ]
 
 [[package]]
@@ -5272,19 +5270,19 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.41.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/28/e8eca94966fe9a1465f6094dc5ddc5398473682180279c94020bc23b4906/opentelemetry_exporter_otlp_proto_common-1.41.0.tar.gz", hash = "sha256:966bbce537e9edb166154779a7c4f8ab6b8654a03a28024aeaf1a3eacb07d6ee", size = 20411, upload-time = "2026-04-09T14:38:36.572Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/c4/78b9bf2d9c1d5e494f44932988d9d91c51a66b9a7b48adf99b62f7c65318/opentelemetry_exporter_otlp_proto_common-1.41.0-py3-none-any.whl", hash = "sha256:7a99177bf61f85f4f9ed2072f54d676364719c066f6d11f515acc6c745c7acf0", size = 18366, upload-time = "2026-04-09T14:38:15.135Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.41.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -5295,14 +5293,14 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/46/d75a3f8c91915f2e58f61d0a2e4ada63891e7c7a37a20ff7949ba184a6b2/opentelemetry_exporter_otlp_proto_grpc-1.41.0.tar.gz", hash = "sha256:f704201251c6f65772b11bddea1c948000554459101bdbb0116e0a01b70592f6", size = 25754, upload-time = "2026-04-09T14:38:37.423Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/f6/b09e2e0c9f0b5750cebc6eaf31527b910821453cef40a5a0fe93550422b2/opentelemetry_exporter_otlp_proto_grpc-1.41.0-py3-none-any.whl", hash = "sha256:3a1a86bd24806ccf136ec9737dbfa4c09b069f9130ff66b0acb014f9c5255fd1", size = 20299, upload-time = "2026-04-09T14:38:17.01Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766, upload-time = "2025-12-11T13:32:21.027Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.41.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -5313,21 +5311,21 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/63/d9f43cd75f3fabb7e01148c89cfa9491fc18f6580a6764c554ff7c953c46/opentelemetry_exporter_otlp_proto_http-1.41.0.tar.gz", hash = "sha256:dcd6e0686f56277db4eecbadd5262124e8f2cc739cadbc3fae3d08a12c976cf5", size = 24139, upload-time = "2026-04-09T14:38:38.128Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/b5/a214cd907eedc17699d1c2d602288ae17cb775526df04db3a3b3585329d2/opentelemetry_exporter_otlp_proto_http-1.41.0-py3-none-any.whl", hash = "sha256:a9c4ee69cce9c3f4d7ee736ad1b44e3c9654002c0816900abbafd9f3cf289751", size = 22673, upload-time = "2026-04-09T14:38:18.349Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.41.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/d9/08e3dc6156878713e8c811682bc76151f5fe1a3cb7f3abda3966fd56e71e/opentelemetry_proto-1.41.0.tar.gz", hash = "sha256:95d2e576f9fb1800473a3e4cfcca054295d06bdb869fda4dc9f4f779dc68f7b6", size = 45669, upload-time = "2026-04-09T14:38:45.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/8c/65ef7a9383a363864772022e822b5d5c6988e6f9dabeebb9278f5b86ebc3/opentelemetry_proto-1.41.0-py3-none-any.whl", hash = "sha256:b970ab537309f9eed296be482c3e7cca05d8aca8165346e929f658dbe153b247", size = 72074, upload-time = "2026-04-09T14:38:29.38Z" },
+    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
 ]
 
 [[package]]
@@ -5347,29 +5345,29 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.41.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/0e/a586df1186f9f56b5a0879d52653effc40357b8e88fc50fe300038c3c08b/opentelemetry_sdk-1.41.0.tar.gz", hash = "sha256:7bddf3961131b318fc2d158947971a8e37e38b1cd23470cfb72b624e7cc108bd", size = 230181, upload-time = "2026-04-09T14:38:47.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/13/a7825118208cb32e6a4edcd0a99f925cbef81e77b3b0aedfd9125583c543/opentelemetry_sdk-1.41.0-py3-none-any.whl", hash = "sha256:a596f5687964a3e0d7f8edfdcf5b79cbca9c93c7025ebf5fb00f398a9443b0bd", size = 180214, upload-time = "2026-04-09T14:38:30.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.62b0"
+version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/b0/c14f723e86c049b7bf8ff431160d982519b97a7be2857ed2247377397a24/opentelemetry_semantic_conventions-0.62b0.tar.gz", hash = "sha256:cbfb3c8fc259575cf68a6e1b94083cc35adc4a6b06e8cf431efa0d62606c0097", size = 145753, upload-time = "2026-04-09T14:38:48.274Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/6c/5e86fa1759a525ef91c2d8b79d668574760ff3f900d114297765eb8786cb/opentelemetry_semantic_conventions-0.62b0-py3-none-any.whl", hash = "sha256:0ddac1ce59eaf1a827d9987ab60d9315fb27aea23304144242d1fcad9e16b489", size = 231619, upload-time = "2026-04-09T14:38:32.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR adds support for Anthropic's strict tool use feature (grammar-constrained sampling) to the `AnthropicAdapter`, bringing it to feature parity with `OpenAIAdapter`. It also updates dependency floors for `openai`, `anthropic`, `google-genai`, and `mcp` to their latest stable versions, and refreshes the lock file to resolve a stale `mistralai` constraint.

## Key Changes

- **Anthropic strict tool use**: `AnthropicAdapter.to_provider_schema()` now accepts an optional `strict=True` parameter. When enabled, the output schema includes `"strict": true` at the tool-definition top level, enabling Anthropic's grammar-constrained sampling to guarantee Claude's tool `input` always matches `input_schema` exactly. This is purely additive; the default `strict=False` preserves all existing behaviour.

- **Dependency floor bumps** (safe internal — floor bumps only):
  - `openai>=2.33.0` → `>=2.34.0`
  - `anthropic>=0.97.0` → `>=0.98.1`
  - `google-genai>=1.74.0` → `>=1.75.0`
  - `mcp>=1.0.0` → `>=1.27.0` (26 minor releases behind; brings stability improvements)

- **Lock file refresh**: `uv lock` now correctly resolves `mistralai 2.4.4` (was stale at 1.12.4 despite `pyproject.toml` requiring `>=2.0.0` from the 4 May audit).

- **Documentation updates**:
  - Azure OpenAI Responses API example: corrected `model="gpt-4o"` → `"gpt-4.1"` (two occurrences), bringing the Azure section into parity with the non-Azure example and `examples/llm_integration/openai_demo.py`.
  - Install guide `pip install` snippets updated to match new pyproject floors.

- **Tests**: Added `TestAnthropicAdapter::test_to_provider_schema_strict_mode` and `TestToolDefinitionToDialect::test_to_dialect_anthropic_strict` to verify the new `strict=True` option.

## Implementation Details

The `strict` parameter is keyword-only (enforced via `*` in the signature) to prevent accidental positional argument conflicts. When `strict=True`, the returned schema dict includes `"strict": True` alongside the existing `name`, `description`, and `input_schema` fields. For production use with strict mode, callers should also set `"additionalProperties": false` on the `input_schema` to ensure full type safety.

All changes are backwards-compatible; existing code continues to work without modification.

https://claude.ai/code/session_01WNjBRQVYv4GEJHNU84zxTT