### PR TITLE
Bump anthropic to 0.99.0 and correct dependency hold documentation

### DIFF
--- a/AUDIT_2026-05-06.md
+++ b/AUDIT_2026-05-06.md
@@ -1,0 +1,249 @@
+# Agent-Gantry Modernisation Audit — 6 May 2026
+
+**Auditor**: Claude (Sonnet 4.6) operating as repository maintainer  
+**Branch**: `claude/elegant-clarke-HBoKV`  
+**Date**: 2026-05-06  
+**Scope**: Full compatibility and modernisation audit against latest stable LLM provider SDKs, provider API standards, and agent framework patterns. Incremental over the 5 May 2026 audit (commit `e24cb09`).
+
+---
+
+## 1. Executive Summary
+
+The repository is structurally sound following six prior audit cycles (April, 1 May, 2 May, 3 May, 4 May, 5 May 2026). This audit identifies **one must-change-now item** (applied in this commit) and **four tracked-hold items** whose blocker causes are now more precisely documented following direct `uv lock` probing.
+
+### Must-Change Now (Applied in This Commit)
+
+| # | Finding | Files Affected | Risk |
+|---|---------|---------------|------|
+| 1 | `pyproject.toml` — `anthropic` floor outdated: `>=0.98.1` vs latest stable `0.99.0` (released 2026-05-05). The new release adds OIDC federation token exchange workspace targeting — a minor auth-layer enhancement with no breaking API changes for existing callers. | `pyproject.toml`, `uv.lock`, `docs/reference/llm_sdk_compatibility.md` | Safe internal — floor bump only |
+
+### Carried-Over Holds (Root Causes Now Precisely Documented)
+
+All three holds from the 5 May audit were re-probed this cycle by attempting `uv lock` after bumping each floor. The resolver error messages identify the precise blockers — correcting some earlier assumptions about the root cause being purely opentelemetry-related.
+
+| Package | Held At | Latest | Precise Blocker (confirmed by `uv lock`) |
+|---------|---------|--------|------------------------------------------|
+| `crewai` | 1.6.1 | 1.14.4 | `crewai>=1.12.0` requires `opentelemetry-api~=1.34.0` (`>=1.34.0,<1.35`), conflicts with `agent-framework 1.2.2`'s `>=1.39.0` |
+| `semantic-kernel` | 1.36.0 | 1.41.3 | `semantic-kernel>=1.39.0` requires `azure-ai-projects>=1.0.0b12,<1.1.dev0`; `agent-framework 1.2.2` requires `azure-ai-projects>=2.0.0,<3.0`. Incompatible ranges (not opentelemetry as previously noted). |
+| `google-adk` | 1.14.1 | 1.32.0 | `google-adk 1.32.0` requires `pydantic>=2.12`; `semantic-kernel>=1.36.0,<1.41.2` requires `pydantic<2.12`. Upgrade path is blocked until semantic-kernel resolves its `azure-ai-projects` conflict with agent-framework. |
+
+**Key finding**: The semantic-kernel blocker has been corrected — the conflict is `azure-ai-projects` version incompatibility (not `opentelemetry-api` as the prior pyproject.toml comment stated). The opentelemetry issue was a red herring: `semantic-kernel 1.41.3`'s constraint `opentelemetry-api~=1.24` is two-component PEP 440 notation meaning `>=1.24, <2`, which is entirely compatible with the lock's `opentelemetry-api 1.39.1`. The actual blocker is `azure-ai-projects`.
+
+---
+
+## 2. Dependency Upgrade Plan
+
+All versions verified against the PyPI JSON API on 2026-05-06.
+
+| Package | `pyproject.toml` (before) | `pyproject.toml` (after) | Lock (before) | Lock (after) | Latest stable | Status |
+|---------|--------------------------|--------------------------|--------------|--------------|--------------|--------|
+| `anthropic` | `>=0.98.1` | **`>=0.99.0`** | 0.98.1 | 0.99.0 | 0.99.0 | ✅ Updated |
+| `openai` | `>=2.34.0` | unchanged | 2.34.0 | 2.34.0 | 2.34.0 | ✅ Current |
+| `google-genai` | `>=1.75.0` | unchanged | 1.75.0 | 1.75.0 | 1.75.0 | ✅ Current |
+| `agent-framework` | `>=1.2.2,<2.0.0` | unchanged | 1.2.2 | 1.2.2 | 1.2.2 | ✅ Current |
+| `mistralai` | `>=2.0.0` | unchanged | 2.4.4 | 2.4.4 | 2.4.4 | ✅ Current |
+| `mcp` | `>=1.27.0` | unchanged | 1.27.0 | 1.27.0 | 1.27.0 | ✅ Current |
+| `groq` | `>=1.2.0` | unchanged | 1.2.0 | 1.2.0 | 1.2.0 | ✅ Current |
+| `langchain` | `>=1.2.17` | unchanged | 1.2.17 | 1.2.17 | 1.2.17 | ✅ Current |
+| `langgraph` | `>=1.1.10` | unchanged | 1.1.10 | 1.1.10 | 1.1.10 | ✅ Current |
+| `langchain-openai` | `>=1.2.1` | unchanged | 1.2.1 | 1.2.1 | 1.2.1 | ✅ Current |
+| `autogen-agentchat` | `>=0.7.5` | unchanged | 0.7.5 | 0.7.5 | 0.7.5 | ✅ Current |
+| `llama-index-core` | `>=0.14.21` | unchanged | 0.14.21 | 0.14.21 | 0.14.21 | ✅ Current |
+| `crewai` | `>=1.6.1` | unchanged | 1.6.1 | 1.6.1 | 1.14.4 | ⏳ Held — otel conflict |
+| `semantic-kernel` | `>=1.36.0` | unchanged | 1.36.0 | 1.36.0 | 1.41.3 | ⏳ Held — azure-ai-projects conflict |
+| `google-adk` | `>=1.14.1` | unchanged | 1.14.1 | 1.14.1 | 1.32.0 | ⏳ Held — pydantic/azure-ai-projects chain |
+
+**Source URLs used for verification (2026-05-06):**
+- `anthropic` 0.99.0: https://pypi.org/pypi/anthropic/json — confirmed via PyPI JSON API  
+- `openai` 2.34.0: https://pypi.org/pypi/openai/json  
+- `google-genai` 1.75.0: https://pypi.org/pypi/google-genai/json  
+- `mistralai` 2.4.4: https://pypi.org/pypi/mistralai/json  
+- `mcp` 1.27.0: https://pypi.org/pypi/mcp/json  
+- `groq` 1.2.0: https://pypi.org/pypi/groq/json  
+- `agent-framework` 1.2.2: https://pypi.org/pypi/agent-framework/json  
+- `langchain` 1.2.17: https://pypi.org/pypi/langchain/json  
+- `langgraph` 1.1.10: https://pypi.org/pypi/langgraph/json  
+- `autogen-agentchat` 0.7.5: https://pypi.org/pypi/autogen-agentchat/json  
+- `llama-index-core` 0.14.21: https://pypi.org/pypi/llama-index-core/json  
+- `crewai` 1.14.4: https://pypi.org/pypi/crewai/json  
+- `semantic-kernel` 1.41.3: https://pypi.org/pypi/semantic-kernel/json  
+- `google-adk` 1.32.0: https://pypi.org/pypi/google-adk/1.32.0/json  
+
+### `uv` commands
+
+```bash
+# Already run in this commit — reproduced here for reference
+uv lock
+
+# Verify the anthropic version bump:
+uv run python -c "import anthropic; print('anthropic', anthropic.__version__)"
+# Expected: anthropic 0.99.0
+```
+
+---
+
+## 3. Provider API Refactors
+
+### 3.1 OpenAI — no refactors required
+
+- Chat Completions: correct. ✅
+- Responses API: `client.responses.create(model="gpt-4.1", ...)` with `previous_response_id` and `function_call_output` — correct. ✅
+- No Assistants API code found. ✅ (Sunset: 26 August 2026 — no action required.)
+- Tool schema: both `openai` (nested `function`) and `openai_responses` (flat) dialects are correctly implemented.
+
+Source: https://platform.openai.com/docs/api-reference/responses
+
+### 3.2 Anthropic — no code refactors required
+
+- `client.messages.create(model="claude-sonnet-4-6", ...)` pattern is correct. ✅
+- `strict=True` tool-use support added in the 5 May audit. ✅
+- `AnthropicFeatures` / `AnthropicClient` in `anthropic_features.py` use documented parameters for extended, adaptive, and interleaved thinking. ✅
+- 0.99.0 adds only OIDC workspace targeting for federation auth — no Messages API or tool-use surface changes. No code refactors required.
+
+Source: https://github.com/anthropics/anthropic-sdk-python/releases/tag/v0.99.0
+
+### 3.3 Gemini — no refactors required
+
+- `client.aio.models.generate_content(...)` with `config=types.GenerateContentConfig(tools=[...])`. ✅
+- `functionDeclarations` shape correct. ✅
+- `format_tool_result()` places `id` inside `functionResponse` for parallel call correlation. ✅
+- Model in examples: `gemini-2.5-flash`. ✅
+
+Source: https://ai.google.dev/gemini-api/docs/function-calling
+
+### 3.4 Mistral — no code refactors required
+
+`async with Mistral(...) as client:` per-call pattern (applied in 4 May audit) is correct for `mistralai>=2.0.0`. No changes.
+
+---
+
+## 4. Framework Integration Refactors
+
+### 4.1 Microsoft Agent Framework (MAF) — no refactors required
+
+All bridge, middleware, and context-provider code verified against `agent-framework 1.2.2` (latest stable).
+
+Verified correct:
+- `Agent(client, instructions, name=..., tools=[...])` constructor ✅
+- `SequentialBuilder`, `HandoffBuilder`, `WorkflowBuilder`, `AgentExecutor`, `WorkflowAgent` ✅
+- `GantryContextProvider` with `before_run`, `as_chat_middleware`, `per_run`/`per_call` strategies ✅
+- `ContextProvider` base class with `source_id` and `extend_tools` keying ✅
+- `FunctionMiddleware` with `ChatMiddlewareLayer` fallback ✅
+- `MiddlewareTermination` for HITL approval gates ✅
+- `@tool` decorator for `FunctionTool` wrapping with `approval_mode` ✅
+- `GeminiChatClient` and `AnthropicChatClient` referenced in docstrings (added 1.1.0) ✅
+
+Source: https://pypi.org/pypi/agent-framework/json
+
+### 4.2 Semantic-kernel hold — root-cause correction
+
+**Previous pyproject.toml comment (incorrect):** stated the conflict was `opentelemetry-api` version incompatibility.
+
+**Actual blocker (confirmed by `uv lock` resolver):** `semantic-kernel>=1.39.0` requires `azure-ai-projects>=1.0.0b12,<1.1.dev0`, while `agent-framework 1.2.2` transitively requires `azure-ai-projects>=2.0.0,<3.0` (via `agent-framework-foundry`). These version ranges do not overlap.
+
+The `opentelemetry-api` constraint for `semantic-kernel 1.41.3` is `~=1.24` (two-component PEP 440 notation = `>=1.24, <2`), which is **compatible** with the lock's `opentelemetry-api 1.39.1`. The prior audit was wrong to cite opentelemetry as the root cause.
+
+**pyproject.toml comment updated** to reflect the precise `azure-ai-projects` conflict.
+
+### 4.3 Google-ADK hold — root-cause correction
+
+**Previous pyproject.toml comment (partially incorrect):** stated the conflict was specifically on Python 3.13/Windows.
+
+**Actual blocker (confirmed by `uv lock` resolver):** `google-adk 1.32.0` requires `pydantic>=2.12`. `semantic-kernel>=1.36.0,<1.41.2` requires `pydantic<2.12`. Since `semantic-kernel>=1.41.2` is blocked by the `azure-ai-projects` conflict with `agent-framework`, there is no feasible pydantic version that satisfies all three packages simultaneously.
+
+**pyproject.toml comment updated** to document the full three-way conflict chain.
+
+### 4.4 CrewAI — hold confirmed
+
+`crewai>=1.12.0` requires `opentelemetry-api~=1.34.0` (`>=1.34.0,<1.35`), conflicting with `agent-framework 1.2.2`'s `>=1.39.0`. This was correctly documented in prior audits.
+
+### 4.5 LangChain / LangGraph — no refactors required
+
+`langchain 1.2.17` and `langgraph 1.1.10` are at current stable. No framework API changes affecting the integration surface.
+
+### 4.6 AutoGen — no refactors required
+
+`autogen-agentchat 0.7.5` (latest stable, released 2025-09-30) is unchanged. The integration is in the `agent-frameworks` optional extra and treated as a peer alternative to MAF, not a replacement.
+
+---
+
+## 5. Universal Tool-Calling Design
+
+The `to_dialect()` / `DialectRegistry` / `ToolSpecAdapter` architecture remains complete and provider-correct.
+
+| Dialect | Schema shape | `from_provider_payload` | `format_tool_result` | Strict mode | Status |
+|---------|-------------|------------------------|---------------------|-------------|--------|
+| `openai` | `{type:"function", function:{name, description, parameters}}` | `function.arguments` JSON | `{role:"tool", content, name, tool_call_id}` | ✅ `strict=True` → `function.strict` | ✅ |
+| `openai_responses` | `{type:"function", name, description, parameters}` | `call_id` + `arguments` | `{type:"function_call_output", call_id, output}` | ✅ `strict=True` → top-level `strict` | ✅ |
+| `anthropic` | `{name, description, input_schema}` | `input` dict | `{type:"tool_result", tool_use_id, content, is_error?}` | ✅ `strict=True` → top-level `strict` (added 5 May) | ✅ |
+| `gemini` | `{name, description, parameters}` | `args` dict + optional `id` | `{functionResponse:{name, response, id?}}` | N/A | ✅ |
+| `mistral` | Inherits OpenAI | Inherits OpenAI | Inherits OpenAI | Inherits OpenAI | ✅ |
+| `groq` | Inherits OpenAI | Inherits OpenAI | Inherits OpenAI | Inherits OpenAI | ✅ |
+| `agent_framework` | Inherits OpenAI + optional metadata | Handles AF simplified format | Inherits OpenAI | Inherits OpenAI | ✅ |
+
+No changes required.
+
+---
+
+## 6. Documentation and Example Updates
+
+### 6.1 Applied in This Commit
+
+| File | Change | Risk |
+|------|--------|------|
+| `docs/reference/llm_sdk_compatibility.md` | Anthropic install snippet: `pip install anthropic>=0.98.1` → `>=0.99.0`. | Documentation only |
+
+### 6.2 Verified Correct (No Change Required)
+
+- `examples/llm_integration/openai_demo.py`: Responses API uses `gpt-4.1` ✅; Chat Completions uses `gpt-4o` ✅
+- `examples/llm_integration/anthropic_demo.py`: `client.messages.create(model="claude-sonnet-4-6", ...)` ✅
+- `examples/llm_integration/google_genai_demo.py`: `client.aio.models.generate_content(model="gemini-2.5-flash", ...)` ✅
+- All examples use `to_dialect()` — no deprecated `to_openai_schema()` / `to_anthropic_schema()` / `to_gemini_schema()` remaining ✅
+- `examples/agent_frameworks/agent_framework_example.py`: `SequentialBuilder`, `HandoffBuilder`, `WorkflowBuilder`, `GantryApprovalMiddleware` all correct ✅
+- `examples/agent_frameworks/agent_framework_provider_example.py`: `GantryContextProvider` with `SkillsProvider` coexistence — correct ✅
+
+---
+
+## 7. Test and Migration Plan
+
+### Regeneration Checklist
+
+- [x] `uv lock` run — lock file updated (`anthropic` 0.98.1 → 0.99.0).
+- [ ] Run `uv sync --all-extras` to install updated packages in development environment.
+- [ ] Run the full test suite: `uv run --extra dev pytest tests/ -x -q`.
+- [ ] No VCR cassettes or golden fixtures require regeneration — the `anthropic 0.99.0` change is an auth-layer enhancement with no Messages API surface changes.
+
+### No New Tests Required
+
+`anthropic 0.99.0` adds OIDC workspace targeting for federation auth. This feature is in the SDK's authentication layer, not in the `messages.create()` / tool-use surface that Agent-Gantry calls. No new tests are needed.
+
+### Changelog-Ready Migration Notes
+
+#### `anthropic` 0.99.0 — Non-breaking
+
+No API surface changes for existing `messages.create()` callers. The new OIDC workspace targeting is an opt-in auth enhancement for enterprise OIDC federation scenarios. Existing API-key-based authentication is unaffected. Floor bump tracks the current stable release.
+
+Source: https://github.com/anthropics/anthropic-sdk-python/releases/tag/v0.99.0
+
+#### `pyproject.toml` comment corrections — Informational
+
+The hold comments for `semantic-kernel` and `google-adk` have been corrected to document the precise blocker (both trace back to the `azure-ai-projects` version incompatibility between `semantic-kernel>=1.39.0` and `agent-framework 1.2.2`). No functional code changes.
+
+---
+
+## Must-Change Now
+
+One item applied in this commit:
+
+1. **`pyproject.toml`** — `anthropic` floor `>=0.98.1` → `>=0.99.0`. ✅ *Applied*
+
+## Good Next-Step Improvements
+
+### Tracked Holds — Unblocking Conditions
+
+| # | Package | Unblocking Condition |
+|---|---------|----------------------|
+| 1 | `crewai` 1.14.4 | `crewai` must relax its `opentelemetry-api~=1.34.0` constraint, or `agent-framework` must lower its `>=1.39.0` floor. Monitor upstream issues on both repos. |
+| 2 | `semantic-kernel` 1.41.3 | `semantic-kernel` must support `azure-ai-projects>=2.0.0`, or `agent-framework` must lower its `azure-ai-projects` floor. The `azure-ai-projects` v1 → v2 migration is a separate SDK issue upstream. |
+| 3 | `google-adk` 1.32.0 | Blocked until semantic-kernel is upgradeable (resolves the pydantic chain). Once semantic-kernel aligns with `azure-ai-projects>=2.0.0` AND `pydantic>=2.12`, google-adk 1.32.0 will likely resolve cleanly. |
+| 4 | Add `output_schema` to `AnthropicClient.create_message()` | Implement `output_config` parameter for structured JSON output (distinct from strict tool use). Tracked from 5 May audit. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   *Risk: safe internal — purely additive; default preserves all existing behaviour.*  
   Source: https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use
 
+### Changed
+
+- **`pyproject.toml`** — Bumped `anthropic` floor `>=0.98.1` → `>=0.99.0` (latest stable 2026-05-05; adds OIDC federation token exchange workspace targeting — no Messages API or tool-use surface changes for existing callers).
+  *Risk: safe internal — floor bump only.*
+
+- **`uv.lock`** — Refreshed via `uv lock`. `anthropic` resolved 0.98.1 → 0.99.0. All other packages unchanged.
+
+- **`pyproject.toml`** — Updated hold comments for `semantic-kernel` and `google-adk` to document the precise blocker chain, correcting the prior claim that the semantic-kernel conflict was opentelemetry-related. The actual blockers are:
+  - `semantic-kernel>=1.39.0` requires `azure-ai-projects>=1.0.0b12,<1.1.dev0`; `agent-framework 1.2.2` requires `azure-ai-projects>=2.0.0,<3.0`. Incompatible.
+  - `google-adk 1.32.0` requires `pydantic>=2.12`; `semantic-kernel>=1.36.0,<1.41.2` requires `pydantic<2.12`. Blocked until the semantic-kernel/azure-ai-projects conflict is resolved upstream.
+  *Risk: informational only — no functional code changes.*
+
+- **`docs/reference/llm_sdk_compatibility.md`** — Anthropic install snippet updated: `pip install anthropic>=0.98.1` → `>=0.99.0`.
+  *Risk: documentation only.*
+
 - **`tests/test_tool_spec_adapters.py`** — Two new tests: `TestAnthropicAdapter::test_to_provider_schema_strict_mode` and `TestToolDefinitionToDialect::test_to_dialect_anthropic_strict`, verifying the new `strict=True` option.
 
 ### Changed

--- a/docs/reference/llm_sdk_compatibility.md
+++ b/docs/reference/llm_sdk_compatibility.md
@@ -253,7 +253,7 @@ response = client.chat.completions.create(
 
 ### Package
 ```bash
-pip install anthropic>=0.98.1
+pip install anthropic>=0.99.0
 ```
 
 ### Client Initialization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,14 +70,19 @@ agent-frameworks = [
     "langgraph>=1.1.10",
     "llama-index-core>=0.14.21",
     "llama-index-llms-openai>=0.7.7",
-    # semantic-kernel>=1.41.3 conflicts with agent-framework>=1.2.1 on some
-    # Python versions due to opentelemetry-api version incompatibility.
+    # semantic-kernel>=1.41.3 is incompatible with agent-framework>=1.2.2:
+    # semantic-kernel 1.41.3 requires azure-ai-projects>=1.0.0b12,<1.1.dev0,
+    # while agent-framework 1.2.2 requires azure-ai-projects>=2.0.0,<3.0.
     # Upgrade semantic-kernel in a standalone environment without agent-framework.
-    # Floor bumped to >=1.36.0 to match the uv.lock-resolved version; full
-    # upgrade to 1.41.3 requires standalone testing without agent-framework.
     "semantic-kernel>=1.36.0",
-    # google-adk 1.31.1 conflicts with agent-framework>=1.2.1 on Python 3.13/Windows;
-    # bump this floor in a standalone (no agent-framework) environment.
+    # google-adk>=1.32.0 is blocked by a three-way conflict:
+    # (a) google-adk 1.32.0 requires pydantic>=2.12
+    # (b) semantic-kernel>=1.36.0,<1.41.2 requires pydantic<2.12
+    # (c) semantic-kernel>=1.39.0 additionally conflicts with agent-framework>=1.2.2
+    #     because semantic-kernel 1.39.x requires azure-ai-projects<1.1.dev0,
+    #     while agent-framework 1.2.2 requires azure-ai-projects>=2.0.0,<3.0.
+    # Resolution: upgrade google-adk in a standalone environment without
+    # agent-framework and semantic-kernel together.
     "google-adk>=1.14.1",
 ]
 example-tools = [
@@ -149,7 +154,7 @@ a2a = [
 ]
 # LLM provider SDK dependencies
 anthropic = [
-    "anthropic>=0.98.1",
+    "anthropic>=0.99.0",
 ]
 google-genai = [
     "google-genai>=1.75.0",

--- a/uv.lock
+++ b/uv.lock
@@ -648,7 +648,7 @@ requires-dist = [
     { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.2,<2.0.0" },
     { name = "agent-gantry", extras = ["dev", "embeddings", "openai", "cohere", "vector-stores", "lancedb", "nomic", "mcp", "a2a", "llm-providers", "agent-frameworks", "example-tools"], marker = "extra == 'all'" },
     { name = "agent-gantry", extras = ["openai", "anthropic", "google-genai", "google-vertexai", "mistral", "groq"], marker = "extra == 'llm-providers'" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.98.1" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.99.0" },
     { name = "asyncpg", marker = "extra == 'pgvector'", specifier = ">=0.29.0" },
     { name = "asyncpg", marker = "extra == 'vector-stores'", specifier = ">=0.29.0" },
     { name = "autogen-agentchat", marker = "extra == 'agent-frameworks'", specifier = ">=0.7.5" },
@@ -907,7 +907,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.98.1"
+version = "0.99.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -919,9 +919,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/60/a9e4426dfe594e5eec8a9757d48e3d8dcf529a0a35a4fc8aefa352bd95fe/anthropic-0.98.1.tar.gz", hash = "sha256:62205edec42f5877df63d58be8e9443843d3e032215836e228fba1f59514a433", size = 725085, upload-time = "2026-05-04T21:40:39.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/c9/e8a3a1caeab575e80551b30b084096b5a430abc52739a526a1daaadd038c/anthropic-0.99.0.tar.gz", hash = "sha256:16f41e00f215ed2d193b146be3dd567c4319c32ed3af6c8725d68ba875257c1c", size = 727239, upload-time = "2026-05-05T16:03:07.986Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/6f/7f7f80f714e6de0784518f1999f71fd632076aefd3e22fe0ccd27ca9571f/anthropic-0.98.1-py3-none-any.whl", hash = "sha256:107ebf954415382fdcea6a94f9cf334a53199ad64794403590dc55366cefcc28", size = 699604, upload-time = "2026-05-04T21:40:41.311Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/d0917506744e1707cf55659a57f1e3ff952eda5636df0ffffe3e884b7c61/anthropic-0.99.0-py3-none-any.whl", hash = "sha256:c44469b746ab2ef19a4c52dcbdb98e17bc95c60bebdd18ec40d76d2d23592b49", size = 700564, upload-time = "2026-05-05T16:03:06.059Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR updates the `anthropic` SDK floor version to 0.99.0 (latest stable as of 2026-05-05) and corrects the documentation for held dependencies to reflect the precise blocker chains identified through `uv lock` probing.

## Changes

- **`pyproject.toml`** — Bumped `anthropic` floor from `>=0.98.1` to `>=0.99.0`. The new release adds OIDC federation token exchange workspace targeting (auth-layer enhancement only; no Messages API or tool-use surface changes).

- **`pyproject.toml`** — Corrected hold comments for `semantic-kernel` and `google-adk`:
  - **`semantic-kernel`**: The blocker is not opentelemetry-related (as previously stated). The actual conflict is that `semantic-kernel>=1.39.0` requires `azure-ai-projects>=1.0.0b12,<1.1.dev0`, while `agent-framework 1.2.2` requires `azure-ai-projects>=2.0.0,<3.0` — incompatible version ranges.
  - **`google-adk`**: Blocked by a three-way conflict: `google-adk 1.32.0` requires `pydantic>=2.12`, but `semantic-kernel>=1.36.0,<1.41.2` requires `pydantic<2.12`. Since `semantic-kernel>=1.39.0` is already blocked by the `azure-ai-projects` conflict with `agent-framework`, there is no feasible upgrade path until the semantic-kernel/azure-ai-projects issue is resolved upstream.

- **`docs/reference/llm_sdk_compatibility.md`** — Updated Anthropic install snippet from `pip install anthropic>=0.98.1` to `>=0.99.0`.

- **`CHANGELOG.md`** — Added entries documenting the anthropic floor bump and the corrected dependency hold documentation.

## Implementation Details

- The `anthropic 0.99.0` upgrade is a safe floor bump with no breaking changes to the Messages API or tool-use surface that Agent-Gantry calls.
- No code refactors required; the change is purely a dependency version update.
- The corrected hold comments now precisely document the blocker chains, enabling clearer tracking of upstream resolution conditions.

https://claude.ai/code/session_01UzYoSa4fkdihqBGivAe2yj