### PR TITLE
🎨 Palette: Add keyboard accessibility (Escape/Tab out) to mobile menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,7 @@
 ## 2026-05-02 - [Keyboard Shortcuts Accessibility & OS Awareness]
 **Learning:** Displaying hardcoded OS-specific keyboard shortcuts (like "Ctrl+K") in placeholders confuses Mac users, who expect "⌘K". Additionally, mapping common single-key shortcuts like "/" for search focus requires careful event handling to avoid intercepting the key when the user is already typing in an input field.
 **Action:** When adding keyboard shortcuts for quick focus or actions, dynamically update visual hints (like placeholders) based on `navigator.userAgent.includes("Mac")`. Furthermore, always check `e.target.tagName` against `"INPUT"`, `"TEXTAREA"`, and `e.target.isContentEditable` before intercepting single-key shortcuts like "/".
+
+## 2026-05-08 - [Keyboard Accessibility for Modal Drawer Menus]
+**Learning:** Mobile "hamburger" menus that slide in (like `.sidebar`) act as modal drawers. If they only close on `click` outside, keyboard users are left with no standard way to dismiss them (`Escape` key) and can accidentally tab out of the menu into the obscured main content, breaking the logical focus flow.
+**Action:** When implementing modal drawer menus or sidebars, always add a `keydown` listener for the `Escape` key (and return focus to the toggle button), as well as a `focusin` listener to auto-close the menu if the user tabs out of its container.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -33,6 +33,29 @@
           toggleButton.setAttribute("aria-expanded", "false");
         }
       });
+
+      // Close sidebar on Escape key
+      document.addEventListener("keydown", function (event) {
+        if (event.key === "Escape" && sidebar.classList.contains("open")) {
+          sidebar.classList.remove("open");
+          toggleButton.setAttribute("aria-expanded", "false");
+          toggleButton.focus();
+        }
+      });
+
+      // Close sidebar when focus moves outside on mobile
+      document.addEventListener("focusin", function (event) {
+        const isMobile = window.innerWidth <= 768;
+        if (
+          isMobile &&
+          !sidebar.contains(event.target) &&
+          !toggleButton.contains(event.target) &&
+          sidebar.classList.contains("open")
+        ) {
+          sidebar.classList.remove("open");
+          toggleButton.setAttribute("aria-expanded", "false");
+        }
+      });
     }
   }
 
@@ -221,11 +244,17 @@
 
     document.addEventListener("keydown", function (e) {
       // Cmd/Ctrl + K or / to focus search
-      const isFocusShortcut = ((e.metaKey || e.ctrlKey) && e.key === "k") || e.key === "/";
+      const isFocusShortcut =
+        ((e.metaKey || e.ctrlKey) && e.key === "k") || e.key === "/";
 
       if (isFocusShortcut) {
         // Prevent '/' from being intercepted if user is already typing in an input
-        if (e.key === "/" && (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA" || e.target.isContentEditable)) {
+        if (
+          e.key === "/" &&
+          (e.target.tagName === "INPUT" ||
+            e.target.tagName === "TEXTAREA" ||
+            e.target.isContentEditable)
+        ) {
           return;
         }
 


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the mobile drawer menu (`.sidebar`) by implementing `Escape` key dismissal and `Tab`-out auto-closing functionality.
🎯 Why: Previously, the mobile menu only closed via mouse clicks outside the container or on the toggle button. Keyboard users had no standard way to dismiss it (`Escape`) and could tab out of the menu into the background page, breaking focus flow and accessibility.
♿ Accessibility: Ensures WCAG compliance for modal dialogs/drawers by providing standard keyboard exit paths and maintaining logical focus.
📸 Before/After: No visual changes, entirely keyboard interaction improvements.

---
*PR created automatically by Jules for task [13305897326805498880](https://jules.google.com/task/13305897326805498880) started by @CodeHalwell*