### PR TITLE
🎨 Palette: Add screen reader announcement for code copy success

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,7 @@
 ## 2026-05-09 - [Search Empty States as Dead Ends]
 **Learning:** A generic "No results found" message is a UX dead end. Users experiencing an empty state often abandon the action because they feel stuck and receive no actionable guidance. Adding visual comfort (like an icon) and explicit suggestions ("Try adjusting your search terms") significantly improves the recovery rate from zero-result states.
 **Action:** When designing or implementing search components or filtered lists, never use a plain text string for an empty state. Always provide a structured empty state with visual feedback (icon/illustration) and actionable guidance for the user's next step.
+
+## 2026-05-10 - [Screen Reader Announcement for Dynamic Button States]
+**Learning:** When a button's primary state or text changes dynamically upon interaction (like "Copy" becoming "Copied!"), screen reader users may not be aware of the successful action if the `aria-label` remains unchanged. The visual change in `textContent` is often insufficient for assistive technologies if they rely on the initial label.
+**Action:** Always dynamically update the `aria-label` along with the text content/visual state for interactive elements to ensure assistive technologies announce the updated state or success message to the user, and remember to revert the label if the visual state reverts.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -186,10 +186,12 @@
           await navigator.clipboard.writeText(block.textContent);
           button.textContent = "Copied!";
           button.classList.add("copied");
+          button.setAttribute("aria-label", "Code copied to clipboard");
 
           setTimeout(() => {
             button.textContent = "Copy";
             button.classList.remove("copied");
+            button.setAttribute("aria-label", "Copy code to clipboard");
           }, 2000);
         } catch (err) {
           console.error("Failed to copy code:", err);


### PR DESCRIPTION
💡 What: Dynamically update the `aria-label` of the documentation code copy buttons when the text changes to "Copied!", and revert it back when the text reverts to "Copy".
🎯 Why: Without this change, screen reader users do not receive any audible feedback that their click successfully copied the code to their clipboard because the `aria-label` remains statically "Copy code to clipboard" and the visual change to `textContent` is not announced. 
♿ Accessibility: Ensures that dynamic button state changes are explicitly announced to assistive technologies.

---
*PR created automatically by Jules for task [15348449420950583470](https://jules.google.com/task/15348449420950583470) started by @CodeHalwell*