### PR TITLE
🎨 Palette: Add dynamic aria-label updates for copy button feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,7 @@
 ## 2026-05-09 - [Search Empty States as Dead Ends]
 **Learning:** A generic "No results found" message is a UX dead end. Users experiencing an empty state often abandon the action because they feel stuck and receive no actionable guidance. Adding visual comfort (like an icon) and explicit suggestions ("Try adjusting your search terms") significantly improves the recovery rate from zero-result states.
 **Action:** When designing or implementing search components or filtered lists, never use a plain text string for an empty state. Always provide a structured empty state with visual feedback (icon/illustration) and actionable guidance for the user's next step.
+
+## 2026-05-10 - [Dynamic ARIA Labels for Feedback States]
+**Learning:** When dynamically updating a button's visual text to provide feedback (e.g., changing 'Copy' to 'Copied!' or 'Failed'), if the button has a static `aria-label`, the screen reader will completely ignore the new visual text. Users relying on assistive technology will not receive any confirmation that their action succeeded or failed.
+**Action:** Always simultaneously update the `aria-label` attribute (using `setAttribute`) whenever visual text is modified to indicate a state change or feedback, ensuring assistive technologies announce the updated state correctly.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -185,18 +185,22 @@
         try {
           await navigator.clipboard.writeText(block.textContent);
           button.textContent = "Copied!";
+          button.setAttribute("aria-label", "Code copied to clipboard!");
           button.classList.add("copied");
 
           setTimeout(() => {
             button.textContent = "Copy";
+            button.setAttribute("aria-label", "Copy code to clipboard");
             button.classList.remove("copied");
           }, 2000);
         } catch (err) {
           console.error("Failed to copy code:", err);
           button.textContent = "Failed";
+          button.setAttribute("aria-label", "Failed to copy code");
 
           setTimeout(() => {
             button.textContent = "Copy";
+            button.setAttribute("aria-label", "Copy code to clipboard");
           }, 2000);
         }
       });


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label` updates to the copy code button in `docs/assets/js/navigation.js`. When the button text changes to "Copied!" or "Failed", the `aria-label` is updated simultaneously, and then reverted along with the text.

🎯 **Why:** If a button has a static `aria-label`, screen readers completely ignore changes to the element's inner text. When providing visual feedback on user actions (like copying text), the screen reader must also be explicitly told the state changed via an updated `aria-label`. Without this, users relying on assistive technology receive no confirmation that their copy action succeeded or failed.

📸 **Before/After:** No visual changes since it only modifies ARIA properties, but it functions correctly for screen readers now.

♿ **Accessibility:** Significantly improves accessibility for screen reader users by ensuring they receive the same interactive feedback as sighted users when copying code snippets. Also recorded a critical learning about this pattern in the Palette journal.

---
*PR created automatically by Jules for task [13333163697528121001](https://jules.google.com/task/13333163697528121001) started by @CodeHalwell*