### PR TITLE
🎨 Palette: Add keyboard scroll support to code blocks

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -49,3 +49,7 @@
 ## 2026-05-10 - [Dynamic ARIA Labels for Feedback States]
 **Learning:** When dynamically updating a button's visual text to provide feedback (e.g., changing 'Copy' to 'Copied!' or 'Failed'), if the button has a static `aria-label`, the screen reader will completely ignore the new visual text. Users relying on assistive technology will not receive any confirmation that their action succeeded or failed.
 **Action:** Always simultaneously update the `aria-label` attribute (using `setAttribute`) whenever visual text is modified to indicate a state change or feedback, ensuring assistive technologies announce the updated state correctly.
+
+## 2026-05-12 - [Keyboard Accessibility for Scrollable Code Blocks]
+**Learning:** Code blocks (`<pre>`) often have `overflow-x: auto` applied via CSS to handle long lines of code without breaking the page layout. However, if these `<pre>` elements are not focusable, keyboard-only users cannot scroll them horizontally to read the truncated content.
+**Action:** When styling elements with `overflow: auto` or `overflow: scroll` (especially code blocks or tables), always ensure they are keyboard-focusable by adding `tabindex="0"`. Additionally, provide a `role="region"` and an `aria-label` (e.g., "Code snippet") so screen readers announce the scrollable container properly.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -167,6 +167,13 @@
     codeBlocks.forEach((block) => {
       const pre = block.parentElement;
 
+      // Make pre focusable and accessible for horizontal scrolling
+      if (!pre.hasAttribute("tabindex")) {
+        pre.setAttribute("tabindex", "0");
+        pre.setAttribute("role", "region");
+        pre.setAttribute("aria-label", "Code snippet");
+      }
+
       // Wrap pre in a container if not already wrapped
       if (!pre.parentElement.classList.contains("code-block-wrapper")) {
         const wrapper = document.createElement("div");


### PR DESCRIPTION
💡 **What**: Added `tabindex="0"`, `role="region"`, and `aria-label="Code snippet"` to `<pre>` elements containing code blocks in the documentation.
🎯 **Why**: Code blocks frequently overflow horizontally (`overflow-x: auto`), but because `<pre>` elements are not focusable by default, keyboard-only users were completely unable to scroll horizontally to read the rest of the line.
📸 **Before/After**: Keyboard focus is now visibly active on code blocks, and left/right arrow keys scroll the container.
♿ **Accessibility**: Significant improvement for keyboard navigation and screen readers dealing with long lines of code.

Also added a journal entry documenting this critical accessibility pattern for scrollable containers.

---
*PR created automatically by Jules for task [12891438040029538568](https://jules.google.com/task/12891438040029538568) started by @CodeHalwell*