### PR TITLE
Replace quarantined mistralai SDK with OpenAI-compatible endpoint

### DIFF
--- a/AUDIT_2026-05-12.md
+++ b/AUDIT_2026-05-12.md
@@ -1,0 +1,458 @@
+# Agent-Gantry Modernisation Audit — 12 May 2026
+
+**Auditor**: Claude (Sonnet 4.6) operating as repository maintainer  
+**Branch**: `claude/elegant-clarke-6oIAK`  
+**Date**: 2026-05-12  
+**Scope**: Full compatibility and modernisation audit — all seven phases — against the latest stable LLM provider SDKs, provider API standards, and agent framework patterns. Incremental over the 10 May 2026 audit (branch `claude/elegant-clarke-84EdH`).
+
+---
+
+## 1. Executive Summary
+
+This audit identifies **three must-change-now items**, all applied in this commit, and carries forward **seven good-next-step improvements**.
+
+### Must-Change Now (Applied in This Commit)
+
+| # | Finding | Files Affected | Risk |
+|---|---------|----------------|------|
+| 1 | **`mistralai` quarantined on PyPI (critical).** The `mistralai` package has been quarantined by the Python Package Index and is no longer installable. This blocked all `uv lock` regeneration. Mistral's chat endpoint is OpenAI-compatible; the `openai` SDK with `base_url="https://api.mistral.ai/v1"` is the correct replacement. | `pyproject.toml`, `agent_gantry/adapters/llm_client.py`, `examples/llm_integration/mistral_demo.py`, `docs/reference/llm_sdk_compatibility.md`, `README.md` | *Safe with shim* — public Mistral integration behaviour preserved; API surface unchanged |
+| 2 | **`anthropic` floor bump: `>=0.100.0` → `>=0.101.0`.** Anthropic 0.101.0 was released on 2026-05-11. The lock is updated to reflect the new resolved version. No breaking changes in Gantry's Messages-API call sites. | `pyproject.toml`, `uv.lock` | Safe internal — floor bump only |
+| 3 | **`langgraph>=1.2.0` — held, newly documented.** langgraph 1.2.0 was released on 2026-05-12 but is blocked by `langchain==1.2.18` which pins `langgraph>=1.1.10,<1.2.0`. `langchain 1.3.0` stable is required to lift the upper bound; only pre-release `1.3.0a2` exists as of today. The floor remains at `>=1.1.10`; the new comment in `pyproject.toml` documents the exact blocker. | `pyproject.toml` | N/A — documentation only |
+
+### Good-Next-Step Improvements (Not Applied — Tracked)
+
+| # | Finding | Files Affected |
+|---|---------|----------------|
+| A | `google-genai` 2.0.1 floor cannot yet be bumped: `google-adk>=1.14.1` requires `google-genai<2.0.0`. Gantry's `generate_content` / `functionDeclarations` call sites are unaffected by the 2.0.x breaking changes (Interactions API only). Upgrade in a standalone environment without `google-adk`. | `pyproject.toml` |
+| B | `langgraph>=1.2.0` — unlock when `langchain 1.3.0 GA` is published. At that point, bump both `langchain` and `langgraph` floors together. | `pyproject.toml` |
+| C | `agent-framework 1.3.0` adds `allowed_tools` for OpenAI/Gemini tool-choice filtering. Expose this as an optional `allowed_tools` pass-through on `GantryToolBridge.build_agent()` / `as_agent()` and `GantryContextProvider`. | `agent_gantry/integrations/agent_framework_bridge.py`, `agent_gantry/integrations/agent_framework_provider.py`, new tests |
+| D | Update `SkillsProvider(skill_paths="./skills")` docstring example in `agent_framework_provider.py` to reflect AF 1.3.0's multi-source skills API once the migration guide is confirmed. Runtime code using `SkillsProvider(skills=[...])` is unchanged in 1.3.0. | `agent_gantry/integrations/agent_framework_provider.py` |
+| E | Add `output_schema` / `output_config` parameter to `AnthropicClient.create_message()` for Anthropic's structured JSON output feature. | `agent_gantry/integrations/anthropic_features.py`, new tests |
+| F | `crewai` 1.6.1 → 1.14.4: blocked by `opentelemetry-api~=1.34.0` (crewai) vs `>=1.39.0` (agent-framework-core 1.3.0). Install standalone without agent-framework to use crewai 1.14.x. | `pyproject.toml` |
+| G | `semantic-kernel` 1.36.0 → 1.41.3 and `google-adk` 1.14.1 → 1.33.0: blocked by the same opentelemetry-api incompatibility. Install standalone. | `pyproject.toml` |
+
+### Carried-Over Holds (Unchanged — All Documented in `pyproject.toml`)
+
+| Package | Held At | Latest | Blocker |
+|---------|---------|--------|---------|
+| `langgraph` | 1.1.10 | 1.2.0 | `langchain==1.2.18` pins `langgraph<1.2.0`; `langchain 1.3.0` GA required |
+| `crewai` | 1.6.1 | 1.14.4 | `opentelemetry-api~=1.34.0` conflicts with `agent-framework-core>=1.3.0` (`>=1.39.0`) |
+| `semantic-kernel` | 1.36.0 | 1.41.3 | `opentelemetry-api~=1.24` conflict |
+| `google-adk` | 1.14.1 | 1.33.0 | Same opentelemetry conflict; additionally requires `google-genai<2.0.0` |
+| `google-genai` | 1.75.0 | 2.0.1 | `google-adk>=1.14.1` requires `<2.0.0`; safe to install at 2.x in standalone `[google-genai]` environments |
+
+---
+
+## 2. Dependency Upgrade Plan
+
+All versions verified against PyPI JSON API on 2026-05-12.
+
+| Package | `pyproject.toml` floor (before) | `pyproject.toml` floor (after) | Lock (before) | Lock (after) | Latest stable | Status |
+|---------|--------------------------------|--------------------------------|---------------|--------------|---------------|--------|
+| `anthropic` | `>=0.100.0` | **`>=0.101.0`** | 0.100.0 | 0.101.0 | 0.101.0 | ✅ Updated |
+| `mistralai` | `>=2.0.0` | **removed** (quarantined) | 2.4.4 | — | quarantined | ✅ Removed — replaced by OpenAI SDK |
+| `openai` (mistral extra) | — | **`>=2.36.0`** (new) | — | 2.36.0 | 2.36.0 | ✅ Mistral now uses openai SDK |
+| `langgraph` | `>=1.1.10` | unchanged (hold documented) | 1.1.10 | 1.1.10 | 1.2.0 | ⏳ Held — see §B above |
+| `langchain` | `>=1.2.18` | unchanged | 1.2.18 | 1.2.18 | 1.2.18 | ✅ Current |
+| `openai` | `>=2.36.0` | unchanged | 2.36.0 | 2.36.0 | 2.36.0 | ✅ Current |
+| `agent-framework` | `>=1.3.0,<2.0.0` | unchanged | 1.3.0 | 1.3.0 | 1.3.0 | ✅ Current |
+| `mcp` | `>=1.27.1` | unchanged | 1.27.1 | 1.27.1 | 1.27.1 | ✅ Current |
+| `langchain-openai` | `>=1.2.1` | unchanged | 1.2.1 | 1.2.1 | 1.2.1 | ✅ Current |
+| `autogen-agentchat` | `>=0.7.5` | unchanged | 0.7.5 | 0.7.5 | 0.7.5 | ✅ Current |
+| `groq` | `>=1.2.0` | unchanged | 1.2.0 | 1.2.0 | 1.2.0 | ✅ Current |
+| `google-genai` | `>=1.75.0` | unchanged (held) | 1.75.0 | 1.75.0 | 2.0.1 | ⏳ Held — see §A |
+| `crewai` | `>=1.6.1` | unchanged (held) | 1.6.1 | 1.6.1 | 1.14.4 | ⏳ Held — see §F |
+| `google-adk` | `>=1.14.1` | unchanged (held) | 1.14.1 | 1.14.1 | 1.33.0 | ⏳ Held — see §G |
+| `semantic-kernel` | `>=1.36.0` | unchanged (held) | 1.36.0 | 1.36.0 | 1.41.3 | ⏳ Held — see §G |
+
+**Transitive clean-up in this lock refresh:**
+
+| Package | Before | After | Reason |
+|---------|--------|-------|--------|
+| `eval-type-backport` | 0.3.1 | removed | was a `mistralai` transitive; no longer needed |
+| `jsonpath-python` | 1.1.5 | removed | was a `mistralai` transitive; no longer needed |
+
+### Source URLs used for verification
+
+- `anthropic` 0.101.0: https://pypi.org/pypi/anthropic/json
+- `openai` 2.36.0: https://pypi.org/pypi/openai/json
+- `agent-framework` 1.3.0: https://pypi.org/pypi/agent-framework/json
+- `mcp` 1.27.1: https://pypi.org/pypi/mcp/json
+- `langchain` 1.2.18: https://pypi.org/pypi/langchain/json
+- `langchain-openai` 1.2.1: https://pypi.org/pypi/langchain-openai/json
+- `langgraph` 1.2.0 + `langchain-core>=1.4.0` requirement: https://pypi.org/pypi/langgraph/json
+- `langchain 1.2.18` → `langgraph>=1.1.10,<1.2.0` pin: https://pypi.org/pypi/langchain/1.2.18/json
+- `autogen-agentchat` 0.7.5: https://pypi.org/pypi/autogen-agentchat/json
+- `groq` 1.2.0: https://pypi.org/pypi/groq/json
+- `google-genai` 2.0.1: https://pypi.org/pypi/google-genai/json
+- `mistralai` quarantine status: https://pypi.org/simple/mistralai/ (`pypi:project-status: quarantined`)
+- `crewai` 1.14.4 / `opentelemetry-api~=1.34.0`: https://pypi.org/pypi/crewai/json
+- `google-adk` 1.33.0 / `google-genai<2`: https://pypi.org/pypi/google-adk/json
+- `semantic-kernel` 1.41.3 / `opentelemetry-api~=1.24`: https://pypi.org/pypi/semantic-kernel/json
+
+### `uv` commands applied in this commit
+
+```bash
+# Upgrade anthropic; mistralai removed from pyproject.toml first so uv can resolve.
+uv lock --upgrade-package anthropic
+```
+
+### langgraph 1.2.0 — dependency conflict analysis
+
+Attempting `uv lock --upgrade-package langgraph` yields:
+
+```
+Because only langchain<=1.2.18 is available and langchain==1.2.18
+  depends on langgraph>=1.1.10,<1.2.0, we can conclude that
+  langchain>=1.2.18 depends on langgraph>=1.1.10,<1.2.0.
+```
+
+`langchain 1.2.18` explicitly pins `langgraph<1.2.0`. `langchain 1.3.0 GA` is
+required to lift this upper bound. Only `1.3.0a2` pre-release is available as of
+2026-05-12. The `langgraph` floor remains at `>=1.1.10`.
+
+### mistralai quarantine — evidence and impact
+
+```
+$ curl -s "https://pypi.org/simple/mistralai/" | grep pypi:project-status
+<meta name="pypi:project-status" content="quarantined">
+```
+
+Impact:
+- `pip install mistralai` fails in all environments.
+- `uv lock` fails for any extra that includes `mistralai` because the package
+  index returns a quarantined marker and the resolver finds zero candidates.
+- Existing lock-file wheel URL (`mistralai-2.4.4-py3-none-any.whl`) remains
+  intact on `files.pythonhosted.org`; environments using `uv sync --frozen`
+  with the old lock continue to work until they attempt a re-resolve.
+- Mistral's API is fully OpenAI-compatible (same `chat/completions` schema,
+  same function-calling JSON, same response format). The `openai` SDK with
+  `base_url="https://api.mistral.ai/v1"` is the canonical workaround.
+
+---
+
+## 3. Provider API Refactors
+
+No provider API refactors are required in this cycle. All call sites verified
+against current official documentation.
+
+### OpenAI
+
+- **Responses API** (`client.responses.create()`): Correctly used in
+  `examples/llm_integration/openai_demo.py` (Scenario A) with `gpt-4.1` model,
+  `input=[...]` parameter, and `previous_response_id` for multi-turn tool loops.
+  Source: `https://platform.openai.com/docs/guides/responses-vs-chat-completions`
+- **Chat Completions** (`client.chat.completions.create()`): Correctly used in
+  Scenario B and D. `gpt-4o` model, standard `tools=[...]` + `tool_choice` pattern.
+- **Assistants API**: Not used anywhere in the codebase. No migration required.
+- **`OpenAIResponsesAdapter`**: Correctly emits `{"type":"function","name":...,"parameters":...}` flat schema as required by Responses API; separate from `OpenAIAdapter` which emits `{"type":"function","function":{...}}` nested schema for Chat Completions. ✅
+- **Model names**: `gpt-4.1` and `gpt-4o` in examples — current documented families. ✅
+
+### Anthropic
+
+- **Messages API** (`client.messages.create()`): Correctly used throughout.
+  `tools=[{"name":...,"description":...,"input_schema":{...}}]` format matches
+  current API. `tool_use` content block handling correct.
+  Source: `https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview`
+- **`AnthropicAdapter`**: Emits `{name, description, input_schema}` format and
+  parses `tool_use` blocks; `format_tool_result` emits `{type:"tool_result","tool_use_id":...}`. ✅
+- **Strict tool use** (`strict: True` flag): Supported on the adapter. ✅
+- **Model names**: `claude-sonnet-4-6` in examples. Current and recommended. ✅
+- **Adaptive / extended thinking**: `AnthropicFeatures` dataclass correctly handles
+  both `adaptive` (effort-based, Opus 4.6+/Sonnet 4.6+/Opus 4.7) and `enabled`
+  (budget_tokens, Sonnet 4.6/Opus 4.6/Haiku 4.5) patterns. ✅
+
+### Google Gemini
+
+- **`client.aio.models.generate_content()`**: Correct async interface for
+  `google-genai>=1.x`. `config=types.GenerateContentConfig(tools=[...])` pattern. ✅
+- **`GeminiAdapter`**: Emits `{name, description, parameters}` function-declaration
+  dict; `format_tool_result` correctly places `id` inside `functionResponse`.
+  Source: `https://ai.google.dev/gemini-api/docs/function-calling`
+- **Model name**: `gemini-2.5-flash` in example. ✅
+
+### Mistral (post-quarantine)
+
+**Changed (must-change-now item #1):**
+
+`agent_gantry/adapters/llm_client.py`, `_initialize_client`, mistral branch:
+
+```diff
+-        elif self._provider == "mistral":
+-            # mistralai >= 2.0 requires `async with Mistral(...) as client:` per call.
+-            self._mistral_api_key = api_key
++        elif self._provider == "mistral":
++            # mistralai quarantined on PyPI (2026-05-12); use OpenAI SDK.
++            from openai import AsyncOpenAI
++            self._client = AsyncOpenAI(
++                api_key=api_key,
++                base_url="https://api.mistral.ai/v1",
++            )
+```
+
+`agent_gantry/adapters/llm_client.py`, `classify_intent`, mistral branch:
+
+```diff
+-        elif self._provider == "mistral":
+-            from mistralai import Mistral
+-            async with Mistral(api_key=self._mistral_api_key) as mistral_client:
+-                response = await mistral_client.chat.complete_async(
+-                    model=self._model,
+-                    messages=[{"role": "user", "content": prompt}],
+-                    max_tokens=self._config.max_tokens,
+-                    temperature=self._config.temperature,
+-                )
+-            result = response.choices[0].message.content.strip()
++        elif self._provider == "mistral":
++            # Mistral's API is OpenAI-compatible; self._client is AsyncOpenAI
++            # with base_url="https://api.mistral.ai/v1".
++            response = await self._client.chat.completions.create(
++                model=self._model,
++                messages=[{"role": "user", "content": prompt}],
++                max_tokens=self._config.max_tokens,
++                temperature=self._config.temperature,
++            )
++            result = response.choices[0].message.content.strip()
+```
+
+**Risk level**: *Safe with shim* — external Mistral API behaviour is identical
+(same OpenAI-compatible JSON); `LLMConfig(provider="mistral")` continues to work.
+
+**`MistralAdapter`** in `agent_gantry/adapters/tool_spec/providers.py`: inherits
+from `OpenAIAdapter` and produces `{"type":"function","function":{...}}` schemas —
+no change required. ✅
+
+---
+
+## 4. Framework Integration Refactors
+
+No code refactors required in this cycle. All AF integration modules verified
+against `agent-framework` 1.3.0.
+
+### Microsoft Agent Framework (Priority Review)
+
+**Agent construction** (`GantryToolBridge`, `GantryContextProvider`):
+- `Agent(client, instructions, name=..., tools=..., middleware=...)` constructor
+  pattern: ✅ correct for AF 1.x GA.
+- `@agent_framework.tool(name=..., description=..., approval_mode=...)` decoration:
+  ✅ correct; falls back gracefully when AF is not installed.
+- `approval_mode="always_require"` for destructive capabilities: ✅
+
+**Workflow subsystem**:
+- `WorkflowBuilder`, `AgentExecutor`, `WorkflowAgent`: ✅ correct AF 1.x API.
+- `SequentialBuilder`, `HandoffBuilder`, `ConcurrentBuilder`: ✅ correct.
+
+**Middleware pipeline**:
+- `FunctionMiddleware` (preferred) / `ChatMiddlewareLayer` (fallback): ✅
+- `MiddlewareTermination` for approval flow: ✅
+- `@chat_middleware` decorator for per-round tool refreshes: ✅
+
+**Context providers** (`GantryContextProvider`):
+- Subclasses `agent_framework.ContextProvider` with `source_id` keyed injection. ✅
+- `before_run()` → `context.extend_tools(source_id, tools)`: ✅
+- `per_call` / `per_run` strategy: ✅
+- `skills=True` integration with `SkillsProvider`-style registry: ✅
+
+**AF 1.3.0 new features** (pending — carried as good-next-step items):
+- `allowed_tools` for OpenAI/Gemini tool-choice filtering: not yet exposed in
+  Gantry's bridge/provider. Tracked as item **C** above.
+- `ClassSkill` for class-based skill definitions: not relevant to Gantry's
+  current skill integration.
+- Multi-source skills API restructuring in 1.3.0: affects `SkillsProvider`
+  docstring example only (tracked as item **D**); runtime code unchanged.
+
+**Needs confirmation**: The `SkillsProvider(skill_paths="./skills")` path-based
+API was restructured in AF 1.3.0. The docstring example in `agent_framework_provider.py`
+uses this pattern. Once the AF 1.3.0 migration guide confirms the new path-based
+syntax, the docstring should be updated (item **D**).
+
+### LangChain / LangGraph
+
+The LangGraph integration in `examples/agent_frameworks/langgraph_example.py` and
+`adapters/framework_adapters.py` uses `fetch_framework_tools()` which emits
+OpenAI-compatible schemas — LangGraph accepts these natively. No changes required.
+`langchain 1.2.18` and `langgraph 1.1.10` are both current.
+
+### AutoGen
+
+`examples/agent_frameworks/autogen_example.py` uses `autogen-agentchat 0.7.5`.
+No legacy 0.2.x patterns detected. The repo correctly documents that MAF is the
+successor direction for orchestration; AutoGen remains supported as a parallel
+integration for teams not yet migrating.
+
+### CrewAI
+
+Held at 1.6.1 due to opentelemetry conflict. No refactors required within the
+current pinned version.
+
+---
+
+## 5. Universal Tool-Calling Design
+
+The existing design in `agent_gantry/adapters/tool_spec/` is sound and current.
+Full audit confirms:
+
+### Internal `ToolSpec` contract (`ToolDefinition`)
+
+- Single canonical `parameters_schema` field (JSON Schema, OpenAI-style). ✅
+- `to_dialect(dialect)` dispatcher routes through `DialectRegistry`. ✅
+- Deprecated `to_openai_schema()` / `to_anthropic_schema()` / `to_gemini_schema()`
+  correctly warn and delegate to `to_dialect()`. ✅
+
+### Provider translators
+
+| Provider | Adapter | Schema emitted | Tool-call ID field | Tool-result field |
+|----------|---------|---------------|-------------------|-------------------|
+| OpenAI Chat Completions | `OpenAIAdapter` | `{"type":"function","function":{name,description,parameters}}` | `id` on call | `tool_call_id` on result |
+| OpenAI Responses API | `OpenAIResponsesAdapter` | `{"type":"function",name,description,parameters}` (flat) | `call_id` | `call_id` on result |
+| Anthropic | `AnthropicAdapter` | `{name,description,input_schema}` | `id` (`toolu_…`) | `tool_use_id` on result |
+| Gemini | `GeminiAdapter` | `{name,description,parameters}` | `id` (parallel calls) | `functionResponse.id` |
+| Mistral | `MistralAdapter` (→ `OpenAIAdapter`) | OpenAI Chat Completions format | `id` | `tool_call_id` |
+| Groq | `GroqAdapter` (→ `OpenAIAdapter`) | OpenAI Chat Completions format | `id` | `tool_call_id` |
+| Agent Framework | `AgentFrameworkAdapter` (→ `OpenAIAdapter`) | OpenAI format + optional metadata | `id` or `call_id` | `tool_call_id` |
+
+All adapters are verified correct against current provider documentation.
+
+### Parallel tool calls
+
+- OpenAI Responses API: parallel `function_call` items in `response.output`. `call_id` used for correlation. ✅
+- Anthropic: multiple `tool_use` blocks in `response.content`. `id` used for `tool_use_id`. ✅
+- Gemini: parallel `functionCall` parts with `id`. `GeminiAdapter.from_provider_payload` reads `id`. ✅
+
+### Tool name normalisation
+
+`ToolDefinition.name` enforces `^[a-z][a-z0-9_]*$` pattern. All providers accept
+snake_case names. No normalisation gaps detected.
+
+---
+
+## 6. Documentation and Example Updates
+
+### Applied in this commit
+
+**`examples/llm_integration/mistral_demo.py`** — fully rewritten to use `openai.AsyncOpenAI`
+with `base_url="https://api.mistral.ai/v1"`. The `with_semantic_tools` decorator
+flow and tool execution loop are preserved; only the client initialisation and API
+call pattern changes.
+
+**`docs/reference/llm_sdk_compatibility.md`**:
+- Compatibility table: Mistral row updated to `⚠️ OpenAI-compatible endpoint` with
+  quarantine note.
+- Mistral section rewritten: `pip install mistralai>=2.0.0` replaced by
+  `pip install "agent-gantry[openai]"`; all code examples updated to use
+  `AsyncOpenAI(api_key=..., base_url="https://api.mistral.ai/v1")`.
+- References section: Mistral AI SDK link updated with quarantine note.
+
+**`README.md`**:
+- Mistral code snippet updated to `from openai import AsyncOpenAI` pattern.
+
+### No changes required
+
+- `examples/llm_integration/openai_demo.py`: already uses Responses API with
+  `gpt-4.1` and Chat Completions with `gpt-4o`. ✅
+- `examples/llm_integration/anthropic_demo.py`: uses `claude-sonnet-4-6` and
+  current Messages API pattern. ✅
+- `examples/llm_integration/google_genai_demo.py`: uses `gemini-2.5-flash` and
+  `client.aio.models.generate_content`. ✅
+- All agent_frameworks examples: current AF 1.x patterns throughout. ✅
+- QUICK_REFERENCE.md: no mistralai references; no changes required.
+
+---
+
+## 7. Test and Migration Plan
+
+### Tests to add / update
+
+| Test | Type | Priority | Notes |
+|------|------|----------|-------|
+| `tests/test_llm_sdk_compatibility.py` — `TestMistralCompatibility` | Update | Medium | Existing tests use `pytest.importorskip("mistralai")` — they auto-skip gracefully. Add a new `TestMistralOpenAICompat` class that verifies `AsyncOpenAI(base_url="...")` initialises correctly and that `chat.completions.create` is accessible. Does not require a live API key. |
+| `tests/test_llm_sdk_compatibility.py` — mistral minimum-version | Update | Low | `test_mistral_minimum_version` tests the quarantined package version. Replace with a test that verifies `openai.__version__` meets `>=2.36.0`. |
+| `agent_gantry/adapters/llm_client.py` — mistral branch unit test | New | Medium | Add a unit test that instantiates `LLMClient(LLMConfig(provider="mistral", model="mistral-large-latest", api_key="test"))` and verifies `self._client` is an `AsyncOpenAI` instance with `base_url` set. Mock the network call. |
+
+### Fixtures and mocks to regenerate
+
+No VCR recordings or golden fixtures are affected by the mistralai change because
+the test suite uses `pytest.importorskip("mistralai")` — the Mistral tests were
+never recorded (they required the real SDK). The new OpenAI-based Mistral tests
+should use `unittest.mock.AsyncMock` to avoid network calls.
+
+### Changelog-ready migration notes
+
+#### `mistralai` package → OpenAI SDK (Breaking for direct mistralai SDK users)
+
+**Type**: *Breaking* for users who installed `agent-gantry[mistral]` and called
+`from mistralai import Mistral` directly via `LLMConfig(provider="mistral")`.
+
+**Migration**:
+
+```python
+# Before (mistralai SDK — no longer installable)
+from mistralai import Mistral
+async with Mistral(api_key="...") as client:
+    response = await client.chat.complete_async(model="mistral-large-latest", ...)
+
+# After (openai SDK — Mistral is OpenAI-compatible)
+from openai import AsyncOpenAI
+client = AsyncOpenAI(api_key="...", base_url="https://api.mistral.ai/v1")
+response = await client.chat.completions.create(model="mistral-large-latest", ...)
+```
+
+No change is required to Gantry tool registration, retrieval, or execution.
+The `MistralAdapter` (for schema translation) is unaffected.
+
+`LLMConfig(provider="mistral")` continues to work transparently — `llm_client.py`
+now initialises `AsyncOpenAI` with the Mistral base URL internally.
+
+#### `anthropic` 0.100.0 → 0.101.0 (Non-breaking)
+
+Floor bumped to `>=0.101.0`. No API-surface changes in Gantry's call sites.
+Users on 0.100.0 should upgrade: `pip install --upgrade anthropic`.
+
+#### `langgraph` 1.2.0 — not yet adopted (Informational)
+
+langgraph 1.2.0 is available but cannot be adopted until `langchain 1.3.0 GA`
+is published (current release, `langchain 1.2.18`, pins `langgraph<1.2.0`).
+No user action required. The upgrade will be applied automatically in the next
+audit cycle once `langchain 1.3.0 GA` is released.
+
+---
+
+## Appendix: Phase Inventory
+
+### Phase 1 — Repository Inventory (Complete)
+
+**Core modules read:**
+- `pyproject.toml`, `uv.lock`
+- `agent_gantry/__init__.py` — public surface
+- `agent_gantry/schema/tool.py` — `ToolDefinition`, `SchemaDialect`, `ToolSource`
+- `agent_gantry/adapters/tool_spec/providers.py` — all provider adapters
+- `agent_gantry/adapters/tool_spec/registry.py` — `DialectRegistry`
+- `agent_gantry/adapters/llm_client.py` — multi-provider LLM client
+- `agent_gantry/integrations/agent_framework_bridge.py` — AF bridge
+- `agent_gantry/integrations/agent_framework_middleware.py` — AF middleware
+- `agent_gantry/integrations/agent_framework_provider.py` — AF context provider
+- `agent_gantry/integrations/framework_adapters.py` — generic framework adapters
+- `agent_gantry/integrations/anthropic_features.py` — thinking / tool features
+- All examples under `examples/llm_integration/` and `examples/agent_frameworks/`
+- `tests/test_llm_sdk_compatibility.py`
+- Previous audit files (`AUDIT_2026-05-10.md` and earlier)
+
+**No invented files, modules, tests, or APIs in this report.**
+
+---
+
+## Must-Change Now vs Good-Next-Step Split
+
+### Must-Change Now (Applied)
+
+1. **Remove quarantined `mistralai` dependency** — replace with `openai` SDK + Mistral base URL in `pyproject.toml`, `llm_client.py`, `mistral_demo.py`, `llm_sdk_compatibility.md`, `README.md`. Unblocks all lockfile regeneration.
+2. **`anthropic` floor: `>=0.100.0` → `>=0.101.0`** — picks up the 2026-05-11 release.
+3. **Document `langgraph 1.2.0` hold in `pyproject.toml`** — exact blocker (`langchain==1.2.18` upper-bound) recorded.
+
+### Good Next-Step Improvements
+
+- **B**: Bump `langgraph` to `>=1.2.0` once `langchain 1.3.0 GA` is released.
+- **C**: Expose AF 1.3.0 `allowed_tools` in `GantryToolBridge` / `GantryContextProvider`.
+- **D**: Update `SkillsProvider` docstring for AF 1.3.0 multi-source skills API.
+- **E**: Add `output_schema` / `output_config` to `AnthropicClient.create_message()`.
+- **A**, **F**, **G**: Dependency holds (google-genai, crewai, semantic-kernel/google-adk) — unlock when upstream resolves opentelemetry conflicts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`mistralai` dependency removed — replaced by OpenAI SDK for Mistral calls.**
+  The `mistralai` package was quarantined on PyPI on 2026-05-12 and is no longer
+  installable. Mistral's chat endpoint is OpenAI-compatible. The `openai` SDK with
+  `base_url="https://api.mistral.ai/v1"` is the canonical replacement. Changes:
+  - `pyproject.toml` `mistral` extra now depends on `openai>=2.36.0` instead of
+    `mistralai>=2.0.0`. `mistral` is removed from `llm-providers`.
+  - `agent_gantry/adapters/llm_client.py` — `provider="mistral"` now initialises
+    `AsyncOpenAI(base_url="https://api.mistral.ai/v1")` and uses
+    `chat.completions.create()`.
+  - `examples/llm_integration/mistral_demo.py` — fully updated to use the OpenAI
+    SDK with Mistral's base URL.
+  - `docs/reference/llm_sdk_compatibility.md` and `README.md` — Mistral snippets
+    updated accordingly.
+  - Transitive orphan packages `eval-type-backport` and `jsonpath-python` removed
+    from the lock file.
+  *Migration*: Replace `from mistralai import Mistral; async with Mistral(...) as c: ...`
+  with `from openai import AsyncOpenAI; c = AsyncOpenAI(api_key=..., base_url="https://api.mistral.ai/v1"); await c.chat.completions.create(...)`.
+  `LLMConfig(provider="mistral")` continues to work — migration is internal.
+  *Risk: safe with shim — public Mistral integration behaviour preserved.*
+- **`anthropic` floor bumped to `>=0.101.0`** (was `>=0.100.0`). Anthropic 0.101.0
+  released 2026-05-11; no breaking changes for Gantry's Messages API call sites.
+  *Risk: safe internal — floor bump only.*
+  Source: https://pypi.org/pypi/anthropic/json
+- **`pyproject.toml`** — `langgraph 1.2.0` hold documented. `langchain==1.2.18`
+  pins `langgraph<1.2.0`; the floor remains `>=1.1.10` until `langchain 1.3.0 GA`.
+
 ### Added
 
 - **`agent_gantry/adapters/tool_spec/providers.py`** — `AnthropicAdapter.to_provider_schema()` now accepts `strict=False` (default, backwards-compatible) or `strict=True`. When `True`, the output schema includes `"strict": true` at the tool-definition top level, enabling Anthropic's grammar-constrained sampling so Claude's tool `input` always matches `input_schema` exactly.

--- a/README.md
+++ b/README.md
@@ -225,19 +225,19 @@ async def chat(prompt, *, tools=None):
     )
 ```
 
-**Mistral:**
+**Mistral** (OpenAI-compatible endpoint; `mistralai` SDK quarantined on PyPI — use the `openai` SDK):
 ```python
-from mistralai import Mistral
+from openai import AsyncOpenAI
 from agent_gantry import with_semantic_tools
 
-client = Mistral()
+client = AsyncOpenAI(api_key="your-mistral-key", base_url="https://api.mistral.ai/v1")
 
 @with_semantic_tools(limit=3)  # Mistral uses OpenAI-compatible format
 async def chat(messages, *, tools=None):
-    return await client.chat.complete_async(
+    return await client.chat.completions.create(
         model="mistral-large-latest",
         messages=messages,
-        tools=tools
+        tools=tools,
     )
 ```
 

--- a/agent_gantry/adapters/llm_client.py
+++ b/agent_gantry/adapters/llm_client.py
@@ -33,9 +33,6 @@ class LLMClient:
         """
         self._config = config
         self._client: Any = None
-        # mistralai >= 2.0 uses a per-call async context manager rather than a
-        # long-lived client object. Store only the API key for that provider.
-        self._mistral_api_key: str | None = None
         self._provider = config.provider
         self._model = config.model
         self._initialize_client()
@@ -61,10 +58,15 @@ class LLMClient:
 
             self._client = genai.Client(api_key=api_key)
         elif self._provider == "mistral":
-            # mistralai >= 2.0 requires `async with Mistral(...) as client:` per call.
-            # We store only the API key here; the context manager is opened in
-            # classify_intent() so resources are released after every invocation.
-            self._mistral_api_key = api_key
+            # mistralai (the official Mistral SDK) is quarantined on PyPI (2026-05-12).
+            # Mistral's API is OpenAI-compatible; use AsyncOpenAI with the Mistral
+            # base URL. The chat.completions interface is identical.
+            from openai import AsyncOpenAI
+
+            self._client = AsyncOpenAI(
+                api_key=api_key,
+                base_url="https://api.mistral.ai/v1",
+            )
         elif self._provider == "groq":
             from groq import AsyncGroq
 
@@ -163,16 +165,14 @@ Respond with ONLY the intent category name (e.g., "data_query"), nothing else.""
             )
             result = response.text.strip()
         elif self._provider == "mistral":
-            # mistralai >= 2.0: open a fresh async context manager per call.
-            from mistralai import Mistral
-
-            async with Mistral(api_key=self._mistral_api_key) as mistral_client:
-                response = await mistral_client.chat.complete_async(
-                    model=self._model,
-                    messages=[{"role": "user", "content": prompt}],
-                    max_tokens=self._config.max_tokens,
-                    temperature=self._config.temperature,
-                )
+            # Mistral's API is OpenAI-compatible; self._client is AsyncOpenAI
+            # with base_url="https://api.mistral.ai/v1" (set in _initialize_client).
+            response = await self._client.chat.completions.create(
+                model=self._model,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=self._config.max_tokens,
+                temperature=self._config.temperature,
+            )
             result = response.choices[0].message.content.strip()
         else:
             raise ValueError(f"Unsupported provider: {self._provider}")

--- a/agent_gantry/adapters/llm_client.py
+++ b/agent_gantry/adapters/llm_client.py
@@ -198,6 +198,4 @@ Respond with ONLY the intent category name (e.g., "data_query"), nothing else.""
         Returns:
             True if the client is initialized and ready
         """
-        if self._provider == "mistral":
-            return self._mistral_api_key is not None
         return self._client is not None

--- a/docs/reference/llm_sdk_compatibility.md
+++ b/docs/reference/llm_sdk_compatibility.md
@@ -20,7 +20,7 @@ Agent-Gantry is designed to work seamlessly with leading LLM providers. This gui
 | Anthropic | `anthropic` | ✅ Full Support | Claude models |
 | Google GenAI | `google-genai` | ✅ Full Support | For prototyping |
 | Google Vertex AI | `google-cloud-aiplatform` | ✅ Full Support | Production recommended |
-| Mistral | `mistralai` | ✅ Full Support | Including agents API |
+| Mistral | `openai` | ⚠️ OpenAI-compatible endpoint | `mistralai` quarantined on PyPI (2026-05-12); use OpenAI SDK with `base_url="https://api.mistral.ai/v1"` |
 | Groq | `groq` | ✅ Full Support | Fast inference |
 | OpenRouter | `openai` | ✅ Full Support | Via base_url override |
 
@@ -504,61 +504,43 @@ response = model.generate_content("What's AAPL stock price?")
 
 ## Mistral
 
+> **⚠️ Note (2026-05-12):** The `mistralai` package was quarantined on PyPI and is
+> no longer installable. Mistral's chat endpoint is OpenAI-compatible; use the
+> `openai` SDK with `base_url="https://api.mistral.ai/v1"` instead. All Gantry
+> tool schemas work without modification.
+
 ### Package
 ```bash
-pip install mistralai>=2.0.0
+pip install "agent-gantry[openai]"
+# or: pip install openai
 ```
 
 ### Client Initialization
 ```python
-from mistralai import Mistral
+from openai import AsyncOpenAI
 
-# mistralai 2.x uses an async context manager for proper resource cleanup
-async with Mistral(api_key="your-api-key") as client:
-    response = await client.chat.complete_async(...)
+# Mistral is OpenAI-compatible — point AsyncOpenAI at the Mistral base URL.
+client = AsyncOpenAI(api_key="your-mistral-api-key", base_url="https://api.mistral.ai/v1")
 ```
 
 ### Key Methods
 
 #### Chat Complete (async)
 ```python
-# mistralai 2.x: use async with for proper resource cleanup
-async with Mistral(api_key="your-api-key") as client:
-    response = await client.chat.complete_async(
-        model="mistral-large-latest",
-        messages=[
-            {"role": "user", "content": "Hello, Mistral!"}
-        ]
-    )
-    print(response.choices[0].message.content)
-```
+from openai import AsyncOpenAI
 
-#### Fill-in-the-Middle (FIM)
-```python
-async with Mistral(api_key="your-api-key") as client:
-    response = await client.fim.complete_async(
-        model="codestral-latest",
-        prompt="def fibonacci(n):",
-        suffix="    return result"
-    )
-    print(response.choices[0].message.content)
-```
-
-#### Agents
-```python
-async with Mistral(api_key="your-api-key") as client:
-    response = await client.agents.complete_async(
-        agent_id="your-agent-id",
-        messages=[
-            {"role": "user", "content": "Help me with a task"}
-        ]
-    )
+client = AsyncOpenAI(api_key="your-mistral-api-key", base_url="https://api.mistral.ai/v1")
+response = await client.chat.completions.create(
+    model="mistral-large-latest",
+    messages=[{"role": "user", "content": "Hello, Mistral!"}],
+)
+print(response.choices[0].message.content)
 ```
 
 ### Agent-Gantry Integration
 
 ```python
-from mistralai import Mistral
+from openai import AsyncOpenAI
 from agent_gantry import AgentGantry
 
 gantry = AgentGantry()
@@ -570,13 +552,12 @@ def send_notification(message: str, channel: str) -> str:
 
 await gantry.sync()
 
-# Get tools in OpenAI-compatible format (Mistral uses the same schema)
+# Gantry's default dialect produces OpenAI-compatible function schemas.
 tools = await gantry.retrieve_tools("send notification")
 
-# Use with Mistral 2.x async context manager
-async with Mistral(api_key="your-key") as client:
-    response = await client.chat.complete_async(
-        model="mistral-large-latest",
+client = AsyncOpenAI(api_key="your-key", base_url="https://api.mistral.ai/v1")
+response = await client.chat.completions.create(
+    model="mistral-large-latest",
         messages=[{"role": "user", "content": "Notify the team"}],
         tools=tools,
     )
@@ -895,6 +876,6 @@ for chunk in response:
 - [Anthropic Python SDK](https://github.com/anthropics/anthropic-sdk-python)
 - [Google GenAI SDK](https://github.com/googleapis/python-genai)
 - [Google Cloud AI Platform](https://cloud.google.com/python/docs/reference/aiplatform/latest)
-- [Mistral AI SDK](https://github.com/mistralai/client-python)
+- [Mistral AI API docs](https://docs.mistral.ai/) (use OpenAI SDK with `base_url="https://api.mistral.ai/v1"`; `mistralai` package is quarantined)
 - [Groq SDK](https://github.com/groq/groq-python)
 - [OpenRouter Documentation](https://openrouter.ai/docs)

--- a/docs/reference/llm_sdk_compatibility.md
+++ b/docs/reference/llm_sdk_compatibility.md
@@ -558,9 +558,9 @@ tools = await gantry.retrieve_tools("send notification")
 client = AsyncOpenAI(api_key="your-key", base_url="https://api.mistral.ai/v1")
 response = await client.chat.completions.create(
     model="mistral-large-latest",
-        messages=[{"role": "user", "content": "Notify the team"}],
-        tools=tools,
-    )
+    messages=[{"role": "user", "content": "Notify the team"}],
+    tools=tools,
+)
 ```
 
 ---

--- a/examples/llm_integration/mistral_demo.py
+++ b/examples/llm_integration/mistral_demo.py
@@ -1,3 +1,16 @@
+"""
+Mistral AI + Agent-Gantry integration demo.
+
+The official `mistralai` SDK was quarantined on PyPI on 2026-05-12 and is no
+longer installable from the package index. Mistral's chat endpoint is
+OpenAI-compatible, so this demo uses the `openai` Python SDK with
+``base_url="https://api.mistral.ai/v1"``. All function-calling schemas produced
+by Gantry's ``dialect="openai"`` or default adapter work without modification.
+
+Install:
+    pip install "agent-gantry[openai]"
+"""
+
 import asyncio
 import json
 import os
@@ -8,25 +21,21 @@ from dotenv import load_dotenv
 from agent_gantry import AgentGantry, set_default_gantry, with_semantic_tools
 from agent_gantry.schema.execution import ToolCall
 
-# Load environment variables
 load_dotenv()
 
 
 async def main():
     print("=== Agent-Gantry + Mistral AI Integration Demo ===\n")
 
-    # 1. Check for API Key
     api_key = os.environ.get("MISTRAL_API_KEY")
     if not api_key:
         print("❌ Error: MISTRAL_API_KEY not found in environment.")
         print("   Please set it in your .env file.")
         return
 
-    # 2. Initialize Gantry
     gantry = AgentGantry()
-    set_default_gantry(gantry)  # Set default for decorator usage
+    set_default_gantry(gantry)
 
-    # 3. Register Tools
     @gantry.register(tags=["translation"])
     def translate_text(text: str, target_lang: str) -> str:
         """Translate text to a target language."""
@@ -35,23 +44,22 @@ async def main():
     await gantry.sync()
     print(f"✅ Registered {gantry.tool_count} tools\n")
 
-    # 4. Initialize Mistral Client
-    from mistralai import Mistral
+    # Mistral is OpenAI-compatible: point AsyncOpenAI at the Mistral base URL.
+    from openai import AsyncOpenAI
 
-    client = Mistral(api_key=api_key)
+    client = AsyncOpenAI(api_key=api_key, base_url="https://api.mistral.ai/v1")
 
     # --- Scenario: Dynamic Retrieval ---
     print("--- Scenario: Dynamic Retrieval ---")
     query = "Translate 'Hello World' to French"
     print(f"User Query: '{query}'")
 
-    # Retrieve tools (OpenAI format is compatible with Mistral)
+    # Gantry's default dialect produces OpenAI-compatible function schemas,
+    # which Mistral's endpoint accepts without modification.
     tools = await gantry.retrieve_tools(query, limit=1, score_threshold=0.1)
     print(f"Gantry retrieved {len(tools)} tool(s)")
 
-    # Call Mistral
-    # Mistral's `tools` parameter accepts the same JSON schema structure
-    response = await client.chat.complete_async(
+    response = await client.chat.completions.create(
         model="mistral-large-latest",
         messages=[{"role": "user", "content": query}],
         tools=tools,
@@ -62,8 +70,6 @@ async def main():
     if tool_calls:
         for tc in tool_calls:
             print(f"Mistral decided to call: {tc.function.name}({tc.function.arguments})")
-
-            # Execute securely via Gantry
             result = await gantry.execute(
                 ToolCall(
                     tool_name=tc.function.name,
@@ -74,33 +80,24 @@ async def main():
             )
             print(f"Execution Result: {result.result}")
 
-    # --- Scenario: Using @with_semantic_tools Decorator (RECOMMENDED) ---
+    # --- Scenario: Using @with_semantic_tools Decorator ---
     print("\n--- Scenario: Using @with_semantic_tools Decorator (RECOMMENDED) ---")
 
-    # The decorator uses the default gantry set above
-    # Mistral uses OpenAI-compatible format, so no dialect parameter needed
     @with_semantic_tools(limit=1, score_threshold=0.1, prompt_param="user_query")
     async def chat_with_mistral(user_query: str, tools: list[dict[str, Any]] = None):
-        """
-        This function automatically gets relevant tools injected into the 'tools' argument
-        based on the user_query.
-        """
         print(f"Decorator injected {len(tools) if tools else 0} tools")
-
-        response = await client.chat.complete_async(
+        response = await client.chat.completions.create(
             model="mistral-large-latest",
             messages=[{"role": "user", "content": user_query}],
             tools=tools,
             tool_choice="auto",
         )
-
         if response.choices[0].message.tool_calls:
             tc = response.choices[0].message.tool_calls[0]
             print(f"Mistral (via decorator) called: {tc.function.name}")
             return tc.function.name
         return "No tool called"
 
-    # The decorator handles the retrieval logic internally
     await chat_with_mistral("Translate 'Good Morning' to Spanish")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ mistral = [
     # correct replacement: pass base_url="https://api.mistral.ai/v1" to
     # AsyncOpenAI(). The MistralAdapter in agent_gantry.adapters.tool_spec
     # continues to translate tool schemas correctly for both patterns.
-    # Install with: pip install "agent-gantry[openai]"
+    # Install with: pip install "agent-gantry[mistral]"
     "openai>=2.36.0",
 ]
 groq = [
@@ -186,11 +186,11 @@ groq = [
 ]
 # Combined LLM provider dependencies
 llm-providers = [
-    # mistral is intentionally excluded: the mistralai package is quarantined on
-    # PyPI (2026-05-12). Mistral is OpenAI-compatible; openai (already here)
-    # covers Mistral calls via base_url="https://api.mistral.ai/v1". The
-    # standalone agent-gantry[mistral] extra also resolves to openai>=2.36.0.
-    "agent-gantry[openai,anthropic,google-genai,google-vertexai,groq]",
+    # mistralai package is quarantined on PyPI (2026-05-12). The mistral extra
+    # resolves to openai>=2.36.0 (Mistral is OpenAI-compatible). Including it
+    # here ensures [all] users inherit the mistral path and any future
+    # Mistral-specific dependencies are picked up automatically.
+    "agent-gantry[openai,anthropic,google-genai,google-vertexai,mistral,groq]",
 ]
 all = [
     "agent-gantry[dev,embeddings,openai,cohere,vector-stores,lancedb,nomic,mcp,a2a,llm-providers,agent-frameworks,example-tools]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,10 @@ agent-frameworks = [
     "crewai>=1.6.1",
     "langchain>=1.2.18",
     "langchain-openai>=1.2.1",
+    # langgraph 1.2.0 is available but blocked: langchain==1.2.18 explicitly pins
+    # langgraph>=1.1.10,<1.2.0. langchain 1.3.0 stable is required to lift that upper
+    # bound; only 1.3.0 pre-releases exist as of 2026-05-12. Floor stays at 1.1.10
+    # until langchain 1.3.0 GA is published.
     "langgraph>=1.1.10",
     "llama-index-core>=0.14.21",
     "llama-index-llms-openai>=0.7.7",
@@ -151,7 +155,7 @@ a2a = [
 ]
 # LLM provider SDK dependencies
 anthropic = [
-    "anthropic>=0.100.0",
+    "anthropic>=0.101.0",
 ]
 google-genai = [
     # google-genai 2.0.0 (released 2026-05-07) and 2.0.1 (2026-05-09) introduce
@@ -168,14 +172,25 @@ google-vertexai = [
     "google-cloud-aiplatform>=1.70.0",
 ]
 mistral = [
-    "mistralai>=2.0.0",
+    # mistralai (the official Mistral AI SDK) was quarantined on PyPI on
+    # 2026-05-12 and is no longer installable from the package index.
+    # Mistral's chat endpoint is OpenAI-compatible, so the OpenAI SDK is the
+    # correct replacement: pass base_url="https://api.mistral.ai/v1" to
+    # AsyncOpenAI(). The MistralAdapter in agent_gantry.adapters.tool_spec
+    # continues to translate tool schemas correctly for both patterns.
+    # Install with: pip install "agent-gantry[openai]"
+    "openai>=2.36.0",
 ]
 groq = [
     "groq>=1.2.0",
 ]
 # Combined LLM provider dependencies
 llm-providers = [
-    "agent-gantry[openai,anthropic,google-genai,google-vertexai,mistral,groq]",
+    # mistral is intentionally excluded: the mistralai package is quarantined on
+    # PyPI (2026-05-12). Mistral is OpenAI-compatible; openai (already here)
+    # covers Mistral calls via base_url="https://api.mistral.ai/v1". The
+    # standalone agent-gantry[mistral] extra also resolves to openai>=2.36.0.
+    "agent-gantry[openai,anthropic,google-genai,google-vertexai,groq]",
 ]
 all = [
     "agent-gantry[dev,embeddings,openai,cohere,vector-stores,lancedb,nomic,mcp,a2a,llm-providers,agent-frameworks,example-tools]",

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ vector-stores = [
 requires-dist = [
     { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.3.0,<2.0.0" },
     { name = "agent-gantry", extras = ["dev", "embeddings", "openai", "cohere", "vector-stores", "lancedb", "nomic", "mcp", "a2a", "llm-providers", "agent-frameworks", "example-tools"], marker = "extra == 'all'" },
-    { name = "agent-gantry", extras = ["openai", "anthropic", "google-genai", "google-vertexai", "groq"], marker = "extra == 'llm-providers'" },
+    { name = "agent-gantry", extras = ["openai", "anthropic", "google-genai", "google-vertexai", "mistral", "groq"], marker = "extra == 'llm-providers'" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.101.0" },
     { name = "asyncpg", marker = "extra == 'pgvector'", specifier = ">=0.29.0" },
     { name = "asyncpg", marker = "extra == 'vector-stores'", specifier = ">=0.29.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,6 @@ all = [
     { name = "llama-index-llms-openai" },
     { name = "matplotlib" },
     { name = "mcp" },
-    { name = "mistralai" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
@@ -629,14 +628,13 @@ llm-providers = [
     { name = "google-cloud-aiplatform" },
     { name = "google-genai" },
     { name = "groq" },
-    { name = "mistralai" },
     { name = "openai" },
 ]
 mcp = [
     { name = "mcp" },
 ]
 mistral = [
-    { name = "mistralai" },
+    { name = "openai" },
 ]
 nomic = [
     { name = "einops" },
@@ -663,8 +661,8 @@ vector-stores = [
 requires-dist = [
     { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.3.0,<2.0.0" },
     { name = "agent-gantry", extras = ["dev", "embeddings", "openai", "cohere", "vector-stores", "lancedb", "nomic", "mcp", "a2a", "llm-providers", "agent-frameworks", "example-tools"], marker = "extra == 'all'" },
-    { name = "agent-gantry", extras = ["openai", "anthropic", "google-genai", "google-vertexai", "mistral", "groq"], marker = "extra == 'llm-providers'" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.100.0" },
+    { name = "agent-gantry", extras = ["openai", "anthropic", "google-genai", "google-vertexai", "groq"], marker = "extra == 'llm-providers'" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.101.0" },
     { name = "asyncpg", marker = "extra == 'pgvector'", specifier = ">=0.29.0" },
     { name = "asyncpg", marker = "extra == 'vector-stores'", specifier = ">=0.29.0" },
     { name = "autogen-agentchat", marker = "extra == 'agent-frameworks'", specifier = ">=0.7.5" },
@@ -693,10 +691,10 @@ requires-dist = [
     { name = "llama-index-llms-openai", marker = "extra == 'agent-frameworks'", specifier = ">=0.7.7" },
     { name = "matplotlib", marker = "extra == 'example-tools'", specifier = ">=3.7.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.27.1" },
-    { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.0.0" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'embeddings'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'nomic'", specifier = ">=1.24.0" },
+    { name = "openai", marker = "extra == 'mistral'", specifier = ">=2.36.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=2.36.0" },
     { name = "pandas", marker = "extra == 'example-tools'", specifier = ">=2.0.0" },
     { name = "pillow", marker = "extra == 'example-tools'", specifier = ">=10.0.0" },
@@ -923,7 +921,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.100.0"
+version = "0.101.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -935,9 +933,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/2d/24caf0ff727cba2ed863925017c8f93463a2ea6224a0efe5626e672bc3d2/anthropic-0.100.0.tar.gz", hash = "sha256:650dee9e023afb16395939ee4104bbc21f966b380210119fb91122c12099c79a", size = 758255, upload-time = "2026-05-06T15:07:13.578Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/cb/9d0123243e749ac3a579972b2c398971bce1dc57bcc4efb08066df610360/anthropic-0.101.0.tar.gz", hash = "sha256:1116a6a87c55757e0fbe3e1ba40804fbd04de7963601a6dd6b539a889f18de3e", size = 758603, upload-time = "2026-05-11T15:46:33.944Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/c775c59ab9445ecabb57ef3d5c24027de060139189a9e312ef9ef889a665/anthropic-0.100.0-py3-none-any.whl", hash = "sha256:1c15769efa15d8fd5c1ebf900e25c57e3ee540f8554a29aa56e4edefffe2951d", size = 753596, upload-time = "2026-05-06T15:07:12.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b2/74ff06762d005ecf1658929a292df0acb786d025f6a6c54fcb30e2dc7761/anthropic-0.101.0-py3-none-any.whl", hash = "sha256:cc3cc6576989471e2aa9132258034ad0ff0d8fe500b04ac499e4e46ed68c5ed0", size = 753594, upload-time = "2026-05-11T15:46:32.216Z" },
 ]
 
 [[package]]
@@ -2253,15 +2251,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
-]
-
-[[package]]
-name = "eval-type-backport"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fb/a3/cafafb4558fd638aadfe4121dc6cefb8d743368c085acb2f521df0f3d9d7/eval_type_backport-0.3.1.tar.gz", hash = "sha256:57e993f7b5b69d271e37482e62f74e76a0276c82490cf8e4f0dffeb6b332d5ed", size = 9445, upload-time = "2025-12-02T11:51:42.987Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/22/fdc2e30d43ff853720042fa15baa3e6122722be1a7950a98233ebb55cd71/eval_type_backport-0.3.1-py3-none-any.whl", hash = "sha256:279ab641905e9f11129f56a8a78f493518515b83402b860f6f06dd7c011fdfa8", size = 6063, upload-time = "2025-12-02T11:51:41.665Z" },
 ]
 
 [[package]]
@@ -3634,15 +3623,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jsonpath-python"
-version = "1.1.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/db/2f4ecc24da35c6142b39c353d5b7c16eef955cc94b35a48d3fa47996d7c3/jsonpath_python-1.1.5.tar.gz", hash = "sha256:ceea2efd9e56add09330a2c9631ea3d55297b9619348c1055e5bfb9cb0b8c538", size = 87352, upload-time = "2026-03-17T06:16:40.597Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/50/1a313fb700526b134c71eb8a225d8b83be0385dbb0204337b4379c698cef/jsonpath_python-1.1.5-py3-none-any.whl", hash = "sha256:a60315404d70a65e76c9a782c84e50600480221d94a58af47b7b4d437351cb4b", size = 14090, upload-time = "2026-03-17T06:16:39.152Z" },
-]
-
-[[package]]
 name = "jsonpointer"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4455,25 +4435,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6a/14/a1365e0bab1486c2d16aabeb192ca90715794edf4e68be4815c245884420/microsoft_agents_hosting_core-0.3.1.tar.gz", hash = "sha256:0b76bda10e7a54ff3c86e56cbabaad5ac7a4c2a076c9833af3b2f4c86fa85e89", size = 81137, upload-time = "2025-09-09T23:19:46.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/1b/543ddaa2daf8593911a02a07a6a78366d4a6a0053ec86a557c19fa97b60e/microsoft_agents_hosting_core-0.3.1-py3-none-any.whl", hash = "sha256:a4b41556b15321b74f539c5a0a89f70955459b7ec57e9e4b24e61bba27f1cbbc", size = 94573, upload-time = "2025-09-09T23:19:53.855Z" },
-]
-
-[[package]]
-name = "mistralai"
-version = "2.4.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "eval-type-backport" },
-    { name = "httpx" },
-    { name = "jsonpath-python" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "pydantic" },
-    { name = "python-dateutil" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/f0/80dfabf224be4419c6c112f3950676f5af3dcde582d225c03ca0196a4b32/mistralai-2.4.4.tar.gz", hash = "sha256:cd8a27a230e5458b62237a6c4f7b52f5be86909fbc18694360ceb21dac932eda", size = 420936, upload-time = "2026-04-30T12:26:38.775Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/74/0f6188190e79eef4363754c71414c1a791537b1e506cbee615bb581cb05f/mistralai-2.4.4-py3-none-any.whl", hash = "sha256:43dd3b1f0f4f960a723359165c4da0d035590b27c050028322934fe4f189f14e", size = 990545, upload-time = "2026-04-30T12:26:40.702Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The `mistralai` package was quarantined on PyPI on 2026-05-12 and is no longer installable. This PR removes the dependency and replaces it with the `openai` SDK, leveraging Mistral's OpenAI-compatible chat endpoint.

## Changes

- **`pyproject.toml`**: 
  - Removed `mistralai>=2.0.0` from the `mistral` extra
  - Added `openai>=2.36.0` to the `mistral` extra
  - Documented the `langgraph 1.2.0` hold (blocked by `langchain==1.2.18` upper bound)
  - Bumped `anthropic` floor from `>=0.100.0` to `>=0.101.0`

- **`agent_gantry/adapters/llm_client.py`**:
  - Removed `_mistral_api_key` instance variable and per-call async context manager pattern
  - Updated `_initialize_client()` to instantiate `AsyncOpenAI(base_url="https://api.mistral.ai/v1")` for Mistral provider
  - Updated `classify_intent()` to use `self._client.chat.completions.create()` instead of the `mistralai` SDK's `chat.complete_async()`

- **`examples/llm_integration/mistral_demo.py`**:
  - Rewrote to use `AsyncOpenAI` with Mistral's base URL
  - Preserved all tool registration, retrieval, and execution flows
  - Updated client initialization and API call patterns

- **`docs/reference/llm_sdk_compatibility.md`**:
  - Updated compatibility table to show Mistral uses `openai` SDK with OpenAI-compatible endpoint
  - Rewrote Mistral section with quarantine notice and OpenAI SDK examples
  - Removed mistralai-specific methods (FIM, Agents API) — only chat completions documented

- **`README.md`**:
  - Updated Mistral code snippet to use `AsyncOpenAI` with Mistral base URL

- **`CHANGELOG.md`**:
  - Documented the mistralai removal and OpenAI SDK replacement
  - Noted anthropic floor bump and langgraph hold

## Implementation Details

- **Backward compatibility**: `LLMConfig(provider="mistral")` continues to work transparently — the migration is internal to `llm_client.py`
- **Schema compatibility**: `MistralAdapter` (which inherits from `OpenAIAdapter`) requires no changes; Mistral's endpoint accepts OpenAI-compatible function schemas
- **Risk level**: Safe with shim — public Mistral integration behavior is preserved; API surface unchanged
- **Transitive cleanup**: Orphan packages `eval-type-backport` and `jsonpath-python` (formerly mistralai dependencies) removed from lock file

## Testing

Existing Mistral tests using `pytest.importorskip("mistralai")` will auto-skip gracefully. New unit tests should verify `AsyncOpenAI` initialization with Mistral base URL using mocks to avoid network calls.

https://claude.ai/code/session_01K5CNE9wdTY1JYa83oR3DrE