### PR TITLE
🎨 Palette: Add responsive accessible wrappers to markdown tables

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -53,3 +53,7 @@
 ## 2026-05-12 - [Keyboard Accessibility for Scrollable Code Blocks]
 **Learning:** Code blocks (`<pre>`) often have `overflow-x: auto` applied via CSS to handle long lines of code without breaking the page layout. However, if these `<pre>` elements are not focusable, keyboard-only users cannot scroll them horizontally to read the truncated content.
 **Action:** When styling elements with `overflow: auto` or `overflow: scroll` (especially code blocks or tables), always ensure they are keyboard-focusable by adding `tabindex="0"`. Additionally, provide a `role="region"` and an `aria-label` (e.g., "Code snippet") so screen readers announce the scrollable container properly.
+
+## 2026-05-13 - [Keyboard Accessibility for Markdown Tables]
+**Learning:** Markdown generators (like Kramdown) output raw `<table>` elements without wrapping them in containers. Consequently, adding `overflow-x: auto` directly to the `<table>` element often fails to contain horizontal overflow consistently or securely across different browsers, and without a wrapper, keyboard users cannot scroll wide tables horizontally.
+**Action:** Always use a client-side JavaScript initialization script to locate raw `<table>` elements and wrap them in a `<div class="table-wrapper">` with `tabindex="0"`, `role="region"`, and a descriptive `aria-label` (e.g., "Data table"), while applying `overflow-x: auto` to the wrapper.

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -24,7 +24,8 @@
   --border-color: #e2e8f0;
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
 
   /* Code block colors (dark theme) */
   --code-bg: #1e293b;
@@ -36,8 +37,12 @@
   --code-number: #fbbf24;
 
   /* Typography */
-  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-  --font-mono: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', 'Fira Mono', 'Roboto Mono', 'Courier New', monospace;
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  --font-mono:
+    "SF Mono", "Monaco", "Inconsolata", "Fira Code", "Fira Mono", "Roboto Mono",
+    "Courier New", monospace;
 
   /* Spacing */
   --spacing-xs: 0.25rem;
@@ -46,7 +51,7 @@
   --spacing-lg: 1.5rem;
   --spacing-xl: 2rem;
   --spacing-2xl: 3rem;
-  
+
   /* Callout Backgrounds (Light Mode) */
   --bg-callout-note: #dbeafe;
   --bg-callout-warning: #fef3c7;
@@ -105,7 +110,12 @@ body {
 }
 
 /* ==================== Typography ==================== */
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-weight: 700;
   line-height: 1.3;
   margin-top: var(--spacing-xl);
@@ -157,12 +167,14 @@ a:hover {
   text-decoration: underline;
 }
 
-strong, b {
+strong,
+b {
   font-weight: 600;
   color: var(--text-primary);
 }
 
-em, i {
+em,
+i {
   font-style: italic;
 }
 
@@ -231,7 +243,9 @@ em, i {
   border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 0.875rem;
-  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 
 .search-input:focus {
@@ -446,10 +460,16 @@ pre code {
 }
 
 /* Tables */
+.table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  margin: var(--spacing-lg) 0;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
-  margin: var(--spacing-lg) 0;
+  margin: 0;
   font-size: 0.9rem;
 }
 
@@ -474,7 +494,8 @@ tr:hover {
 }
 
 /* Lists */
-ul, ol {
+ul,
+ol {
   margin: var(--spacing-md) 0;
   padding-left: var(--spacing-xl);
 }

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -421,6 +421,32 @@
     });
   }
 
+  // ==================== Responsive Tables ====================
+
+  function initResponsiveTables() {
+    const tables = document.querySelectorAll("table");
+
+    tables.forEach((table) => {
+      // Check if it's already wrapped
+      if (table.parentElement.classList.contains("table-wrapper")) {
+        return;
+      }
+
+      // Create wrapper
+      const wrapper = document.createElement("div");
+      wrapper.className = "table-wrapper";
+
+      // Add accessibility attributes for horizontal scrolling
+      wrapper.setAttribute("tabindex", "0");
+      wrapper.setAttribute("role", "region");
+      wrapper.setAttribute("aria-label", "Data table");
+
+      // Wrap the table
+      table.parentNode.insertBefore(wrapper, table);
+      wrapper.appendChild(table);
+    });
+  }
+
   // ==================== Initialize All Features ====================
 
   function init() {
@@ -440,6 +466,7 @@
     markExternalLinks();
     initCollapsibleSections();
     addHeadingAnchors();
+    initResponsiveTables();
 
     console.log("Agent-Gantry Documentation - Navigation initialized");
   }


### PR DESCRIPTION
💡 What: Added a JavaScript initialization script to wrap raw markdown tables in a dynamically created `<div class="table-wrapper">`.
🎯 Why: Without a wrapper container, tables on narrow screens either break layout or, if `overflow-x: auto` is placed directly on the `table` itself, fail to contain horizontal overflow consistently. Additionally, unwrapped overflowing tables are inaccessible to keyboard-only users who cannot "scroll" horizontally.
♿ Accessibility: 
- Added `tabindex="0"` to the `.table-wrapper` making it keyboard focusable.
- Added `role="region"` and `aria-label="Data table"` so screen readers properly announce the scrollable container's purpose to users.

---
*PR created automatically by Jules for task [7905744567713224688](https://jules.google.com/task/7905744567713224688) started by @CodeHalwell*