### PR TITLE
Add end-to-end Agent tests for bridge.build_agent and bridge.as_agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-13
+
 ### Added
 
+- **End-to-end orchestration test coverage for `bridge.build_agent` and
+  `bridge.as_agent`.** The bridge previously had construction-shape tests
+  but no end-to-end `agent.run()` coverage with multi-arg Gantry tools.
+  New tests in `tests/test_agent_framework_orchestration.py` drive a
+  `ScriptedChatClient` through the full
+  function_call → Gantry-execute → function_result → final-text loop and
+  assert the resulting `function_result` content carries the expected
+  `call_id` and payload. Includes `extra_tools=` mixing static AF
+  FunctionTools with Gantry-selected tools in one Agent.
+- **Tool-surface reduction proof-of-routing test.** Registers 12 tools
+  across mixed domains, builds an Agent for a weather query with
+  `limit=3`, and asserts (a) the Agent's bound tool set is exactly 3,
+  (b) the chat client saw 3 tools (not 12) on the first turn, and
+  (c) `get_weather` is present while most unrelated tools are filtered.
+  This is the regression guard for Gantry's headline value-prop
+  (75% reduction in this scenario).
+- **Per-user-turn and per-chat-round re-routing tests.** Drives a real
+  multi-turn `agent.run` session over a topic-shifting conversation and
+  asserts the chat client's per-turn `seen_tools` differs across user
+  turns — Gantry re-queries on every `agent.run()` in `per_run` mode.
+  Adds a per-call refresher unit test that walks the
+  `_refresh_tools_on_chat_context` code path directly with two synthetic
+  chat contexts (round 1 weather, round 2 billing) and asserts the
+  surface flips between rounds.
+- **Real end-to-end `per_call` middleware test.**
+  `test_context_provider_per_call_end_to_end` drives a real `agent.run`
+  with `query_strategy="per_call"` + `as_chat_middleware()` through two
+  LLM rounds (function_call → result → final text) and asserts the
+  function executed via the `function_result` content. This is the
+  regression guard for the in-place mutation invariant.
+- **Per-round routing adaptation end-to-end test.**
+  `test_context_provider_per_call_surface_adapts_to_tool_result` uses a
+  deterministic keyword-overlap embedder (no model downloads) to prove
+  the per-round tool surface actually shifts as the message stream
+  shifts: round 1 = weather tools, round 2 = refund/billing tools after
+  the tool result mentions invoice content. Asserts the refund tool was
+  findable by AF's function executor (no `"not found"` in
+  `fr.exception`).
+- **`SkillsProvider` co-existence test.**
+  `test_context_provider_preserves_skill_tools_across_refresh` pre-seeds
+  options with a foreign `load_skill` tool, runs two refresh rounds
+  with a topic shift, and asserts the skill tool survives both
+  refreshes and the options dict reference is never replaced. Locks in
+  the contract that Gantry's refresh only strips tools whose names are
+  in the Gantry registry.
+- **Non-dict (Pydantic-ish) options coverage.**
+  `test_context_provider_refresh_mutates_non_dict_options_in_place`
+  exercises the non-dict options refresh branch with a stand-in
+  Pydantic-style object. Asserts (a) same reference mutated in-place,
+  (b) peer-provider tools preserved, (c) Gantry's dynamic top-k added.
+- **Unit tests for the `_msg_text` fix.**
+  `test_msg_text_walks_dict_contents_for_function_result` and
+  `test_msg_text_function_result_fallback_is_per_content` in
+  `tests/test_query_strategies.py` lock the dict-`contents` walker
+  and the per-content fallback gating. AF-Message coverage of the
+  same path lives in
+  `test_last_tool_result_extracts_text_from_af_function_result_message`
+  in the orchestration file (kept out of the query-strategies file
+  so it stays AF-free per its module docstring).
 - **`agent_gantry/adapters/tool_spec/providers.py`** — `AnthropicAdapter.to_provider_schema()` now accepts `strict=False` (default, backwards-compatible) or `strict=True`. When `True`, the output schema includes `"strict": true` at the tool-definition top level, enabling Anthropic's grammar-constrained sampling so Claude's tool `input` always matches `input_schema` exactly.
   *Risk: safe internal — purely additive; default preserves all existing behaviour.*  
   Source: https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use
@@ -125,6 +186,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`GantryContextProvider` per-call refresh now mutates `options` in
+  place instead of replacing the reference.** AF's
+  `FunctionInvocationLayer` keeps a reference to the same options dict
+  across its inner function-invocation loop and uses it both as the
+  chat-call payload *and* as the tool-lookup table when executing
+  function calls. The previous code did
+  `context.options = new_options`, which updated the chat client's
+  view but left the function executor reading a stale tool list — so
+  the model emitted a function call, AF couldn't find the tool in
+  `mutable_options['tools']`, and the inner loop terminated after one
+  round with an unexecuted `function_call` in the message stream.
+  Now mutates `options["tools"] = combined` in place. Symptom in the
+  wild: `agent.run` returning a function_call with no result.
+  *Risk: corrects a silent inner-loop termination; behaviour-fix only.*
+- **`GantryContextProvider` non-dict options branch now preserves
+  peer-provider tools and mutates in place.** Two regressions in the
+  Pydantic ChatOptions path: (a) existing tools were only read from
+  dict options, so peer-provider tools (skills, static tools, tools
+  from other ContextProviders) on a Pydantic model were dropped on
+  every per-call refresh; (b) the fallback path reassigned the same
+  reference (no-op) and wrapped the surrounding
+  `context.options = new_options` in `try/except AttributeError: pass`,
+  silently dropping tool updates on read-only attributes. Now reads
+  existing tools from `getattr(options, "tools", None)` for non-dict
+  inputs, uses `setattr(options, "tools", combined)` to preserve the
+  FunctionInvocationLayer reference invariant, and only falls back to
+  `model_copy` + reassign for genuinely frozen Pydantic models —
+  warning if even that fails. *Risk: corrects silent data loss for
+  non-dict options.*
+- **`agent_gantry.query._msg_text` now walks structured `contents`
+  for AF tool-role messages.** AF wraps tool output as a
+  `function_result` Content nested inside `Message.contents`;
+  `Message.text` is empty in that case and the actual text lives in
+  `Content.items[].text` (or `Content.result` for primitives).
+  `_msg_text` previously only inspected `Message.text` /
+  `Message.content`, so `last_tool_result` returned `""` for AF tool
+  messages and the query generator's `fallback_chain` collapsed to
+  `last_user_text` — which never changes within a single `agent.run`,
+  defeating per-round adaptation. Now walks `contents` (and
+  `msg["contents"]` for dict-shaped messages), pulling text from
+  `text` and `function_result` Content variants. *Risk: corrects
+  per-round routing adaptation; previously broken silently.*
+- **`agent_gantry.query._msg_text` per-content `function_result`
+  fallback now tracks contribution per-content.** The `.result`
+  fallback was gated by a global `if not parts:` check across the
+  whole message. When an earlier text content already populated
+  `parts`, a later `function_result` with empty `items[]` would
+  silently drop its primitive `.result`. Tracks `contributed` per
+  function_result so earlier text stays AND each function_result
+  still falls back to its own `.result`. *Risk: corrects silent
+  drop of tool output in mixed-content tool-role messages.*
 - **`README.md`**: Updated deprecated model identifiers in quick-start examples:
   `claude-sonnet-4-20250514` → `claude-sonnet-4-6` (retiring 15 June 2026);
   `gemini-2.0-flash` → `gemini-2.5-flash` (deprecated; service shutdown imminent).

--- a/agent_gantry/__init__.py
+++ b/agent_gantry/__init__.py
@@ -25,7 +25,7 @@ from agent_gantry.schema.tool import (
     ToolSource,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __all__ = [
     "AgentGantry",
     "GantryContextProvider",

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -390,6 +390,16 @@ class GantryContextProvider:
                 always_include / skill pins. This guarantees the per-round
                 top-k stays bounded and stale dynamic selections from
                 earlier rounds do not accumulate.
+
+                Mutates the existing options dict **in place** rather than
+                replacing the reference. ``FunctionInvocationLayer`` in
+                agent-framework keeps the same options dict across its
+                inner loop and uses it both as the chat-call payload *and*
+                as the tool-lookup table when executing function calls.
+                Reassigning ``context.options = new_options`` would only
+                update the chat-call payload — the function executor would
+                still see the original (stale) tool list and fail to find
+                the tools we just injected.
                 """
                 options = getattr(context, "options", None)
                 existing = []
@@ -426,15 +436,19 @@ class GantryContextProvider:
                     combined.append(t)
 
                 if isinstance(options, dict):
-                    new_options = dict(options)
-                    new_options["tools"] = combined
+                    # Mutate in place — see docstring above.
+                    options["tools"] = combined
+                elif options is not None:
+                    # Non-dict options (e.g. a Pydantic ChatOptions model):
+                    # fall back to attribute assignment with a rebuilt copy.
+                    if hasattr(options, "model_copy"):
+                        new_options = options.model_copy(update={"tools": combined})
+                    else:
+                        new_options = options
                     try:
                         context.options = new_options
                     except AttributeError:
-                        # Some AF versions expose options as a read-only attr;
-                        # mutate in place as a fallback.
-                        options.clear()
-                        options.update(new_options)
+                        pass
 
                 logger.debug(
                     "GantryContextProvider: refreshed tools per-call "

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -402,9 +402,18 @@ class GantryContextProvider:
                 the tools we just injected.
                 """
                 options = getattr(context, "options", None)
-                existing = []
+                existing: list[Any] = []
                 if isinstance(options, dict):
                     existing = list(options.get("tools") or [])
+                elif options is not None:
+                    # Pydantic ChatOptions / plain objects: peer-provider
+                    # tools live on the `tools` attribute. Read them too,
+                    # otherwise the combined list would drop everything
+                    # the model already carried (skills, static tools,
+                    # tools from another ContextProvider).
+                    attr_tools = getattr(options, "tools", None)
+                    if attr_tools:
+                        existing = list(attr_tools)
 
                 messages = (
                     getattr(context, "messages", None)
@@ -439,16 +448,44 @@ class GantryContextProvider:
                     # Mutate in place — see docstring above.
                     options["tools"] = combined
                 elif options is not None:
-                    # Non-dict options (e.g. a Pydantic ChatOptions model):
-                    # fall back to attribute assignment with a rebuilt copy.
-                    if hasattr(options, "model_copy"):
-                        new_options = options.model_copy(update={"tools": combined})
-                    else:
-                        new_options = options
+                    # Non-dict options (e.g. a Pydantic ChatOptions model).
+                    # The in-place invariant from the docstring applies here
+                    # too — AF's FunctionInvocationLayer keeps the same
+                    # options reference across the inner loop, so we must
+                    # mutate the existing object rather than reassign
+                    # context.options. Try setattr first (works for plain
+                    # objects and mutable Pydantic models); only fall back
+                    # to a rebuilt-copy + reassignment if the attribute is
+                    # genuinely immutable (frozen model).
+                    mutated_in_place = False
                     try:
-                        context.options = new_options
-                    except AttributeError:
+                        setattr(options, "tools", combined)
+                        mutated_in_place = True
+                    except (AttributeError, TypeError, ValueError):
                         pass
+                    if not mutated_in_place:
+                        if hasattr(options, "model_copy"):
+                            new_options = options.model_copy(update={"tools": combined})
+                            try:
+                                context.options = new_options
+                            except AttributeError:
+                                logger.warning(
+                                    "GantryContextProvider: cannot update tools on "
+                                    "immutable options object %r (no in-place setattr, "
+                                    "no settable context.options). %d Gantry tools were "
+                                    "selected but will NOT be visible to AF.",
+                                    type(options).__name__,
+                                    len(combined),
+                                )
+                        else:
+                            logger.warning(
+                                "GantryContextProvider: options object %r is neither "
+                                "dict-like nor a Pydantic model and rejected attribute "
+                                "assignment. %d Gantry tools were selected but will "
+                                "NOT be visible to AF.",
+                                type(options).__name__,
+                                len(combined),
+                            )
 
                 logger.debug(
                     "GantryContextProvider: refreshed tools per-call "

--- a/agent_gantry/query/strategies.py
+++ b/agent_gantry/query/strategies.py
@@ -19,6 +19,18 @@ def _msg_text(msg: Any) -> str:
 
     Tries ``.text`` first (AF native), then ``.content`` (OpenAI dialect),
     and for dict-shaped messages checks ``"text"`` and ``"content"``.
+
+    If none of those surface text, walks the structured ``contents`` list
+    (AF native) looking for text-bearing Content variants:
+
+    - ``type="text"``: use ``.text``
+    - ``type="function_result"``: prefer joined ``items[].text``; fall
+      back to ``str(.result)`` when the result is a primitive.
+
+    This is important for tool-role messages whose result text is nested
+    inside a ``function_result`` Content rather than exposed at the
+    Message level — without it, ``last_tool_result`` would always miss.
+
     Returns the empty string if no non-empty string content is found.
     """
     text = getattr(msg, "text", None)
@@ -32,6 +44,32 @@ def _msg_text(msg: Any) -> str:
             value = msg.get(key)
             if isinstance(value, str) and value.strip():
                 return value
+
+    contents = getattr(msg, "contents", None)
+    if contents:
+        parts: list[str] = []
+        for c in contents:
+            ctype = getattr(c, "type", None)
+            if ctype == "text":
+                t = getattr(c, "text", None)
+                if isinstance(t, str) and t.strip():
+                    parts.append(t.strip())
+            elif ctype == "function_result":
+                items = getattr(c, "items", None) or []
+                for item in items:
+                    if getattr(item, "type", None) == "text":
+                        t = getattr(item, "text", None)
+                        if isinstance(t, str) and t.strip():
+                            parts.append(t.strip())
+                if not parts:
+                    result = getattr(c, "result", None)
+                    if isinstance(result, (str, int, float, bool)):
+                        s = str(result).strip()
+                        if s:
+                            parts.append(s)
+        if parts:
+            return " ".join(parts)
+
     return ""
 
 

--- a/agent_gantry/query/strategies.py
+++ b/agent_gantry/query/strategies.py
@@ -46,6 +46,8 @@ def _msg_text(msg: Any) -> str:
                 return value
 
     contents = getattr(msg, "contents", None)
+    if contents is None and isinstance(msg, dict):
+        contents = msg.get("contents")
     if contents:
         parts: list[str] = []
         for c in contents:
@@ -55,13 +57,19 @@ def _msg_text(msg: Any) -> str:
                 if isinstance(t, str) and t.strip():
                     parts.append(t.strip())
             elif ctype == "function_result":
+                # Track per-content contribution: the `.result` fallback
+                # must fire when *this* function_result had no item text,
+                # independently of whether earlier contents in the same
+                # message produced any text.
+                contributed = False
                 items = getattr(c, "items", None) or []
                 for item in items:
                     if getattr(item, "type", None) == "text":
                         t = getattr(item, "text", None)
                         if isinstance(t, str) and t.strip():
                             parts.append(t.strip())
-                if not parts:
+                            contributed = True
+                if not contributed:
                     result = getattr(c, "result", None)
                     if isinstance(result, (str, int, float, bool)):
                         s = str(result).strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-gantry"
-version = "0.2.0"
+version = "0.3.0"
 description = "Universal Tool Orchestration Platform - Intelligent, secure tool orchestration for LLM-based agent systems"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_agent_framework_orchestration.py
+++ b/tests/test_agent_framework_orchestration.py
@@ -1081,3 +1081,232 @@ async def test_bridge_filters_tool_surface_for_agent() -> None:
     assert len(leaked) <= 2, (
         f"Too many unrelated tools leaked through semantic routing: {leaked}"
     )
+
+
+# ---------------------------------------------------------------------------
+# 19. Tool surface updates *between* loop iterations (per-run re-routing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_provider_reroutes_per_user_turn() -> None:
+    """As the agent loops over user turns, the GantryContextProvider must
+    re-query the router on every ``agent.run`` invocation so the LLM only
+    sees tools relevant to the *current* turn — not a static set frozen at
+    agent construction.
+
+    This is the answer to "the agent is running in a loop, how does the
+    tool selection update?": ``query_strategy='per_run'`` (default) fires
+    ``before_run`` at the start of each ``agent.run`` call, derives a fresh
+    query from the latest user message, and rewrites the injected tool set.
+    """
+    from agent_gantry import GantryContextProvider
+
+    gantry = AgentGantry()
+
+    @gantry.register
+    def get_weather(city: str) -> str:
+        """Get current weather for a city."""
+        return f"{city}: sunny"
+
+    @gantry.register
+    def get_forecast(city: str, days: int = 3) -> str:
+        """Multi-day weather forecast for a city."""
+        return f"{city}: sunny"
+
+    @gantry.register
+    def lookup_invoice(invoice_id: str) -> str:
+        """Look up a billing invoice."""
+        return f"invoice {invoice_id}: $42 due"
+
+    @gantry.register
+    def refund_invoice(invoice_id: str) -> str:
+        """Refund a billing invoice."""
+        return f"refunded {invoice_id}"
+
+    @gantry.register
+    def read_file(path: str) -> str:
+        """Read file contents from disk."""
+        return f"contents:{path}"
+
+    @gantry.register
+    def write_file(path: str, contents: str) -> str:
+        """Write file contents to disk."""
+        return f"wrote {path}"
+
+    await gantry.sync()
+    total_registered = len(gantry.export_tools())
+    assert total_registered == 6
+
+    # Per-run strategy: re-query before each agent.run call.
+    provider = GantryContextProvider(
+        gantry,
+        top_k=2,
+        score_threshold=0.0,
+        query_strategy="per_run",
+    )
+
+    # Three scripted turns, each on a different domain. Each turn is a single
+    # text response (no function_call) so the script consumes exactly one
+    # entry per agent.run call.
+    client = ScriptedChatClient(
+        script=[
+            [Content.from_text("Weather noted.")],
+            [Content.from_text("Invoice handled.")],
+            [Content.from_text("File saved.")],
+        ]
+    )
+    agent = Agent(
+        client,
+        instructions="",
+        name="MultiTurnAgent",
+        context_providers=[provider],
+    )
+
+    session = agent.create_session()
+    # Loop the agent over user turns spanning different domains.
+    await agent.run("What's the weather forecast for London?", session=session)
+    await agent.run("Look up invoice INV-9 please.", session=session)
+    await agent.run("Read the file at /tmp/notes.md.", session=session)
+
+    assert client.call_count == 3
+    assert len(client.seen_tools) == 3
+
+    turn_weather, turn_billing, turn_files = client.seen_tools
+
+    # Each turn must have surfaced <= top_k tools — the surface stayed bounded.
+    for turn_idx, names in enumerate(client.seen_tools):
+        assert len(names) <= 2, (
+            f"Turn {turn_idx} forwarded {len(names)} tools, expected <= top_k=2: {names}"
+        )
+        assert len(names) < total_registered
+
+    # The tool surface must actually *change* between turns — otherwise the
+    # provider is just locking in a static set, not re-routing.
+    assert turn_weather != turn_billing, (
+        f"Tool set did not refresh between turn 1 (weather) and turn 2 (billing): "
+        f"both saw {turn_weather}"
+    )
+    assert turn_billing != turn_files, (
+        f"Tool set did not refresh between turn 2 (billing) and turn 3 (files): "
+        f"both saw {turn_billing}"
+    )
+
+    # And the right tool for each domain must be present on the right turn.
+    assert any(n.startswith("get_") and "weather" in n or n == "get_forecast" for n in turn_weather), (
+        f"Weather turn missing weather tool: {turn_weather}"
+    )
+    assert any("invoice" in n for n in turn_billing), (
+        f"Billing turn missing invoice tool: {turn_billing}"
+    )
+    assert any("file" in n for n in turn_files), (
+        f"File turn missing file tool: {turn_files}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 20. Tool surface updates *within* a single agent.run (per-call re-routing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_provider_per_call_refresh_mechanism() -> None:
+    """Drive the per-call refresher directly with two synthetic chat contexts
+    to prove the routing-update *mechanism*: when the second round's message
+    stream shifts topic, the rewritten ``options['tools']`` reflects the new
+    query.
+
+    This is a unit-level proof of the same behaviour the ``per_call``
+    middleware delivers inside ``agent.run``. We invoke the refresher
+    directly because AF's middleware dispatcher is what the end-to-end form
+    depends on, and that dispatch is out of scope for this test — what we
+    care about is Gantry's contract: given a fresh message stream, produce
+    a fresh tool surface.
+    """
+    from agent_gantry import GantryContextProvider
+    from agent_gantry.query import concatenate_recent
+
+    gantry = AgentGantry()
+
+    @gantry.register
+    def get_weather(city: str) -> str:
+        """Get current weather for a city."""
+        return f"{city}: sunny"
+
+    @gantry.register
+    def get_forecast(city: str, days: int = 3) -> str:
+        """Multi-day weather forecast for a city."""
+        return f"{city}: sunny"
+
+    @gantry.register
+    def lookup_invoice(invoice_id: str) -> str:
+        """Look up a billing invoice."""
+        return f"invoice {invoice_id}"
+
+    @gantry.register
+    def refund_invoice(invoice_id: str) -> str:
+        """Refund a billing invoice."""
+        return f"refunded {invoice_id}"
+
+    await gantry.sync()
+
+    provider = GantryContextProvider(
+        gantry,
+        top_k=2,
+        score_threshold=0.0,
+        query_strategy="per_call",
+        query_generator=concatenate_recent,
+    )
+
+    # Simulate two successive chat rounds inside a single agent.run by
+    # feeding the refresher two synthetic context objects with shifting
+    # message streams.
+    class _FakeChatContext:
+        def __init__(self, messages: list[Message]) -> None:
+            self.messages = messages
+            self.options: dict[str, Any] = {"tools": []}
+
+    round1_ctx = _FakeChatContext(
+        messages=[Message(role="user", contents=[Content.from_text("Weather in Paris?")])]
+    )
+    await provider._refresh_tools_on_chat_context(round1_ctx)
+    round1_tools = [getattr(t, "name", None) for t in round1_ctx.options["tools"]]
+
+    # The model emitted a function_call to get_weather; the tool ran and now
+    # the conversation context for the second LLM round includes a tool
+    # result + a follow-up user request about a totally different domain.
+    round2_ctx = _FakeChatContext(
+        messages=[
+            Message(role="user", contents=[Content.from_text("Weather in Paris?")]),
+            Message(role="assistant", contents=[
+                Content.from_function_call(call_id="pc0", name="get_weather", arguments={"city": "Paris"})
+            ]),
+            Message(role="tool", contents=[
+                Content.from_function_result(call_id="pc0", result="Paris: sunny")
+            ]),
+            Message(role="user", contents=[Content.from_text("Now look up invoice INV-9 and refund it.")]),
+        ]
+    )
+    await provider._refresh_tools_on_chat_context(round2_ctx)
+    round2_tools = [getattr(t, "name", None) for t in round2_ctx.options["tools"]]
+
+    # Per-round bound on the surface.
+    assert len(round1_tools) <= 2, round1_tools
+    assert len(round2_tools) <= 2, round2_tools
+
+    # Round 1 (weather query) must surface weather tools.
+    assert any("weather" in n or "forecast" in n for n in round1_tools), round1_tools
+
+    # Round 2 (billing query) must surface invoice tools and must *drop*
+    # the stale weather tools from round 1.
+    assert any("invoice" in n for n in round2_tools), round2_tools
+    assert round1_tools != round2_tools, (
+        f"Round-2 tool surface did not refresh after topic shift: "
+        f"r1={round1_tools} r2={round2_tools}"
+    )
+
+    # And weather tools from r1 should not have leaked into r2's surface.
+    weather_in_r2 = [n for n in round2_tools if "weather" in n or "forecast" in n]
+    assert not weather_in_r2, (
+        f"Stale weather tools from round 1 leaked into round 2: {weather_in_r2}"
+    )

--- a/tests/test_agent_framework_orchestration.py
+++ b/tests/test_agent_framework_orchestration.py
@@ -1503,3 +1503,136 @@ async def test_context_provider_preserves_skill_tools_across_refresh() -> None:
         f"Skill tool stripped on second refresh: {tool_names_r2}"
     )
     assert ctx.options is options, "Options reference changed on second refresh."
+
+
+# ---------------------------------------------------------------------------
+# 23. Per-round routing actually adapts when the tool result shifts topic.
+#     Uses a real sentence-transformer embedder so semantic ranking is
+#     meaningful (SimpleEmbedder's hash-based scoring is too noisy to
+#     deterministically differentiate domains in a 5-tool registry).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_provider_per_call_surface_adapts_to_tool_result() -> None:
+    """End-to-end proof of per-round routing adaptation.
+
+    The user asks a weather question. Round 1's router (driven by the
+    user message) surfaces weather-flavoured tools. The model emits a
+    function_call; the Gantry tool runs and its result legitimately
+    introduces a *new* domain (billing/refund). On round 2 the query
+    generator (``last_tool_result``) picks up the tool's output, and the
+    router must re-rank — surfacing the refund tool that wasn't in the
+    round-1 set.
+
+    Skipped when ``sentence-transformers`` is not installed because
+    ``SimpleEmbedder``'s hash-based scoring is too noisy to differentiate
+    domains deterministically.
+    """
+    st = pytest.importorskip(
+        "sentence_transformers",
+        reason="real embedder required to deterministically demonstrate "
+               "per-round adaptation; install agent-gantry[nomic] or "
+               "sentence-transformers",
+    )
+    del st  # only used as import gate
+
+    from agent_gantry import GantryContextProvider
+    from agent_gantry.adapters.embedders.sentence_transformers import (
+        SentenceTransformersEmbedder,
+    )
+    from agent_gantry.query import last_tool_result, last_user_text
+
+    embedder = SentenceTransformersEmbedder(model="all-MiniLM-L6-v2")
+    gantry = AgentGantry(embedder=embedder)
+
+    @gantry.register
+    def get_weather(city: str) -> str:
+        """Get the current weather and temperature for a city."""
+        # Result legitimately introduces a NEW domain — billing.
+        return (
+            "Paris is sunny. Customer follow-up: invoice INV-9 payment refund "
+            "overdue billing."
+        )
+
+    @gantry.register
+    def refund_invoice(invoice_id: str) -> str:
+        """Issue a refund payment on a customer billing invoice."""
+        return f"refunded {invoice_id}"
+
+    @gantry.register
+    def read_file(path: str) -> str:
+        """Read file contents from the local filesystem disk."""
+        return ""
+
+    @gantry.register
+    def write_file(path: str, contents: str) -> str:
+        """Write content to a file on the local filesystem disk."""
+        return ""
+
+    await gantry.sync()
+
+    def query_gen(messages: Any) -> str:
+        return last_tool_result(messages) or last_user_text(messages)
+
+    provider = GantryContextProvider(
+        gantry,
+        top_k=2,
+        score_threshold=0.0,
+        query_strategy="per_call",
+        query_generator=query_gen,
+    )
+
+    client = ScriptedChatClient(
+        script=[
+            [_fc("get_weather", {"city": "Paris"}, "r0")],
+            [_fc("refund_invoice", {"invoice_id": "INV-9"}, "r1")],
+            [Content.from_text("All done.")],
+        ]
+    )
+    agent = Agent(
+        client,
+        instructions="",
+        name="AdaptiveAgent",
+        context_providers=[provider],
+        middleware=[provider.as_chat_middleware()],
+    )
+
+    resp = await agent.run("What's the weather in Paris?")
+
+    # 3 LLM rounds — both function calls executed (otherwise we'd see <3).
+    assert client.call_count == 3
+    assert len(client.seen_tools) == 3
+
+    round1, round2, _round3 = client.seen_tools
+
+    # Round 1: weather-flavoured query → weather tool present.
+    assert "get_weather" in round1, round1
+
+    # Round 2: query shifted to the tool result (mentions invoice/refund/billing).
+    # The refund tool must now be in the surfaced set, AND the surface must
+    # have actually *changed* — that's the headline adaptation guarantee.
+    assert "refund_invoice" in round2, (
+        f"Round-2 surface did not surface refund_invoice after the topic "
+        f"shifted in the tool result: {round2}"
+    )
+    assert round1 != round2, (
+        f"Tool surface did not change between round 1 and round 2 even "
+        f"though the query content shifted: r1={round1} r2={round2}"
+    )
+
+    # And the refund function call actually resolved (gating policy may
+    # require confirmation, but the function NAME must be found — that
+    # only happens when round-2 routing correctly surfaced it).
+    refund_results = [
+        c
+        for m in resp.messages
+        for c in (m.contents or [])
+        if getattr(c, "type", None) == "function_result" and c.call_id == "r1"
+    ]
+    assert refund_results, "refund_invoice function_result missing"
+    fr = refund_results[0]
+    assert "not found" not in (fr.exception or ""), (
+        f"refund_invoice was not surfaced on round 2 — executor reported "
+        f"missing tool: {fr.exception!r}"
+    )

--- a/tests/test_agent_framework_orchestration.py
+++ b/tests/test_agent_framework_orchestration.py
@@ -888,7 +888,7 @@ async def test_build_agent_extra_tools_and_multi_arg_roundtrip(
     assert function_results, "Agent must surface the Gantry tool result"
     fr = function_results[0]
     assert fr.call_id == "c0"
-    rendered = str(fr.result) + (str(getattr(fr, "items", "")) or "")
+    rendered = str(fr.result) + str(getattr(fr, "items", ""))
     assert "shipped" in rendered.lower()
     assert "ORD-77" in rendered
 
@@ -1193,7 +1193,10 @@ async def test_context_provider_reroutes_per_user_turn() -> None:
     )
 
     # And the right tool for each domain must be present on the right turn.
-    assert any(n.startswith("get_") and "weather" in n or n == "get_forecast" for n in turn_weather), (
+    assert any(
+        (n.startswith("get_") and "weather" in n) or n == "get_forecast"
+        for n in turn_weather
+    ), (
         f"Weather turn missing weather tool: {turn_weather}"
     )
     assert any("invoice" in n for n in turn_billing), (
@@ -1507,10 +1510,66 @@ async def test_context_provider_preserves_skill_tools_across_refresh() -> None:
 
 # ---------------------------------------------------------------------------
 # 23. Per-round routing actually adapts when the tool result shifts topic.
-#     Uses a real sentence-transformer embedder so semantic ranking is
-#     meaningful (SimpleEmbedder's hash-based scoring is too noisy to
-#     deterministically differentiate domains in a 5-tool registry).
+#     Uses a deterministic keyword-overlap embedder so the assertion runs
+#     in CI without downloading any model weights — what we're testing is
+#     the *plumbing* (does the router get re-queried with new content per
+#     round, do new tools get injected, are they findable by the function
+#     executor), not the quality of any specific embedder.
 # ---------------------------------------------------------------------------
+
+
+class _KeywordEmbedder:
+    """Deterministic, dependency-free embedder for tests.
+
+    Each text is embedded as a unit-norm vector over a fixed keyword
+    vocabulary. Two texts that share a domain keyword (e.g. "weather",
+    "invoice", "file") will have a high cosine similarity; texts in
+    disjoint domains will have near-zero similarity.
+
+    This is enough to deterministically demonstrate per-round routing
+    adaptation without depending on sentence-transformers, ONNX, or any
+    network-resident model.
+    """
+
+    _VOCAB: ClassVar[tuple[str, ...]] = (
+        "weather", "temperature", "forecast", "city",
+        "invoice", "refund", "billing", "payment",
+        "file", "filesystem", "disk", "path",
+        "email", "message",
+    )
+
+    @property
+    def dimension(self) -> int:
+        return len(self._VOCAB)
+
+    @property
+    def model_name(self) -> str:
+        return "keyword-overlap"
+
+    def get_embedder_id(self) -> str:
+        return f"{self.model_name}:{self.dimension}"
+
+    async def health_check(self) -> bool:
+        return True
+
+    def _vec(self, text: str) -> list[float]:
+        import math
+        lower = (text or "").lower()
+        counts = [float(lower.count(kw)) for kw in self._VOCAB]
+        norm = math.sqrt(sum(c * c for c in counts))
+        if norm == 0:
+            return [0.0] * len(self._VOCAB)
+        return [c / norm for c in counts]
+
+    async def embed_text(self, text: str) -> list[float]:
+        return self._vec(text)
+
+    async def embed_batch(
+        self,
+        texts: list[str],
+        batch_size: int | None = None,
+    ) -> list[list[float]]:
+        return [self._vec(t) for t in texts]
 
 
 @pytest.mark.asyncio
@@ -1525,30 +1584,17 @@ async def test_context_provider_per_call_surface_adapts_to_tool_result() -> None
     router must re-rank — surfacing the refund tool that wasn't in the
     round-1 set.
 
-    Skipped when ``sentence-transformers`` is not installed because
-    ``SimpleEmbedder``'s hash-based scoring is too noisy to differentiate
-    domains deterministically.
+    Uses a deterministic keyword-overlap embedder so the test runs in CI
+    without any model download or hash-based-embedder flake.
     """
-    st = pytest.importorskip(
-        "sentence_transformers",
-        reason="real embedder required to deterministically demonstrate "
-               "per-round adaptation; install agent-gantry[nomic] or "
-               "sentence-transformers",
-    )
-    del st  # only used as import gate
-
     from agent_gantry import GantryContextProvider
-    from agent_gantry.adapters.embedders.sentence_transformers import (
-        SentenceTransformersEmbedder,
-    )
     from agent_gantry.query import last_tool_result, last_user_text
 
-    embedder = SentenceTransformersEmbedder(model="all-MiniLM-L6-v2")
-    gantry = AgentGantry(embedder=embedder)
+    gantry = AgentGantry(embedder=_KeywordEmbedder())
 
     @gantry.register
     def get_weather(city: str) -> str:
-        """Get the current weather and temperature for a city."""
+        """Get the current weather forecast temperature for a city."""
         # Result legitimately introduces a NEW domain — billing.
         return (
             "Paris is sunny. Customer follow-up: invoice INV-9 payment refund "
@@ -1562,12 +1608,12 @@ async def test_context_provider_per_call_surface_adapts_to_tool_result() -> None
 
     @gantry.register
     def read_file(path: str) -> str:
-        """Read file contents from the local filesystem disk."""
+        """Read file contents from the local filesystem disk path."""
         return ""
 
     @gantry.register
     def write_file(path: str, contents: str) -> str:
-        """Write content to a file on the local filesystem disk."""
+        """Write content to a file on the local filesystem disk path."""
         return ""
 
     await gantry.sync()
@@ -1598,7 +1644,7 @@ async def test_context_provider_per_call_surface_adapts_to_tool_result() -> None
         middleware=[provider.as_chat_middleware()],
     )
 
-    resp = await agent.run("What's the weather in Paris?")
+    resp = await agent.run("What's the weather forecast temperature in Paris?")
 
     # 3 LLM rounds — both function calls executed (otherwise we'd see <3).
     assert client.call_count == 3
@@ -1636,3 +1682,120 @@ async def test_context_provider_per_call_surface_adapts_to_tool_result() -> None
         f"refund_invoice was not surfaced on round 2 — executor reported "
         f"missing tool: {fr.exception!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# 24. _msg_text on AF function_result Content. Relocated from
+#     test_query_strategies.py to keep that file AF-free as documented.
+# ---------------------------------------------------------------------------
+
+
+def test_last_tool_result_extracts_text_from_af_function_result_message() -> None:
+    """AF wraps tool output as a ``function_result`` Content inside a
+    tool-role Message — ``Message.text`` is empty in that case and the
+    payload lives in ``Content.items[].text``. ``_msg_text`` must walk
+    ``contents`` to surface it, otherwise ``last_tool_result`` returns
+    "" and the per-call refresh's query collapses back to the original
+    user prompt across the entire run.
+    """
+    from agent_gantry.query import last_tool_result
+
+    fr = Content.from_function_result(
+        call_id="r0",
+        result="Paris is sunny. Invoice INV-9 payment is overdue.",
+    )
+    msg = Message(role="tool", contents=[fr])
+
+    out = last_tool_result([msg])
+    assert "Paris is sunny" in out, out
+    assert "INV-9" in out, out
+    assert out.startswith("tool result:") or out.startswith("result of"), out
+
+
+# ---------------------------------------------------------------------------
+# 25. Per-content function_result fallback: when an earlier text content
+#     populated `parts`, a later function_result with empty items[] must
+#     still surface its `.result` via the per-content fallback.
+# ---------------------------------------------------------------------------
+
+
+def test_msg_text_function_result_fallback_is_per_content() -> None:
+    from agent_gantry.query.strategies import _msg_text
+
+    # function_result Content with empty items and a primitive .result.
+    fr = Content.from_function_result(call_id="r0", result="")
+    fr.items = []  # explicit empty
+    fr.result = "actual tool output payload"
+
+    class _Msg:
+        role = "tool"
+        text = ""
+        content = None
+        contents = [
+            Content.from_text(text="hi"),
+            fr,
+        ]
+
+    out = _msg_text(_Msg())
+    # The earlier "hi" text must not gate the function_result fallback.
+    assert "hi" in out
+    assert "actual tool output payload" in out
+
+
+# ---------------------------------------------------------------------------
+# 26. Non-dict (Pydantic-ish) options refresh: peer-provider tools must
+#     be preserved and the existing options reference must be mutated in
+#     place rather than replaced, mirroring the dict-options invariant
+#     that FunctionInvocationLayer depends on.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_provider_refresh_mutates_non_dict_options_in_place() -> None:
+    from agent_framework import tool
+
+    from agent_gantry import GantryContextProvider
+
+    gantry = AgentGantry()
+
+    @gantry.register
+    def get_weather(city: str) -> str:
+        """Get current weather for a city."""
+        return f"{city}: sunny"
+
+    await gantry.sync()
+
+    @tool(name="load_skill", description="Foreign peer-provider tool.")
+    def load_skill(name: str) -> str:
+        return f"loaded {name}"
+
+    class _OptionsModel:
+        """Minimal stand-in for a Pydantic ChatOptions object: not a dict,
+        no model_copy, settable `tools` attribute."""
+
+        def __init__(self, tools: list[Any]) -> None:
+            self.tools = list(tools)
+
+    class _Ctx:
+        def __init__(self, messages: list[Message], options: _OptionsModel) -> None:
+            self.messages = messages
+            self.options = options
+
+    options = _OptionsModel(tools=[load_skill])
+    ctx = _Ctx(
+        messages=[Message(role="user", contents=[Content.from_text("Weather in Paris?")])],
+        options=options,
+    )
+
+    provider = GantryContextProvider(
+        gantry, top_k=2, score_threshold=0.0, query_strategy="per_call",
+    )
+    await provider._refresh_tools_on_chat_context(ctx)
+
+    # In-place mutation: same options reference, tools updated.
+    assert ctx.options is options
+    tool_names = [getattr(t, "name", None) for t in options.tools]
+    # Peer-provider tool preserved.
+    assert "load_skill" in tool_names, tool_names
+    # Gantry's dynamic selection added.
+    assert "get_weather" in tool_names, tool_names

--- a/tests/test_agent_framework_orchestration.py
+++ b/tests/test_agent_framework_orchestration.py
@@ -1214,14 +1214,8 @@ async def test_context_provider_per_call_refresh_mechanism() -> None:
     """Drive the per-call refresher directly with two synthetic chat contexts
     to prove the routing-update *mechanism*: when the second round's message
     stream shifts topic, the rewritten ``options['tools']`` reflects the new
-    query.
-
-    This is a unit-level proof of the same behaviour the ``per_call``
-    middleware delivers inside ``agent.run``. We invoke the refresher
-    directly because AF's middleware dispatcher is what the end-to-end form
-    depends on, and that dispatch is out of scope for this test — what we
-    care about is Gantry's contract: given a fresh message stream, produce
-    a fresh tool surface.
+    query. Complementary to ``test_context_provider_per_call_end_to_end``,
+    which exercises the same code path through ``agent.run``.
     """
     from agent_gantry import GantryContextProvider
     from agent_gantry.query import concatenate_recent
@@ -1310,3 +1304,202 @@ async def test_context_provider_per_call_refresh_mechanism() -> None:
     assert not weather_in_r2, (
         f"Stale weather tools from round 1 leaked into round 2: {weather_in_r2}"
     )
+
+
+# ---------------------------------------------------------------------------
+# 21. End-to-end per-call refresh through agent.run (the function-invocation
+#     inner loop). This is the real proof that chat_middleware fires on
+#     every round inside one agent.run AND that the freshly-injected tools
+#     are actually executable by AF's function-invocation layer.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_provider_per_call_end_to_end() -> None:
+    """A single ``agent.run`` makes 2 LLM rounds (function_call → result →
+    final text). With ``query_strategy='per_call'`` + ``as_chat_middleware``
+    the provider must run *between* the rounds and the tools it injects
+    must be visible to AF's function executor on round 1.
+
+    This guards against the regression where the refresher reassigned
+    ``context.options = new_options`` — the chat client saw the new tools
+    but ``FunctionInvocationLayer.mutable_options`` kept its original
+    reference and failed to locate the tool to execute.
+    """
+    from agent_gantry import GantryContextProvider
+    from agent_gantry.query import concatenate_recent
+
+    gantry = AgentGantry()
+
+    @gantry.register
+    def get_weather(city: str) -> str:
+        """Get current weather for a city."""
+        return f"Weather in {city}: 22C sunny"
+
+    @gantry.register
+    def lookup_invoice(invoice_id: str) -> str:
+        """Look up a billing invoice."""
+        return f"invoice {invoice_id}"
+
+    await gantry.sync()
+
+    provider = GantryContextProvider(
+        gantry,
+        top_k=2,
+        score_threshold=0.0,
+        query_strategy="per_call",
+        query_generator=concatenate_recent,
+    )
+
+    client = ScriptedChatClient(
+        script=[
+            # Round 1: model emits a function_call for the Gantry tool.
+            [_fc("get_weather", {"city": "Paris"}, "e2e0")],
+            # Round 2: model produces the final text answer using the result.
+            [Content.from_text("Paris weather: 22C sunny.")],
+        ]
+    )
+
+    agent = Agent(
+        client,
+        instructions="",
+        name="PerCallE2E",
+        context_providers=[provider],
+        middleware=[provider.as_chat_middleware()],
+    )
+
+    resp = await agent.run("Weather in Paris?")
+
+    # The model made 2 chat-completion rounds — meaning the function call
+    # was executed (otherwise AF would have stopped after round 1).
+    assert client.call_count == 2, (
+        f"Expected 2 inner rounds, got {client.call_count}. "
+        f"If only 1 ran, the function_call was not executed — the freshly "
+        f"injected tools were not visible to AF's function executor."
+    )
+
+    # Final text comes from round 2.
+    assert "22c" in resp.text.lower() or "sunny" in resp.text.lower(), resp.text
+
+    # The middleware refreshed tools on each of the two rounds.
+    assert len(client.seen_tools) == 2
+    for r_idx, names in enumerate(client.seen_tools):
+        assert names, f"Round {r_idx} forwarded no tools to the LLM"
+        assert "get_weather" in names, (
+            f"Round {r_idx} missing get_weather — refresh didn't propagate: {names}"
+        )
+        assert len(names) <= 2, (
+            f"Round {r_idx} exceeded top_k=2: {names}"
+        )
+
+    # The function_result message is present in the response — proof the
+    # tool actually executed end-to-end through the Gantry-wrapped path.
+    function_results = [
+        c
+        for m in resp.messages
+        for c in (m.contents or [])
+        if getattr(c, "type", None) == "function_result"
+    ]
+    assert function_results, (
+        "No function_result in the response — the tool was not executed."
+    )
+    fr = function_results[0]
+    assert fr.call_id == "e2e0"
+    rendered = str(fr.result) + str(getattr(fr, "items", ""))
+    assert "paris" in rendered.lower()
+
+
+# ---------------------------------------------------------------------------
+# 22. SkillsProvider co-existence: Gantry's per-call refresh must not strip
+#     skill tools (load_skill, read_skill_resource, run_skill_script) that
+#     another provider injected.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_provider_preserves_skill_tools_across_refresh() -> None:
+    """``SkillsProvider`` injects its own tools (``load_skill`` et al.) via
+    ``context.extend_tools(self.source_id, tools)`` in ``before_run``. The
+    Gantry per-call refresh must preserve those tools — only Gantry-owned
+    tools should be dropped & re-injected.
+
+    Rather than spin up a real SkillsProvider (which needs a skills source
+    on disk), we simulate its effect: pre-seed the chat context with a
+    foreign tool whose name is *not* in the Gantry registry, then run the
+    refresh and assert the foreign tool survives.
+    """
+    from agent_framework import tool
+
+    from agent_gantry import GantryContextProvider
+    from agent_gantry.query import concatenate_recent
+
+    gantry = AgentGantry()
+
+    @gantry.register
+    def get_weather(city: str) -> str:
+        """Get current weather for a city."""
+        return f"{city}: sunny"
+
+    await gantry.sync()
+
+    # Foreign tool not in the Gantry registry — represents what a peer
+    # provider (e.g. SkillsProvider) would have injected via extend_tools.
+    @tool(name="load_skill", description="Load a skill bundle by name (foreign).")
+    def load_skill(name: str) -> str:
+        return f"loaded {name}"
+
+    provider = GantryContextProvider(
+        gantry,
+        top_k=2,
+        score_threshold=0.0,
+        query_strategy="per_call",
+        query_generator=concatenate_recent,
+    )
+
+    class _FakeChatContext:
+        def __init__(self, messages: list[Message], options: dict[str, Any]) -> None:
+            self.messages = messages
+            self.options = options
+
+    # Round 1: only the foreign skill tool is in options (as if SkillsProvider
+    # had just injected it in before_run and no Gantry refresh has run yet).
+    options: dict[str, Any] = {"tools": [load_skill]}
+    ctx = _FakeChatContext(
+        messages=[Message(role="user", contents=[Content.from_text("Weather in Paris?")])],
+        options=options,
+    )
+
+    await provider._refresh_tools_on_chat_context(ctx)
+
+    tool_names = [getattr(t, "name", None) for t in ctx.options["tools"]]
+
+    # The skill tool must survive the refresh.
+    assert "load_skill" in tool_names, (
+        f"Foreign skill tool was stripped by Gantry refresh: {tool_names}"
+    )
+    # And Gantry's dynamic selection was layered on top.
+    assert "get_weather" in tool_names, (
+        f"Gantry's semantically-selected tool was not injected: {tool_names}"
+    )
+
+    # Critical: the refresh must mutate the SAME options dict (not replace
+    # the reference) so AF's FunctionInvocationLayer.mutable_options stays
+    # in sync. Confirm by identity.
+    assert ctx.options is options, (
+        "Provider replaced the options dict reference — this would desync "
+        "AF's tool-lookup table from the chat-call payload."
+    )
+
+    # Now simulate a follow-up round where the user shifts topic. The
+    # refresh should re-route Gantry's dynamic slot (none of get_weather's
+    # synonyms match) while still keeping load_skill.
+    ctx.messages.append(
+        Message(role="user", contents=[Content.from_text("Now load the math skill please.")])
+    )
+    await provider._refresh_tools_on_chat_context(ctx)
+
+    tool_names_r2 = [getattr(t, "name", None) for t in ctx.options["tools"]]
+    assert "load_skill" in tool_names_r2, (
+        f"Skill tool stripped on second refresh: {tool_names_r2}"
+    )
+    assert ctx.options is options, "Options reference changed on second refresh."

--- a/tests/test_agent_framework_orchestration.py
+++ b/tests/test_agent_framework_orchestration.py
@@ -828,3 +828,108 @@ async def test_build_workflow_empty_specs_raises(bridge: GantryToolBridge) -> No
     """build_workflow with no specs should raise ValueError."""
     with pytest.raises(ValueError, match="at least one agent"):
         await bridge.build_workflow(agent_specs=[])
+
+
+# ---------------------------------------------------------------------------
+# 16. build_agent end-to-end with extra_tools + multi-arg Gantry tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_agent_extra_tools_and_multi_arg_roundtrip(
+    bridge: GantryToolBridge,
+) -> None:
+    """build_agent must surface both Gantry-selected and extra tools, and the
+    Agent must round-trip a multi-arg Gantry tool call (call_id + result)."""
+    from agent_framework import tool
+
+    @tool(name="echo_note", description="Echo a short operator note.")
+    def echo_note(note: str) -> str:
+        return f"note:{note}"
+
+    client = ScriptedChatClient(
+        script=[
+            [_fc("lookup_order", {"order_id": "ORD-77", "include_items": True}, "c0")],
+            [Content.from_text("Order ORD-77 is shipped with 1 widget.")],
+        ]
+    )
+
+    agent = await bridge.build_agent(
+        client,
+        query="order lookup",
+        name="OrderAgent",
+        instructions="Answer order questions.",
+        limit=5,
+        score_threshold=0.0,
+        extra_tools=[echo_note],
+    )
+
+    assert isinstance(agent, Agent)
+    bound_tool_names = {
+        getattr(t, "name", None)
+        for t in (agent.default_options or {}).get("tools") or []
+    }
+    assert "lookup_order" in bound_tool_names, bound_tool_names
+    assert "echo_note" in bound_tool_names, "extra_tools must be appended"
+
+    resp = await agent.run("Look up order ORD-77 with items.")
+
+    assert "shipped" in resp.text.lower()
+    assert client.call_count == 2, "expected one function-call turn + final turn"
+
+    # The Agent's response must include a tool-result message with our call_id
+    # and the actual Gantry-executed payload.
+    function_results = [
+        c
+        for m in resp.messages
+        for c in (m.contents or [])
+        if getattr(c, "type", None) == "function_result"
+    ]
+    assert function_results, "Agent must surface the Gantry tool result"
+    fr = function_results[0]
+    assert fr.call_id == "c0"
+    rendered = str(fr.result) + (str(getattr(fr, "items", "")) or "")
+    assert "shipped" in rendered.lower()
+    assert "ORD-77" in rendered
+
+
+# ---------------------------------------------------------------------------
+# 17. as_agent end-to-end with a multi-arg Gantry tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_as_agent_runs_multi_arg_tool(bridge: GantryToolBridge) -> None:
+    """as_agent must produce an Agent that executes a Gantry tool with bool+str args."""
+    client = ScriptedChatClient(
+        script=[
+            [_fc("lookup_order", {"order_id": "ORD-AA", "include_items": False}, "k0")],
+            [Content.from_text("Order ORD-AA is shipped.")],
+        ]
+    )
+
+    agent = await bridge.as_agent(
+        client,
+        query="order lookup",
+        name="OrderAgent2",
+        instructions="",
+        limit=5,
+        score_threshold=0.0,
+    )
+
+    assert isinstance(agent, Agent)
+
+    resp = await agent.run("Look up order ORD-AA.")
+    assert "shipped" in resp.text.lower()
+
+    # Tool-result payload should carry the dict that the registered Python tool
+    # returned, including the empty items list for include_items=False.
+    fr = next(
+        c
+        for m in resp.messages
+        for c in (m.contents or [])
+        if getattr(c, "type", None) == "function_result"
+    )
+    rendered = str(fr.result) + str(getattr(fr, "items", ""))
+    assert "ORD-AA" in rendered
+    assert "shipped" in rendered.lower()

--- a/tests/test_agent_framework_orchestration.py
+++ b/tests/test_agent_framework_orchestration.py
@@ -933,3 +933,151 @@ async def test_as_agent_runs_multi_arg_tool(bridge: GantryToolBridge) -> None:
     rendered = str(fr.result) + str(getattr(fr, "items", ""))
     assert "ORD-AA" in rendered
     assert "shipped" in rendered.lower()
+
+
+# ---------------------------------------------------------------------------
+# 18. Gantry actually reduces the tool surface the Agent sees
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bridge_filters_tool_surface_for_agent() -> None:
+    """Register many tools, prove the Agent only receives the relevant subset.
+
+    This is Agent-Gantry's headline value proposition: semantic routing must
+    keep the LLM's tool surface small. ``ScriptedChatClient.seen_tools``
+    records exactly which tools were forwarded on each AF turn, so this test
+    asserts (a) the AF Agent saw `limit` tools, not all registered, and
+    (b) the unrelated tools were filtered out.
+    """
+    gantry = AgentGantry()
+
+    @gantry.register
+    def get_weather(city: str) -> str:
+        """Get current weather forecast for a city."""
+        return f"{city}: sunny"
+
+    @gantry.register
+    def get_forecast(city: str, days: int = 3) -> str:
+        """Multi-day weather forecast for a city."""
+        return f"{city}: sunny for {days} days"
+
+    @gantry.register
+    def get_air_quality(city: str) -> str:
+        """Air quality index lookup for a city."""
+        return f"{city} AQI: 42"
+
+    @gantry.register
+    def lookup_order(order_id: str) -> str:
+        """Look up an e-commerce order by id."""
+        return f"order {order_id}: shipped"
+
+    @gantry.register
+    def refund_order(order_id: str) -> str:
+        """Issue a refund for an e-commerce order."""
+        return f"refunded {order_id}"
+
+    @gantry.register
+    def list_invoices(user_id: str) -> list[str]:
+        """List billing invoices for a customer."""
+        return ["INV-1", "INV-2"]
+
+    @gantry.register
+    def compute_tax(amount: float, rate: float) -> float:
+        """Compute sales tax for a transaction amount."""
+        return amount * rate
+
+    @gantry.register
+    def read_file(path: str) -> str:
+        """Read the contents of a file from disk."""
+        return f"contents of {path}"
+
+    @gantry.register
+    def write_file(path: str, contents: str) -> str:
+        """Write contents to a file on disk."""
+        return f"wrote {path}"
+
+    @gantry.register
+    def send_email(to: str, body: str) -> str:
+        """Send an email message to a recipient."""
+        return f"sent to {to}"
+
+    @gantry.register
+    def search_codebase(query: str) -> list[str]:
+        """Search the source code repository for a string."""
+        return [f"hit for {query}"]
+
+    @gantry.register
+    def schedule_meeting(title: str, when: str) -> str:
+        """Schedule a calendar meeting."""
+        return f"booked {title}"
+
+    await gantry.sync()
+
+    total_registered = len(gantry.export_tools())
+    assert total_registered == 12, total_registered
+
+    bridge = GantryToolBridge(gantry, score_threshold=0.0)
+
+    client = ScriptedChatClient(
+        script=[
+            [_fc("get_weather", {"city": "Tokyo"}, "rf0")],
+            [Content.from_text("Tokyo: sunny.")],
+        ]
+    )
+
+    # Limit=3 should retrieve at most 3 weather-related tools out of 12.
+    agent = await bridge.build_agent(
+        client,
+        query="what's the weather forecast",
+        name="WeatherAgent",
+        instructions="",
+        limit=3,
+        score_threshold=0.0,
+    )
+
+    bound = (agent.default_options or {}).get("tools") or []
+    bound_names = [getattr(t, "name", None) for t in bound]
+    assert len(bound) == 3, (
+        f"build_agent must attach exactly limit=3 tools (got {len(bound)}: {bound_names})"
+    )
+    assert len(bound) < total_registered, (
+        "Gantry must reduce the tool surface vs. all registered tools"
+    )
+
+    # Drive the Agent so the ScriptedChatClient records what the LLM saw.
+    resp = await agent.run("Weather in Tokyo?")
+    assert "sunny" in resp.text.lower()
+
+    # The AF Agent forwards its bound tool set to the chat client per turn.
+    # seen_tools[0] is the very first turn → exactly the Gantry-filtered set.
+    seen_first_turn = client.seen_tools[0]
+    assert seen_first_turn, "ScriptedChatClient must have received tools"
+    assert len(seen_first_turn) == 3, (
+        f"Agent forwarded {len(seen_first_turn)} tools instead of the filtered 3: "
+        f"{seen_first_turn}"
+    )
+    assert len(seen_first_turn) < total_registered
+
+    # Semantic correctness: the weather tool we actually need is in the set.
+    assert "get_weather" in seen_first_turn, seen_first_turn
+
+    # And most of the 12 unrelated/loosely-related tools were dropped.
+    # (SimpleEmbedder is hash-based, so we don't assert zero leakage — only
+    # that the surface shrank meaningfully.  The 3/12 == 75% reduction above
+    # is the headline value-prop assertion.)
+    irrelevant = {
+        "read_file",
+        "write_file",
+        "compute_tax",
+        "send_email",
+        "search_codebase",
+        "schedule_meeting",
+        "refund_order",
+        "list_invoices",
+        "lookup_order",
+    }
+    leaked = irrelevant.intersection(seen_first_turn)
+    assert len(leaked) <= 2, (
+        f"Too many unrelated tools leaked through semantic routing: {leaked}"
+    )

--- a/tests/test_query_strategies.py
+++ b/tests/test_query_strategies.py
@@ -111,28 +111,52 @@ def test_strategies_accept_dict_messages():
     assert "result of fn:" in last_tool_result(msgs)
 
 
-def test_last_tool_result_extracts_text_from_af_function_result_message() -> None:
-    """AF wraps tool output as a ``function_result`` Content inside a
-    tool-role Message — ``Message.text`` is empty in that case and the
-    payload lives in ``Content.items[].text``. ``_msg_text`` must walk
-    ``contents`` to surface it, otherwise ``last_tool_result`` returns
-    "" and the per-call refresh's query collapses back to the original
-    user prompt across the entire run.
+def test_msg_text_walks_dict_contents_for_function_result() -> None:
+    """``_msg_text`` walks structured ``contents`` lists for text-bearing
+    items. Verified here with dict-shaped messages so this file stays
+    free of any ``agent_framework`` import (per the module docstring);
+    AF-specific Message/Content coverage lives in
+    ``test_agent_framework_orchestration.py``.
     """
-    af = pytest.importorskip("agent_framework")
+    from agent_gantry.query.strategies import _msg_text
 
-    fr = af.Content.from_function_result(
-        call_id="r0",
-        result="Paris is sunny. Invoice INV-9 payment is overdue.",
-    )
-    msg = af.Message(role="tool", contents=[fr])
+    # Mimic an AF tool-role message: function_result Content with
+    # items[].text populated; Message.text is empty.
+    msg = {
+        "role": "tool",
+        "text": "",
+        "contents": [
+            type("FR", (), {
+                "type": "function_result",
+                "items": [
+                    type("T", (), {"type": "text", "text": "Paris is sunny."})(),
+                ],
+                "result": None,
+            })(),
+        ],
+    }
+    assert "Paris is sunny" in _msg_text(msg)
 
-    out = last_tool_result([msg])
-    assert "Paris is sunny" in out, out
-    assert "INV-9" in out, out
-    # AF Messages don't carry a tool name at the message level; the
-    # generic-label fallback should kick in.
-    assert out.startswith("tool result:") or out.startswith("result of"), out
+
+def test_msg_text_function_result_fallback_is_per_content() -> None:
+    """When an earlier text content already populated ``parts``, a later
+    function_result with empty ``items[]`` must still surface its
+    ``.result`` via the per-content fallback — not get gated by the
+    cumulative ``parts`` list.
+    """
+    from agent_gantry.query.strategies import _msg_text
+
+    text_c = type("TC", (), {"type": "text", "text": "hi"})()
+    empty_fr = type("FR", (), {
+        "type": "function_result",
+        "items": [],
+        "result": "actual tool output payload",
+    })()
+
+    msg = {"role": "tool", "text": "", "contents": [text_c, empty_fr]}
+    out = _msg_text(msg)
+    assert "hi" in out, out
+    assert "actual tool output payload" in out, out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_query_strategies.py
+++ b/tests/test_query_strategies.py
@@ -111,6 +111,30 @@ def test_strategies_accept_dict_messages():
     assert "result of fn:" in last_tool_result(msgs)
 
 
+def test_last_tool_result_extracts_text_from_af_function_result_message() -> None:
+    """AF wraps tool output as a ``function_result`` Content inside a
+    tool-role Message — ``Message.text`` is empty in that case and the
+    payload lives in ``Content.items[].text``. ``_msg_text`` must walk
+    ``contents`` to surface it, otherwise ``last_tool_result`` returns
+    "" and the per-call refresh's query collapses back to the original
+    user prompt across the entire run.
+    """
+    af = pytest.importorskip("agent_framework")
+
+    fr = af.Content.from_function_result(
+        call_id="r0",
+        result="Paris is sunny. Invoice INV-9 payment is overdue.",
+    )
+    msg = af.Message(role="tool", contents=[fr])
+
+    out = last_tool_result([msg])
+    assert "Paris is sunny" in out, out
+    assert "INV-9" in out, out
+    # AF Messages don't carry a tool name at the message level; the
+    # generic-label fallback should kick in.
+    assert out.startswith("tool result:") or out.startswith("result of"), out
+
+
 # ---------------------------------------------------------------------------
 # AgentGantry.list_tools_sync + preview
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Existing tests cover construction shape (tools attached, name set, etc.)
but don't run agent.run() against a multi-arg Gantry tool through the
helper-constructed Agent. These two tests drive a ScriptedChatClient so
the AF Agent emits a function_call, the Gantry-wrapped tool executes,
and the resulting function_result content is asserted to carry the
expected call_id and payload.

https://claude.ai/code/session_01WxGbfT3yqLGFRj4d9VFsbG