### PR TITLE
🎨 Palette: Add semantic ARIA relationships to sidebar navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -57,3 +57,7 @@
 ## 2026-05-13 - [Keyboard Accessibility for Markdown Tables]
 **Learning:** Markdown generators (like Kramdown) output raw `<table>` elements without wrapping them in containers. Consequently, adding `overflow-x: auto` directly to the `<table>` element often fails to contain horizontal overflow consistently or securely across different browsers, and without a wrapper, keyboard users cannot scroll wide tables horizontally.
 **Action:** Always use a client-side JavaScript initialization script to locate raw `<table>` elements and wrap them in a `<div class="table-wrapper">` with `tabindex="0"`, `role="region"`, and a descriptive `aria-label` (e.g., "Data table"), while applying `overflow-x: auto` to the wrapper.
+
+## 2026-05-15 - [Semantic Grouping for Navigation Submenus]
+**Learning:** When building complex sidebar navigation with categorized sections (e.g., using `<div>` for titles above `<ul>` submenus), screen readers announce the submenus as isolated lists without context. Users cannot easily discern which category the list belongs to.
+**Action:** Always associate navigation section titles with their respective submenus by giving the title an `id` and adding `aria-labelledby="[id]"` to the `<ul>` element. This ensures screen readers announce the category name when entering the list.

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -79,16 +79,16 @@
     <nav class="sidebar" role="navigation" aria-label="Main navigation">
       <ul class="sidebar-nav">
         <li class="nav-section">
-          <div class="nav-section-title">Getting Started</div>
-          <ul class="nav-submenu">
+          <div class="nav-section-title" id="nav-getting-started">Getting Started</div>
+          <ul class="nav-submenu" aria-labelledby="nav-getting-started">
             <li class="nav-item"><a href="{{ '/' | relative_url }}" class="nav-link">Home</a></li>
             <li class="nav-item"><a href="{{ '/getting-started' | relative_url }}" class="nav-link">Quick Start</a></li>
           </ul>
         </li>
 
         <li class="nav-section">
-          <div class="nav-section-title">Guides</div>
-          <ul class="nav-submenu">
+          <div class="nav-section-title" id="nav-guides">Guides</div>
+          <ul class="nav-submenu" aria-labelledby="nav-guides">
             <li class="nav-item"><a href="{{ '/guides/semantic_tool_decorator' | relative_url }}" class="nav-link">Semantic Tool Decorator</a></li>
             <li class="nav-item"><a href="{{ '/guides/dynamic_mcp_selection' | relative_url }}" class="nav-link">Dynamic MCP Selection</a></li>
             <li class="nav-item"><a href="{{ '/guides/vector_store_llm_integration' | relative_url }}" class="nav-link">Vector Store & LLM Integration</a></li>
@@ -97,8 +97,8 @@
         </li>
 
         <li class="nav-section">
-          <div class="nav-section-title">Reference</div>
-          <ul class="nav-submenu">
+          <div class="nav-section-title" id="nav-reference">Reference</div>
+          <ul class="nav-submenu" aria-labelledby="nav-reference">
             <li class="nav-item"><a href="{{ '/reference/api-reference' | relative_url }}" class="nav-link">API Reference</a></li>
             <li class="nav-item"><a href="{{ '/reference/configuration' | relative_url }}" class="nav-link">Configuration</a></li>
             <li class="nav-item"><a href="{{ '/reference/llm_sdk_compatibility' | relative_url }}" class="nav-link">LLM SDK Compatibility</a></li>
@@ -107,16 +107,16 @@
         </li>
 
         <li class="nav-section">
-          <div class="nav-section-title">Architecture</div>
-          <ul class="nav-submenu">
+          <div class="nav-section-title" id="nav-architecture">Architecture</div>
+          <ul class="nav-submenu" aria-labelledby="nav-architecture">
             <li class="nav-item"><a href="{{ '/architecture/overview' | relative_url }}" class="nav-link">System Overview</a></li>
             <li class="nav-item"><a href="{{ '/architecture/best-practices' | relative_url }}" class="nav-link">Best Practices</a></li>
           </ul>
         </li>
 
         <li class="nav-section">
-          <div class="nav-section-title">Help</div>
-          <ul class="nav-submenu">
+          <div class="nav-section-title" id="nav-help">Help</div>
+          <ul class="nav-submenu" aria-labelledby="nav-help">
             <li class="nav-item"><a href="{{ '/troubleshooting' | relative_url }}" class="nav-link">Troubleshooting</a></li>
             <li class="nav-item"><a href="https://github.com/CodeHalwell/Agent-Gantry/issues" class="nav-link">Report Issue</a></li>
           </ul>


### PR DESCRIPTION
💡 **What:** Added `id` attributes to `.nav-section-title` elements and matching `aria-labelledby` attributes to their corresponding `.nav-submenu` `<ul>` containers.
🎯 **Why:** Screen readers previously announced the navigation submenus as isolated lists without communicating the overarching category (e.g., "Getting Started" or "Guides").
♿ **Accessibility:** This semantic grouping ensures that when a screen reader user navigates into a submenu list, the list's name/category is appropriately announced, providing vital navigation context.

---
*PR created automatically by Jules for task [10080389775276191072](https://jules.google.com/task/10080389775276191072) started by @CodeHalwell*