### PR TITLE
Add retrieval introspection, relative thresholds, and registry linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`CachedEmbedder`** (`agent_gantry.adapters.embedders.cached`): wraps
   any embedder with a disk-backed SQLite cache keyed by embedder_id and
   text hash. Eliminates re-embedding spend across cold starts. Default
-  cache path `~/.cache/agent_gantry/embeddings.sqlite`.
+  cache path `~/.cache/agent_gantry/embeddings.sqlite`. Dedups duplicate
+  strings within a batch so the underlying embedder is never called
+  twice for the same text. SQLite I/O is offloaded to a thread so it
+  doesn't block the event loop.
+- **Bundled Claude Skill** at `agent_gantry/skills/agent-gantry/SKILL.md`,
+  shipped in the wheel and discoverable via `from agent_gantry.skills
+  import skill_path`. Install into a project's skills directory with
+  `agent-gantry install-skill --target ./skills`. The skill also
+  publishes under the standard `share/claude/skills/agent-gantry/`
+  wheel data path so Claude Code can find it automatically.
+- **`gantry.embedder`** public property — sibling modules should use
+  this instead of reaching into `gantry._embedder`.
 
 ### Changed
 
@@ -65,10 +76,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on the first `before_run`. The previous behavior silently degraded
   to `per_run` semantics.
 - **Threshold-filtered-everything WARNING**: when `score_threshold`
-  drops every candidate, the bridge logs a WARNING with the top scores
-  so users see "it was the threshold, not relevance".
+  drops every candidate, the bridge logs a WARNING with the threshold
+  (and the resolved cutoff for relative mode) plus the top scores so
+  users see "it was the threshold, not relevance".
 
+### Fixed
 
+- Relative `score_threshold` over-fetches the candidate pool by 4× to
+  compute the cutoff. The over-fetched limit is now clamped to the
+  `ToolQuery.limit` upper bound (50) so callers passing `limit >= 13`
+  with a relative threshold no longer hit a Pydantic validation error.
+- Relative threshold falls back to `0.0` cutoff when the top score is
+  non-positive (defensive — `ScoredTool.semantic_score` is Pydantic
+  clamped `>= 0`, but the guard prevents the degenerate "filtered the
+  top match" path if a custom embedder ever returned negative scores).
+- Registry linter pre-compiles regex patterns once instead of inside
+  the nested loop — O(N²) → O(N) compile cost.
+- `_default_query_generator` reference removed (the import was renamed
+  to `last_user_text` in this release).
 
 - **`anthropic` floor bumped to `>=0.102.0`** (was `>=0.101.0`). Anthropic 0.102.0
   released 2026-05-13; no breaking changes for Gantry's Messages API call sites.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`RetrievalDecision` introspection** on `GantryContextProvider` and
+  `GantryToolBridge.get_tools_with_decision`. Carries the ranked candidate
+  list (kept/dropped), the injected tools, and the effective threshold.
+  Exposed on the provider as `provider.last_selection`. The decision is
+  attached to the new `gantry.bridge_retrieval` telemetry span as
+  structured attributes. Pair with `verbose=True` on the provider for
+  a one-line INFO summary per round.
+- **`provider.dry_run_retrieve(query)`**: officially supported diagnostic
+  that uses the *exact same* code path as the live middleware. Use to
+  validate "would the LLM see X?" without spinning up an agent.
+- **Relative score thresholds**: `score_threshold="relative:0.8"` retains
+  any candidate within 80% of the top score. Length-robust where absolute
+  cosine cutoffs collapse with long pipeline-style queries.
+- **`static_tools=[...]` on `GantryContextProvider`**: pin AF-native tools
+  that live *outside* the gantry registry into every round's surface.
+- **`provider.attach_to(agent)` helper**: appends the provider and
+  (when in `per_call`) the chat middleware in one call.
+- **`agent_gantry.query.keyword_focused`** and **`truncated`**: drop-in
+  query generators that strip imperative scaffolding and cap query
+  length respectively. Mitigate the long-query degradation pattern.
+- **`GantryToolChoiceMiddleware`**: AF chat middleware that re-derives
+  `tool_choice` per round from a user-supplied callable. Enables the
+  "force tool calls for N rounds, then text on summarisation" pattern.
+- **Registry linter**: `gantry.analyze_registry()` and
+  `gantry.pairwise_similarity()` Python APIs flag tool descriptions that
+  cross-reference other tools, pairs whose searchable text is too
+  similar, and tags with low discriminative value. Exposed via the CLI
+  as `gantry lint` and `gantry sim toolA toolB`.
+- **`gantry sync --dry-run` CLI**: reports which tools would be
+  (re-)embedded and why, without invoking the embedder.
+- **`CachedEmbedder`** (`agent_gantry.adapters.embedders.cached`): wraps
+  any embedder with a disk-backed SQLite cache keyed by embedder_id and
+  text hash. Eliminates re-embedding spend across cold starts. Default
+  cache path `~/.cache/agent_gantry/embeddings.sqlite`.
+
 ### Changed
+
+- **Default `score_threshold` on `GantryContextProvider` and
+  `GantryToolBridge` lowered from `0.3` to `0.0`** (no filtering).
+  Long queries dilute absolute cosine similarities, so the previous
+  default silently filtered relevant tools on multi-step pipelines.
+  Filtering is now opt-in. Pair with `score_threshold="relative:<frac>"`
+  for length-robust filtering.
+- **`per_call` default query generator** is now
+  `fallback_chain(last_tool_result, last_user_text)` (was
+  `last_user_text`). `last_user_text` returns the same string every
+  round, which silently disabled per-round adaptation. `per_run` still
+  defaults to `last_user_text`. Explicitly passing `last_user_text`
+  with `query_strategy="per_call"` now logs a WARNING.
+- **`OpenAIEmbedder` honours `config.api_base` / `OPENAI_BASE_URL`**.
+  Previously hard-coded to OpenAI's endpoint, blocking Requesty,
+  OpenRouter, Together, vLLM and other OpenAI-compatible providers.
+- **`per_call` without `as_chat_middleware()` attached now warns once**
+  on the first `before_run`. The previous behavior silently degraded
+  to `per_run` semantics.
+- **Threshold-filtered-everything WARNING**: when `score_threshold`
+  drops every candidate, the bridge logs a WARNING with the top scores
+  so users see "it was the threshold, not relevance".
+
+
 
 - **`anthropic` floor bumped to `>=0.102.0`** (was `>=0.101.0`). Anthropic 0.102.0
   released 2026-05-13; no breaking changes for Gantry's Messages API call sites.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ For development:
 pip install agent-gantry[dev]
 ```
 
+### Optional: install the bundled Claude Skill
+
+Agent-Gantry ships a Claude Skill — a self-contained reference an agent can read to learn the library — bundled inside the wheel. Install it next to your other skills with one command:
+
+```bash
+agent-gantry install-skill --target ./skills
+```
+
+This drops a `skills/agent-gantry/` directory in your project. Wire it into an AF agent via `SkillsProvider(skill_paths=["./skills"])` or point Claude Code at it directly. To use the bundled copy without copying:
+
+```python
+from agent_gantry.skills import skill_path
+print(skill_path())  # /…/site-packages/agent_gantry/skills/agent-gantry
+```
+
+The skill covers each integration (Microsoft Agent Framework, LangChain, AutoGen, CrewAI, LlamaIndex, Semantic Kernel, Google ADK, plain SDK use), the new introspection APIs, and a debugging playbook.
+
 ### LLM Provider SDKs
 
 Install with specific LLM provider support:
@@ -243,6 +260,78 @@ async def chat(messages, *, tools=None):
 
 See [docs/llm_sdk_compatibility.md](docs/llm_sdk_compatibility.md) for detailed integration guides.
 
+### Microsoft Agent Framework (native integration)
+
+For Microsoft Agent Framework 1.x, `GantryContextProvider` plugs into AF's context-engineering pipeline as a first-class `ContextProvider` — no manual schema wiring, no static tool list, no overrides of `Agent(tools=...)`. Two modes:
+
+```python
+from agent_framework import Agent
+from agent_framework.openai import OpenAIChatClient
+from agent_gantry import AgentGantry, GantryContextProvider
+
+gantry = AgentGantry()
+# ... register tools, await gantry.sync() ...
+
+# Per-run mode: tool set is fixed for one agent.run() call.
+provider = GantryContextProvider(gantry, top_k=5)
+agent = Agent(OpenAIChatClient(), "...", context_providers=[provider])
+
+# Per-call mode: re-runs retrieval every chat-completion round (multi-step agents).
+provider = GantryContextProvider(gantry, top_k=3, query_strategy="per_call")
+agent = Agent(OpenAIChatClient(), "...")
+provider.attach_to(agent)  # one-call helper — attaches provider + middleware
+```
+
+`GantryContextProvider` co-exists with `SkillsProvider`, flows through `WorkflowBuilder` / `SequentialBuilder` / `HandoffBuilder`, and supports `required=[...]`, `always_include=[...]`, `static_tools=[...]`, and `verbose=True` for one-line per-round logging. See `examples/agent_frameworks/agent_framework_provider_example.py` for the full walkthrough.
+
+### Debugging tool routing
+
+When the LLM "doesn't see" a tool you expect, Agent-Gantry surfaces the decision so you don't have to write middleware to find out:
+
+```python
+# After any agent.run() call:
+decision = provider.last_selection
+print(decision.summary())         # query="..." → top5: [tool_a:0.61, ...]
+for c in decision.candidates:
+    print(c.name, c.score, c.kept)  # full ranked list, kept/dropped
+
+# Or, offline — same code path as the live middleware:
+decision = await provider.dry_run_retrieve("the user's actual query")
+```
+
+For registry-level mistakes — descriptions that name other tools, near-duplicate tools, overly generic tags — run the linter:
+
+```bash
+agent-gantry lint
+agent-gantry sim factorial fibonacci   # cosine similarity between two tools
+```
+
+### Robust score thresholds for long queries
+
+Absolute cosine thresholds collapse on long instructional queries because the embedding gets diluted. Use the relative mode for length-robust filtering:
+
+```python
+provider = GantryContextProvider(gantry, score_threshold="relative:0.8")
+# Keep anything within 80% of the top score, regardless of query length.
+```
+
+The default is `score_threshold=0.0` (no filtering) — opt-in to filtering, don't get filtered by surprise.
+
+### Persistent embedding cache
+
+`InMemoryVectorStore` (the default) re-embeds every tool on each cold start — real money on paid embedders. Wrap with `CachedEmbedder` for a disk-backed SQLite cache keyed by `(embedder_id, text_hash)`:
+
+```python
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.openai import OpenAIEmbedder
+from agent_gantry.adapters.embedders.cached import CachedEmbedder
+from agent_gantry.schema.config import EmbedderConfig
+
+base = OpenAIEmbedder(EmbedderConfig(type="openai", model="text-embedding-3-large"))
+embedder = CachedEmbedder(base)  # default: ~/.cache/agent_gantry/embeddings.sqlite
+gantry = AgentGantry(embedder=embedder)
+```
+
 ### Load tools from multiple modules
 
 Organize tools in a `tools/` directory with separate files for each category, then import them into your main file:
@@ -358,11 +447,17 @@ with a warning so shared modules can be safely combined.
 ## Features
 
 - **Semantic Routing**: Intelligent tool selection using vector similarity, intent classification, and conversation context
+- **Native Microsoft Agent Framework integration**: `GantryContextProvider` plugs into AF as a first-class `ContextProvider` — per-run or per-call retrieval
 - **Multi-Protocol Support**: Native support for MCP (Model Context Protocol) and A2A (Agent-to-Agent)
 - **Schema Transcoding**: Automatic conversion between OpenAI, Anthropic, and Gemini tool formats
-- **LLM Provider Compatibility**: Works with OpenAI, Azure OpenAI, Anthropic, Google GenAI, Vertex AI, Mistral, Groq, and OpenRouter
+- **LLM Provider Compatibility**: Works with OpenAI, Azure OpenAI, Anthropic, Google GenAI, Vertex AI, Mistral, Groq, OpenRouter — plus any OpenAI-compatible endpoint via `api_base`
+- **First-class introspection**: `RetrievalDecision`, `provider.last_selection`, `provider.dry_run_retrieve(query)`, verbose mode — debug routing without writing middleware
+- **Length-robust thresholds**: `score_threshold="relative:0.8"` keeps anything within 80% of the top score, surviving long pipeline-style queries that collapse absolute cosine cutoffs
+- **Registry linter**: `agent-gantry lint` flags tool descriptions that pull each other into the wrong queries (cross-references, near-duplicates, generic tags)
+- **Persistent embedding cache**: `CachedEmbedder` wraps any embedder with a SQLite cache so cold starts don't re-embed everything
+- **Bundled Claude Skill**: ship usage docs to your agents via `agent-gantry install-skill` or `from agent_gantry.skills import skill_path`
 - **Circuit Breakers**: Automatic failure detection and recovery
-- **Observability**: Built-in structured logging and telemetry for tracing and metrics
+- **Observability**: Built-in structured logging and telemetry for tracing and metrics, including `gantry.bridge_retrieval` spans carrying the full ranked candidate list
 - **Zero-Trust Security**: Capability-based permissions and policy enforcement
 - **Modular tool loading**: Import and deduplicate tool registries from other modules or packages
 - **Local persistence & skills**: LanceDB-backed tool/skill storage, Matryoshka embeddings, and skill schemas for prompt guidance
@@ -418,17 +513,23 @@ Agent-Gantry has been verified in end-to-end scenarios with real LLMs and tangib
 
 ```
 agent_gantry/
-├── core/                 # Main facade, registry, router, executor
+├── core/                 # Main facade, registry, router, executor, security
 ├── schema/               # Data models (tools, queries, events, config)
 ├── adapters/             # Protocol adapters
-│   ├── vector_stores/    # Qdrant, Chroma, In-Memory, etc.
-│   ├── embedders/        # OpenAI, SentenceTransformers, etc.
-│   ├── rerankers/        # Cohere, CrossEncoder, etc.
+│   ├── vector_stores/    # Qdrant, Chroma, LanceDB, In-Memory, PGVector
+│   ├── embedders/        # OpenAI, Azure, Nomic, SentenceTransformers, Simple, Cached
+│   ├── rerankers/        # Cohere, CrossEncoder
 │   └── executors/        # Direct, Sandbox, MCP, HTTP, A2A
-├── providers/            # Tool import from various sources
+├── providers/            # Tool import from various sources (A2A, …)
 ├── servers/              # MCP and A2A server implementations
-├── integrations/         # LangChain, AutoGen, LlamaIndex, CrewAI
-├── observability/        # Telemetry, metrics, logging
+├── integrations/         # Microsoft Agent Framework bridge/provider/middleware,
+│                         # LangChain, AutoGen, LlamaIndex, CrewAI, Semantic Kernel,
+│                         # Google ADK, Anthropic Skills
+├── query/                # Query generators (last_user_text, last_tool_result, …)
+├── metrics/              # Token-savings metrics
+├── observability/        # Telemetry adapters (console, OpenTelemetry, Prometheus)
+├── utils/                # Fingerprinting, registry linter, async helpers
+├── skills/               # Bundled Claude Skill (Agent-Gantry usage docs)
 └── cli/                  # Command-line interface
 ```
 
@@ -648,15 +749,20 @@ See `examples/a2a_integration_demo.py` for a complete demonstration.
 
 ## CLI
 
-A lightweight CLI ships with the package for quick inspection:
+A lightweight CLI ships with the package for quick inspection and diagnostics:
 
 ```bash
-agent-gantry list
+agent-gantry list                              # list registered tools
 agent-gantry search "refund an order" --limit 3
+agent-gantry lint                              # detect tool-description authoring mistakes
+agent-gantry sim factorial fibonacci           # cosine similarity between two tools
+agent-gantry sync --dry-run                    # which tools would (re-)embed and why
+agent-gantry install-skill --target ./skills   # install the bundled Claude Skill
 ```
 
-It boots with demo tools and an in-memory embedder. For details and customization options, see
-[docs/cli.md](docs/cli.md).
+`lint` flags three patterns that silently degrade routing quality: tool descriptions that name *other* registered tools (the embedding pulls them toward the wrong queries), pairs of tools with >0.85 cosine similarity (probably should be merged or differentiated), and tags that appear on more than half the registry (low discriminative value).
+
+The CLI boots with demo tools and an in-memory embedder. For details and customization options, see [docs/cli.md](docs/cli.md).
 
 ## Documentation
 

--- a/agent_gantry/__init__.py
+++ b/agent_gantry/__init__.py
@@ -7,6 +7,10 @@ Core Philosophy: Context is precious. Execution is sacred. Trust is earned.
 """
 
 from agent_gantry.core.gantry import AgentGantry, create_default_gantry
+from agent_gantry.integrations.agent_framework_bridge import (
+    RetrievalCandidate,
+    RetrievalDecision,
+)
 from agent_gantry.integrations.agent_framework_provider import (
     GantryContextProvider,
     MissingRequiredToolError,
@@ -30,6 +34,8 @@ __all__ = [
     "AgentGantry",
     "GantryContextProvider",
     "MissingRequiredToolError",
+    "RetrievalCandidate",
+    "RetrievalDecision",
     "create_default_gantry",
     "with_semantic_tools",
     "set_default_gantry",

--- a/agent_gantry/adapters/embedders/cached.py
+++ b/agent_gantry/adapters/embedders/cached.py
@@ -1,0 +1,198 @@
+"""
+Disk-backed cache wrapper for embedders.
+
+The default :class:`InMemoryVectorStore` discards embeddings between
+processes, so any non-trivial registry re-embeds every cold start. With
+paid embedders (OpenAI, Azure OpenAI, Cohere) that's real spend repeated
+on every restart. ``CachedEmbedder`` wraps any
+:class:`~agent_gantry.adapters.embedders.base.EmbeddingAdapter` with a
+SQLite cache keyed by ``(embedder_id, sha256(text))``. Lookups that hit
+return instantly; misses are forwarded to the underlying embedder and
+the result is persisted before being returned.
+
+Storage is a single SQLite file. Default location is
+``~/.cache/agent_gantry/embeddings.sqlite`` (overridable). The cache
+is keyed by the underlying embedder's :meth:`get_embedder_id` so two
+embedders with different models / dimensions never collide.
+
+Usage::
+
+    from agent_gantry.adapters.embedders.openai import OpenAIEmbedder
+    from agent_gantry.adapters.embedders.cached import CachedEmbedder
+
+    base = OpenAIEmbedder(config)
+    embedder = CachedEmbedder(base)
+    gantry = AgentGantry(embedder=embedder)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_gantry.adapters.embedders.base import EmbeddingAdapter
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_CACHE_PATH = Path.home() / ".cache" / "agent_gantry" / "embeddings.sqlite"
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class CachedEmbedder:
+    """Wrap any :class:`EmbeddingAdapter` with a persistent on-disk cache.
+
+    Args:
+        embedder: The backing embedder. All non-cache operations are
+            delegated to it.
+        cache_path: Path to the SQLite cache file. Defaults to
+            ``~/.cache/agent_gantry/embeddings.sqlite``.
+    """
+
+    def __init__(
+        self,
+        embedder: EmbeddingAdapter,
+        *,
+        cache_path: str | os.PathLike[str] | None = None,
+    ) -> None:
+        self._embedder = embedder
+        self._cache_path = Path(cache_path) if cache_path else DEFAULT_CACHE_PATH
+        self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+        # A connection-per-instance is fine — SQLite handles per-connection
+        # serialisation internally. We disable the same-thread check because
+        # this is read from anyio-driven async code that may bounce calls
+        # between event-loop threads.
+        self._conn = sqlite3.connect(
+            str(self._cache_path), check_same_thread=False
+        )
+        self._lock = asyncio.Lock()
+        self._init_schema()
+        self.hits = 0
+        self.misses = 0
+
+    def _init_schema(self) -> None:
+        with self._conn:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS embeddings (
+                    embedder_id TEXT NOT NULL,
+                    text_hash TEXT NOT NULL,
+                    embedding TEXT NOT NULL,
+                    PRIMARY KEY (embedder_id, text_hash)
+                )
+                """
+            )
+
+    @property
+    def dimension(self) -> int:
+        return self._embedder.dimension
+
+    @property
+    def model_name(self) -> str:
+        return self._embedder.model_name
+
+    def get_embedder_id(self) -> str:
+        get_id = getattr(self._embedder, "get_embedder_id", None)
+        if callable(get_id):
+            return get_id()
+        return f"{self.model_name}:{self.dimension}"
+
+    async def embed_text(self, text: str) -> list[float]:
+        result = await self.embed_batch([text])
+        return result[0]
+
+    async def embed_batch(
+        self,
+        texts: list[str],
+        batch_size: int | None = None,
+    ) -> list[list[float]]:
+        if not texts:
+            return []
+
+        embedder_id = self.get_embedder_id()
+        # Hash once per text and reuse for both read and write.
+        hashes = [_hash(t) for t in texts]
+
+        async with self._lock:
+            cached = self._lookup_batch(embedder_id, hashes)
+
+        outputs: list[list[float] | None] = [cached.get(h) for h in hashes]
+        miss_indices = [i for i, v in enumerate(outputs) if v is None]
+        self.hits += len(texts) - len(miss_indices)
+        self.misses += len(miss_indices)
+
+        if miss_indices:
+            miss_texts = [texts[i] for i in miss_indices]
+            # Delegate the actual embedding work outside the lock so
+            # cache reads from other coroutines can proceed in parallel.
+            new_embeddings = await self._embedder.embed_batch(
+                miss_texts, batch_size=batch_size
+            )
+            async with self._lock:
+                self._store_batch(
+                    embedder_id,
+                    [(hashes[i], emb) for i, emb in zip(miss_indices, new_embeddings)],
+                )
+            for i, emb in zip(miss_indices, new_embeddings):
+                outputs[i] = emb
+
+        # outputs has no Nones at this point — every slot was either a
+        # hit or filled by the embedding call.
+        return [o for o in outputs if o is not None]
+
+    def _lookup_batch(
+        self, embedder_id: str, hashes: list[str]
+    ) -> dict[str, list[float]]:
+        if not hashes:
+            return {}
+        # SQLite parameter limit is 999 by default; chunk to stay safe.
+        out: dict[str, list[float]] = {}
+        cur = self._conn.cursor()
+        for i in range(0, len(hashes), 500):
+            chunk = hashes[i : i + 500]
+            placeholders = ",".join("?" * len(chunk))
+            rows = cur.execute(
+                f"SELECT text_hash, embedding FROM embeddings "
+                f"WHERE embedder_id = ? AND text_hash IN ({placeholders})",
+                (embedder_id, *chunk),
+            ).fetchall()
+            for h, blob in rows:
+                out[h] = json.loads(blob)
+        return out
+
+    def _store_batch(
+        self,
+        embedder_id: str,
+        items: list[tuple[str, list[float]]],
+    ) -> None:
+        with self._conn:
+            self._conn.executemany(
+                "INSERT OR REPLACE INTO embeddings "
+                "(embedder_id, text_hash, embedding) VALUES (?, ?, ?)",
+                [
+                    (embedder_id, h, json.dumps(emb))
+                    for h, emb in items
+                ],
+            )
+
+    async def health_check(self) -> bool:
+        return await self._embedder.health_check()
+
+    def close(self) -> None:
+        try:
+            self._conn.close()
+        except Exception:  # pragma: no cover - shutdown best-effort
+            logger.debug("CachedEmbedder: error closing SQLite connection.", exc_info=True)
+
+
+__all__ = ["CachedEmbedder", "DEFAULT_CACHE_PATH"]

--- a/agent_gantry/adapters/embedders/cached.py
+++ b/agent_gantry/adapters/embedders/cached.py
@@ -123,8 +123,13 @@ class CachedEmbedder:
         # Hash once per text and reuse for both read and write.
         hashes = [_hash(t) for t in texts]
 
+        # SQLite operations are CPU/IO blocking; offload them to a thread
+        # so a long lookup doesn't starve the event loop in concurrent
+        # workloads (a chat session running other tasks in parallel).
         async with self._lock:
-            cached = self._lookup_batch(embedder_id, hashes)
+            cached = await asyncio.to_thread(
+                self._lookup_batch, embedder_id, hashes
+            )
 
         outputs: list[list[float] | None] = [cached.get(h) for h in hashes]
         miss_indices = [i for i, v in enumerate(outputs) if v is None]
@@ -132,19 +137,46 @@ class CachedEmbedder:
         self.misses += len(miss_indices)
 
         if miss_indices:
-            miss_texts = [texts[i] for i in miss_indices]
+            # Dedupe miss_indices by hash so duplicate strings inside a
+            # single batch don't produce duplicate embed calls. The
+            # underlying embedder is the expensive part; passing the same
+            # text twice would otherwise pay twice. Order-preserving so
+            # the unique miss list is deterministic.
+            unique_miss_hashes: list[str] = []
+            unique_miss_texts: list[str] = []
+            unique_miss_seen: set[str] = set()
+            for i in miss_indices:
+                h = hashes[i]
+                if h in unique_miss_seen:
+                    continue
+                unique_miss_seen.add(h)
+                unique_miss_hashes.append(h)
+                unique_miss_texts.append(texts[i])
+
             # Delegate the actual embedding work outside the lock so
             # cache reads from other coroutines can proceed in parallel.
             new_embeddings = await self._embedder.embed_batch(
-                miss_texts, batch_size=batch_size
+                unique_miss_texts, batch_size=batch_size
             )
-            async with self._lock:
-                self._store_batch(
-                    embedder_id,
-                    [(hashes[i], emb) for i, emb in zip(miss_indices, new_embeddings)],
+            if len(new_embeddings) != len(unique_miss_texts):
+                # Defensive: if the underlying embedder returns the wrong
+                # number of vectors, surface a clear error rather than
+                # silently writing a truncated result that would mis-index.
+                raise RuntimeError(
+                    f"CachedEmbedder: underlying {type(self._embedder).__name__} "
+                    f"returned {len(new_embeddings)} embeddings for "
+                    f"{len(unique_miss_texts)} inputs."
                 )
-            for i, emb in zip(miss_indices, new_embeddings):
-                outputs[i] = emb
+
+            by_hash = dict(zip(unique_miss_hashes, new_embeddings))
+            async with self._lock:
+                await asyncio.to_thread(
+                    self._store_batch,
+                    embedder_id,
+                    list(by_hash.items()),
+                )
+            for i in miss_indices:
+                outputs[i] = by_hash[hashes[i]]
 
         # outputs has no Nones at this point — every slot was either a
         # hit or filled by the embedding call.
@@ -156,10 +188,12 @@ class CachedEmbedder:
         if not hashes:
             return {}
         # SQLite parameter limit is 999 by default; chunk to stay safe.
+        # Also dedupe hashes in case the input batch had duplicates.
+        unique_hashes = list(dict.fromkeys(hashes))
         out: dict[str, list[float]] = {}
         cur = self._conn.cursor()
-        for i in range(0, len(hashes), 500):
-            chunk = hashes[i : i + 500]
+        for i in range(0, len(unique_hashes), 500):
+            chunk = unique_hashes[i : i + 500]
             placeholders = ",".join("?" * len(chunk))
             rows = cur.execute(
                 f"SELECT text_hash, embedding FROM embeddings "

--- a/agent_gantry/adapters/embedders/openai.py
+++ b/agent_gantry/adapters/embedders/openai.py
@@ -200,15 +200,31 @@ class OpenAIEmbedder(BaseOpenAIEmbedder):
                 "OPENAI_API_KEY environment variable."
             )
 
-        # Initialize client with retry logic
-        self._client = AsyncOpenAI(
-            api_key=api_key,
-            max_retries=self._max_retries,
-        )
+        # Honor an OpenAI-compatible custom endpoint (Requesty, OpenRouter,
+        # Together, vLLM, …) when supplied via config.api_base or the
+        # OPENAI_BASE_URL env var. Without this users have to monkey-patch
+        # or globally set OPENAI_BASE_URL — both brittle.
+        base_url = config.api_base or os.getenv("OPENAI_BASE_URL")
 
-        logger.info(
-            f"Initialized OpenAIEmbedder with model={self._model}, dimension={self._dimension}"
-        )
+        client_kwargs: dict[str, Any] = {
+            "api_key": api_key,
+            "max_retries": self._max_retries,
+        }
+        if base_url:
+            client_kwargs["base_url"] = base_url
+
+        self._client = AsyncOpenAI(**client_kwargs)
+
+        if base_url:
+            logger.info(
+                f"Initialized OpenAIEmbedder with model={self._model}, "
+                f"dimension={self._dimension}, base_url={base_url}"
+            )
+        else:
+            logger.info(
+                f"Initialized OpenAIEmbedder with model={self._model}, "
+                f"dimension={self._dimension}"
+            )
 
     def get_embedder_id(self) -> str:
         """

--- a/agent_gantry/cli/main.py
+++ b/agent_gantry/cli/main.py
@@ -48,6 +48,45 @@ def main(argv: list[str] | None = None) -> int:
     search_parser.add_argument("query", help="Natural language query")
     search_parser.add_argument("--limit", type=int, default=5, help="Maximum tools to return")
 
+    lint_parser = subparsers.add_parser(
+        "lint",
+        help="Detect tool-description authoring mistakes",
+    )
+    lint_parser.add_argument(
+        "--similarity-threshold",
+        type=float,
+        default=0.85,
+        help="Cosine threshold above which two tools are flagged as similar (default 0.85).",
+    )
+    lint_parser.add_argument(
+        "--tag-overlap-share",
+        type=float,
+        default=0.5,
+        help="Tag flagged when it appears on more than this fraction of tools (default 0.5).",
+    )
+
+    sim_parser = subparsers.add_parser(
+        "sim",
+        help="Print the cosine similarity between two registered tools",
+    )
+    sim_parser.add_argument("tool_a", help="First tool name (or namespace.name)")
+    sim_parser.add_argument("tool_b", help="Second tool name (or namespace.name)")
+
+    sync_parser = subparsers.add_parser(
+        "sync",
+        help="Sync tool embeddings into the configured vector store",
+    )
+    sync_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report which tools would be (re-)embedded and why, without doing it.",
+    )
+    sync_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force re-sync of all tools regardless of fingerprint match.",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command is None:
@@ -56,7 +95,10 @@ def main(argv: list[str] | None = None) -> int:
 
     gantry = AgentGantry()
     _load_demo_tools(gantry)
-    asyncio.run(gantry.sync())
+    # Defer the eager sync until we know the command actually needs it —
+    # lint/sim/sync --dry-run shouldn't trigger embedding work.
+    if args.command not in ("lint", "sim", "sync"):
+        asyncio.run(gantry.sync())
 
     if args.command == "list":
         tools = asyncio.run(gantry.list_tools(namespace=args.namespace))
@@ -75,7 +117,67 @@ def main(argv: list[str] | None = None) -> int:
             print(f"{scored.tool.name} ({scored.semantic_score:.2f}) - {scored.tool.description}")
         return 0
 
+    if args.command == "lint":
+        analysis = asyncio.run(
+            gantry.analyze_registry(
+                similarity_threshold=args.similarity_threshold,
+                tag_overlap_share=args.tag_overlap_share,
+            )
+        )
+        print(analysis.format_text())
+        return 1 if not analysis.empty else 0
+
+    if args.command == "sim":
+        try:
+            score = asyncio.run(
+                gantry.pairwise_similarity(args.tool_a, args.tool_b)
+            )
+        except LookupError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print(f"{args.tool_a} ⇄ {args.tool_b}: {score:.4f}")
+        return 0
+
+    if args.command == "sync":
+        return asyncio.run(_run_sync_command(gantry, dry_run=args.dry_run, force=args.force))
+
     parser.print_help()
+    return 0
+
+
+async def _run_sync_command(
+    gantry: AgentGantry,
+    *,
+    dry_run: bool,
+    force: bool,
+) -> int:
+    """Run the ``gantry sync`` subcommand.
+
+    In ``--dry-run`` mode, queries the SyncManager for the set of tools
+    whose fingerprints don't match what's stored, and reports them
+    without invoking the embedder.
+    """
+    # Touching ``ensure_synced`` triggers the embedding work we are
+    # trying to avoid in dry-run mode. Use the lower-level
+    # ``detect_changes`` path instead.
+    await gantry._ensure_initialized()
+    sync_mgr = gantry._sync_manager
+    all_tools = gantry.export_tools()
+    to_sync = await sync_mgr.detect_changes(all_tools, force=force)
+    if dry_run:
+        if not to_sync:
+            print("Up to date — no tools would be (re-)embedded.")
+            return 0
+        print(f"{len(to_sync)} tool(s) would be (re-)embedded:")
+        stored = await gantry._vector_store.get_stored_fingerprints()
+        for tool in to_sync:
+            tool_id = f"{tool.namespace}.{tool.name}"
+            reason = "new" if tool_id not in stored else "fingerprint changed"
+            print(f"  - {tool_id}: {reason}")
+        return 0
+
+    count = await gantry.sync(force=force)
+    print(f"Synced {count} tool(s).")
     return 0
 
 

--- a/agent_gantry/cli/main.py
+++ b/agent_gantry/cli/main.py
@@ -87,18 +87,43 @@ def main(argv: list[str] | None = None) -> int:
         help="Force re-sync of all tools regardless of fingerprint match.",
     )
 
+    skill_parser = subparsers.add_parser(
+        "install-skill",
+        help="Install the bundled Agent-Gantry Claude Skill into a target directory",
+    )
+    skill_parser.add_argument(
+        "--target",
+        default="./skills",
+        help="Destination directory (default: ./skills).",
+    )
+    skill_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace an existing agent-gantry directory in --target.",
+    )
+    skill_parser.add_argument(
+        "--print-path",
+        action="store_true",
+        help="Just print the path to the bundled skill (no copy).",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command is None:
         parser.print_help()
         return 0
 
-    gantry = AgentGantry()
-    _load_demo_tools(gantry)
-    # Defer the eager sync until we know the command actually needs it —
-    # lint/sim/sync --dry-run shouldn't trigger embedding work.
-    if args.command not in ("lint", "sim", "sync"):
-        asyncio.run(gantry.sync())
+    # install-skill is a pure file-copy operation; it doesn't need a
+    # gantry instance or demo tool registration.
+    if args.command == "install-skill":
+        gantry = None  # type: ignore[assignment]
+    else:
+        gantry = AgentGantry()
+        _load_demo_tools(gantry)
+        # Defer the eager sync until we know the command actually needs it —
+        # lint/sim/sync --dry-run shouldn't trigger embedding work.
+        if args.command not in ("lint", "sim", "sync"):
+            asyncio.run(gantry.sync())
 
     if args.command == "list":
         tools = asyncio.run(gantry.list_tools(namespace=args.namespace))
@@ -140,6 +165,28 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "sync":
         return asyncio.run(_run_sync_command(gantry, dry_run=args.dry_run, force=args.force))
+
+    if args.command == "install-skill":
+        from agent_gantry.skills import install_to, skill_path
+
+        if args.print_path:
+            try:
+                print(skill_path())
+                return 0
+            except FileNotFoundError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
+        try:
+            dst = install_to(args.target, overwrite=args.overwrite)
+        except FileExistsError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            print("  Re-run with --overwrite to replace.", file=sys.stderr)
+            return 2
+        except FileNotFoundError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print(f"Installed Agent-Gantry skill to {dst}")
+        return 0
 
     parser.print_help()
     return 0

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -1310,6 +1310,16 @@ class AgentGantry:
         """Return the number of registered tools."""
         return len(self._tool_handlers)
 
+    @property
+    def embedder(self) -> EmbeddingAdapter:
+        """Return the embedder this gantry is using.
+
+        Public accessor exposed so sibling modules (CLI helpers,
+        the registry linter, custom tooling) can perform their own
+        embedding work without reaching into ``_embedder``.
+        """
+        return self._embedder
+
     async def get_tool(self, name: str, namespace: str = "default") -> ToolDefinition | None:
         """
         Get a tool by name.

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -1429,6 +1429,41 @@ class AgentGantry:
             for st in result.tools
         ]
 
+    async def analyze_registry(
+        self,
+        *,
+        similarity_threshold: float = 0.85,
+        tag_overlap_share: float = 0.5,
+    ) -> Any:
+        """Lint the registry for common tool-description mistakes.
+
+        Convenience wrapper around
+        :func:`agent_gantry.utils.registry_linter.analyze_registry`.
+        Returns a :class:`RegistryAnalysis` listing tools whose
+        descriptions name other registered tools (which pulls them
+        toward the wrong queries via embedding similarity), pairs of
+        tools whose searchable text is too similar to disambiguate,
+        and tags that appear on so many tools they no longer carry
+        discriminative value.
+        """
+        from agent_gantry.utils.registry_linter import (
+            analyze_registry as _analyze,
+        )
+
+        return await _analyze(
+            self,
+            similarity_threshold=similarity_threshold,
+            tag_overlap_share=tag_overlap_share,
+        )
+
+    async def pairwise_similarity(self, tool_a: str, tool_b: str) -> float:
+        """Cosine similarity between two registered tools' searchable text."""
+        from agent_gantry.utils.registry_linter import (
+            pairwise_similarity as _sim,
+        )
+
+        return await _sim(self, tool_a, tool_b)
+
     def export_tools(self) -> list[ToolDefinition]:
         """
         Export all registered and pending tools.

--- a/agent_gantry/integrations/__init__.py
+++ b/agent_gantry/integrations/__init__.py
@@ -5,10 +5,15 @@ Integrations with LangChain, AutoGen, LlamaIndex, CrewAI,
 Microsoft Agent Framework, etc.
 """
 
-from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+from agent_gantry.integrations.agent_framework_bridge import (
+    GantryToolBridge,
+    RetrievalCandidate,
+    RetrievalDecision,
+)
 from agent_gantry.integrations.agent_framework_middleware import (
     GantryApprovalMiddleware,
     GantryObservabilityMiddleware,
+    GantryToolChoiceMiddleware,
 )
 from agent_gantry.integrations.agent_framework_provider import (
     GantryContextProvider,
@@ -26,7 +31,10 @@ __all__: list[str] = [
     "GantryContextProvider",
     "GantryObservabilityMiddleware",
     "GantryToolBridge",
+    "GantryToolChoiceMiddleware",
     "MissingRequiredToolError",
+    "RetrievalCandidate",
+    "RetrievalDecision",
     "SemanticToolSelector",
     "SemanticToolsDecorator",
     "with_semantic_tools",

--- a/agent_gantry/integrations/agent_framework_bridge.py
+++ b/agent_gantry/integrations/agent_framework_bridge.py
@@ -37,6 +37,7 @@ import inspect
 import json
 import logging
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Annotated, Any
 
 from pydantic import Field
@@ -50,6 +51,136 @@ if TYPE_CHECKING:
     from agent_gantry.schema.tool import ToolDefinition
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RetrievalCandidate:
+    """A single tool that was considered during a retrieval round.
+
+    Carries the qualified name and the raw semantic score, plus a flag
+    indicating whether the candidate survived the configured score
+    threshold and was therefore eligible for injection into the LLM
+    prompt.
+    """
+
+    name: str
+    qualified_name: str
+    score: float
+    kept: bool
+
+
+@dataclass
+class RetrievalDecision:
+    """Structured record of *what just happened* during a retrieval round.
+
+    The dataclass is intentionally cheap to construct and pickle so it
+    can be attached to telemetry spans, dumped to logs, and inspected
+    from middleware. ``GantryContextProvider.last_selection`` exposes
+    the most-recent decision; the same shape is returned by
+    :meth:`GantryContextProvider.dry_run_retrieve`.
+
+    Fields:
+        query: The query string that drove this retrieval.
+        candidates: All candidates returned by the gantry, in score order.
+            Each carries a ``kept`` flag indicating whether it passed the
+            threshold filter.
+        injected: Names of tools that were ultimately injected into the
+            LLM tool list (top-K of candidates after thresholding, plus
+            always_include / required pins / skills, in injection order).
+        threshold: The effective ``score_threshold`` applied. ``None``
+            for the relative-threshold mode; ``effective_threshold`` carries
+            the resolved numeric cutoff for that case.
+        threshold_mode: ``"absolute"`` for a fixed cosine cutoff,
+            ``"relative:<frac>"`` for the relative mode.
+        effective_threshold: The numeric cutoff actually applied for this
+            round (the input ``threshold`` for absolute mode, or the
+            resolved ``frac * top_score`` for relative mode).
+    """
+
+    query: str = ""
+    candidates: list[RetrievalCandidate] = field(default_factory=list)
+    injected: list[str] = field(default_factory=list)
+    threshold: float | str | None = None
+    threshold_mode: str = "absolute"
+    effective_threshold: float | None = None
+
+    @property
+    def kept(self) -> list[RetrievalCandidate]:
+        """Candidates that passed the threshold filter."""
+        return [c for c in self.candidates if c.kept]
+
+    @property
+    def dropped(self) -> list[RetrievalCandidate]:
+        """Candidates that were dropped by the threshold filter."""
+        return [c for c in self.candidates if not c.kept]
+
+    def summary(self, top: int = 5) -> str:
+        """One-line ``INFO``-style summary, truncated to ``top`` candidates."""
+        head = self.candidates[:top]
+        rendered = ", ".join(f"{c.name}:{c.score:.2f}" for c in head)
+        q = (self.query or "").strip().replace("\n", " ")
+        if len(q) > 60:
+            q = q[:60] + "…"
+        return f'query="{q}" → top{min(top, len(head))}: [{rendered}]'
+
+    def as_span_attributes(self) -> dict[str, Any]:
+        """Flat attribute dict suitable for telemetry spans."""
+        return {
+            "query": self.query,
+            "threshold_mode": self.threshold_mode,
+            "effective_threshold": self.effective_threshold,
+            "candidate_count": len(self.candidates),
+            "injected_count": len(self.injected),
+            "candidates": [c.qualified_name for c in self.candidates],
+            "scores": [c.score for c in self.candidates],
+            "kept": [c.qualified_name for c in self.candidates if c.kept],
+            "injected": list(self.injected),
+        }
+
+
+def _parse_threshold(
+    threshold: float | str | None,
+) -> tuple[str, float | None]:
+    """Decode a ``score_threshold`` value into ``(mode, numeric)``.
+
+    Accepts:
+    - ``None`` → ``("absolute", None)`` (no filtering, equivalent to 0.0).
+    - ``float`` → ``("absolute", <value>)``.
+    - ``"relative:<frac>"`` → ``("relative", <frac>)`` where ``<frac>``
+      is the multiplier applied to the top candidate's score to produce
+      the cutoff for the round.
+    """
+    if threshold is None:
+        return "absolute", None
+    if isinstance(threshold, (int, float)):
+        return "absolute", float(threshold)
+    if isinstance(threshold, str):
+        s = threshold.strip().lower()
+        if s.startswith("relative:"):
+            try:
+                frac = float(s.split(":", 1)[1])
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid relative score_threshold {threshold!r}: "
+                    "expected 'relative:<float>' (e.g. 'relative:0.8')."
+                ) from exc
+            if not 0.0 <= frac <= 1.0:
+                raise ValueError(
+                    f"Relative score_threshold fraction must be in [0.0, 1.0], "
+                    f"got {frac}."
+                )
+            return "relative", frac
+        # Bare numeric strings — be forgiving.
+        try:
+            return "absolute", float(s)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid score_threshold {threshold!r}: expected a float "
+                f"or 'relative:<float>'."
+            ) from exc
+    raise TypeError(
+        f"score_threshold must be float, str, or None; got {type(threshold).__name__}."
+    )
 
 
 # Capabilities that indicate a tool is potentially destructive / requires
@@ -306,21 +437,25 @@ class GantryToolBridge:
 
     Args:
         gantry: The AgentGantry instance providing tool retrieval and execution.
-        score_threshold: Minimum relevance score for tool selection (default: 0.3).
+        score_threshold: Minimum relevance score for tool selection (default: 0.0).
+            Accepts a ``float`` (absolute cosine cutoff), the string
+            ``"relative:<frac>"`` (e.g. ``"relative:0.8"`` retains anything
+            within 80% of the top score), or ``None`` (no filtering).
     """
 
     def __init__(
         self,
         gantry: AgentGantry,
         *,
-        score_threshold: float = 0.3,
+        score_threshold: float | str | None = 0.0,
         as_function_tool: bool | None = None,
     ) -> None:
         """Initialize the bridge.
 
         Args:
             gantry: The AgentGantry instance providing tool retrieval and execution.
-            score_threshold: Minimum relevance score for tool selection (default: 0.3).
+            score_threshold: Minimum relevance score for tool selection
+                (default: ``0.0``; see class docstring for the relative mode).
             as_function_tool: Whether wrapped tools should be elevated to
                 ``agent_framework.FunctionTool`` via the ``@tool`` decorator.
                 ``None`` (default) = auto-detect (wrap if AF is importable);
@@ -328,6 +463,9 @@ class GantryToolBridge:
                 ``False`` = always return bare callables. Defaults produce the
                 most idiomatic AF behaviour without introducing a hard dep.
         """
+        # Validate the threshold eagerly so misconfiguration surfaces at
+        # construction time rather than on the first retrieval round.
+        _parse_threshold(score_threshold)
         self._gantry = gantry
         self._score_threshold = score_threshold
         self._as_function_tool = as_function_tool
@@ -338,13 +476,22 @@ class GantryToolBridge:
         query: str,
         *,
         limit: int = 5,
-        score_threshold: float | None = None,
+        score_threshold: float | str | None = None,
         **query_kwargs: Any,
     ) -> RetrievalResult:
-        """Shared retrieval logic for get_tools and get_tools_with_scores."""
+        """Shared retrieval logic for get_tools and get_tools_with_scores.
+
+        The relative threshold mode (``"relative:<frac>"``) cannot be
+        applied at the vector-store level (the cutoff is data-dependent),
+        so we issue the underlying gantry query without a score cutoff
+        and apply the filter post-hoc in :meth:`_apply_threshold`.
+        """
         from agent_gantry.schema.query import ConversationContext, ToolQuery
 
-        threshold = score_threshold if score_threshold is not None else self._score_threshold
+        threshold = (
+            score_threshold if score_threshold is not None else self._score_threshold
+        )
+        mode, _numeric = _parse_threshold(threshold)
 
         # Separate context-level kwargs from query-level kwargs
         context_fields = set(ConversationContext.model_fields.keys()) - {"query"}
@@ -352,14 +499,79 @@ class GantryToolBridge:
         tool_query_fields = set(ToolQuery.model_fields.keys()) - {"context", "limit", "score_threshold"}
         tq_kwargs = {k: v for k, v in query_kwargs.items() if k in tool_query_fields}
 
+        # Always push 0.0 to the underlying store and apply the threshold
+        # post-hoc in :meth:`_apply_threshold`. This costs a few extra
+        # candidates from the vector store (the router already over-fetches
+        # query.limit * 4 anyway) but lets the decision record list the
+        # tools that were dropped — without that, "score_threshold filtered
+        # every candidate" warnings are blind and the relative-threshold
+        # mode is impossible to implement.
         return await self._gantry.retrieve(
             ToolQuery(
                 context=ConversationContext(query=query, **context_kwargs),
-                limit=limit,
-                score_threshold=threshold,
+                limit=max(limit * 4, limit) if mode == "relative" else limit,
+                score_threshold=0.0,
                 **tq_kwargs,
             )
         )
+
+    def _apply_threshold(
+        self,
+        scored: list[Any],
+        *,
+        threshold: float | str | None,
+        limit: int,
+    ) -> tuple[list[Any], RetrievalDecision]:
+        """Filter scored tools by threshold and return a decision record.
+
+        ``scored`` is the list of ``ScoredTool`` from
+        :class:`RetrievalResult.tools`. The returned tuple is
+        ``(kept_top_K, decision)`` where ``kept_top_K`` honours ``limit``.
+        """
+        effective = threshold if threshold is not None else self._score_threshold
+        mode, numeric = _parse_threshold(effective)
+
+        if not scored:
+            return [], RetrievalDecision(
+                threshold=effective,
+                threshold_mode=mode
+                if mode == "absolute"
+                else f"relative:{numeric}",
+                effective_threshold=None,
+            )
+
+        if mode == "relative" and numeric is not None:
+            top_score = max(st.semantic_score for st in scored)
+            cutoff = top_score * numeric
+        else:
+            cutoff = numeric or 0.0
+
+        candidates: list[RetrievalCandidate] = []
+        kept: list[Any] = []
+        for st in scored:
+            score = float(st.semantic_score)
+            keep = score >= cutoff
+            candidates.append(
+                RetrievalCandidate(
+                    name=st.tool.name,
+                    qualified_name=f"{st.tool.namespace}.{st.tool.name}",
+                    score=score,
+                    kept=keep,
+                )
+            )
+            if keep:
+                kept.append(st)
+
+        kept_top = kept[:limit]
+        decision = RetrievalDecision(
+            candidates=candidates,
+            threshold=effective,
+            threshold_mode=mode
+            if mode == "absolute"
+            else f"relative:{numeric}",
+            effective_threshold=cutoff,
+        )
+        return kept_top, decision
 
     def _get_or_build(
         self,
@@ -384,7 +596,7 @@ class GantryToolBridge:
         query: str,
         *,
         limit: int = 5,
-        score_threshold: float | None = None,
+        score_threshold: float | str | None = None,
         cache: bool = True,
         **query_kwargs: Any,
     ) -> list[Any]:
@@ -400,6 +612,10 @@ class GantryToolBridge:
             query: The user query or task description to match tools against.
             limit: Maximum number of tools to return (default: 5).
             score_threshold: Override the bridge's default score threshold.
+                Accepts a ``float`` (absolute cosine cutoff), the string
+                ``"relative:<frac>"`` (e.g. ``"relative:0.8"`` keeps
+                anything within 80% of the top score), or ``None`` (use
+                the bridge default).
             cache: Whether to reuse previously wrapped callables for the same
                    tool (avoids re-creating wrappers). Default: True.
             **query_kwargs: Additional keyword arguments passed through to
@@ -411,19 +627,101 @@ class GantryToolBridge:
         Returns:
             List of async callables suitable for AF agent ``tools=[...]``.
         """
-        result = await self._retrieve(
-            query, limit=limit, score_threshold=score_threshold, **query_kwargs
-        )
-
-        tools = [self._get_or_build(st.tool, cache) for st in result.tools]
-
-        logger.debug(
-            "GantryToolBridge: selected %d/%d tools for query '%s'",
-            len(tools),
-            result.candidate_count,
-            query[:50],
+        tools, _ = await self.get_tools_with_decision(
+            query,
+            limit=limit,
+            score_threshold=score_threshold,
+            cache=cache,
+            **query_kwargs,
         )
         return tools
+
+    async def get_tools_with_decision(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        score_threshold: float | str | None = None,
+        cache: bool = True,
+        **query_kwargs: Any,
+    ) -> tuple[list[Any], RetrievalDecision]:
+        """Same as :meth:`get_tools` but also returns the decision record.
+
+        Returns the ranked candidate list (passed and dropped by the
+        threshold filter), the final injected list, and the effective
+        threshold — enough to make the routing path self-diagnosable
+        from outside the library. See :class:`RetrievalDecision`.
+
+        Wraps the retrieval in a ``gantry.bridge_retrieval`` telemetry
+        span carrying the candidate list and scores as attributes so
+        OpenTelemetry consumers see the ranked decision in their
+        tracing backend.
+        """
+        from agent_gantry.utils.async_utils import AsyncNoopContext
+
+        telemetry = getattr(self._gantry, "_telemetry", None)
+        span_attrs: dict[str, Any] = {
+            "query": query,
+            "limit": limit,
+            "score_threshold": (
+                score_threshold
+                if score_threshold is not None
+                else self._score_threshold
+            ),
+        }
+        span_cm = (
+            telemetry.span("gantry.bridge_retrieval", span_attrs)
+            if telemetry
+            else AsyncNoopContext()
+        )
+
+        async with span_cm:
+            result = await self._retrieve(
+                query, limit=limit, score_threshold=score_threshold, **query_kwargs
+            )
+
+            # Threshold filtering happens post-hoc so the decision record can
+            # see both kept and dropped candidates regardless of whether the
+            # threshold was relative or absolute.
+            kept_top, decision = self._apply_threshold(
+                list(result.tools), threshold=score_threshold, limit=limit
+            )
+            decision.query = query
+            tools = [self._get_or_build(st.tool, cache) for st in kept_top]
+            decision.injected = [st.tool.name for st in kept_top]
+
+            # Enrich the span with the structured decision. Telemetry
+            # adapters in this codebase store the same dict instance they
+            # were handed at span open, so mutating it now persists the
+            # candidates list onto the recorded span.
+            try:
+                span_attrs.update(decision.as_span_attributes())
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+            # If threshold filtered everything out, surface a WARNING so
+            # users don't see "empty surface" without context.
+            if result.tools and not kept_top:
+                logger.warning(
+                    "GantryToolBridge: score_threshold %s filtered out all %d "
+                    "candidates for query %r. Top scores: %s",
+                    decision.threshold_mode
+                    if decision.threshold == 0.0
+                    else decision.threshold,
+                    len(result.tools),
+                    query[:80],
+                    ", ".join(
+                        f"{c.name}:{c.score:.3f}" for c in decision.candidates[:5]
+                    ),
+                )
+
+            logger.debug(
+                "GantryToolBridge: selected %d/%d tools for query '%s'",
+                len(tools),
+                result.candidate_count,
+                query[:50],
+            )
+            return tools, decision
 
     def wrap_tools(
         self,
@@ -467,7 +765,7 @@ class GantryToolBridge:
         query: str,
         *,
         limit: int = 5,
-        score_threshold: float | None = None,
+        score_threshold: float | str | None = None,
         cache: bool = True,
         **query_kwargs: Any,
     ) -> list[tuple[Any, float]]:
@@ -493,9 +791,13 @@ class GantryToolBridge:
             query, limit=limit, score_threshold=score_threshold, **query_kwargs
         )
 
+        kept_top, _ = self._apply_threshold(
+            list(result.tools), threshold=score_threshold, limit=limit
+        )
+
         return [
             (self._get_or_build(st.tool, cache), st.final_score)
-            for st in result.tools
+            for st in kept_top
         ]
 
     # ------------------------------------------------------------------

--- a/agent_gantry/integrations/agent_framework_bridge.py
+++ b/agent_gantry/integrations/agent_framework_bridge.py
@@ -183,6 +183,14 @@ def _parse_threshold(
     )
 
 
+# Mirror of the ``le`` constraint on ``ToolQuery.limit`` (see
+# ``agent_gantry/schema/query.py``). Kept as a module-level constant so the
+# bridge can clamp its relative-mode over-fetch without re-introspecting
+# the Pydantic model at call time. If the schema's upper bound changes,
+# update this constant.
+_TOOL_QUERY_MAX_LIMIT = 50
+
+
 # Capabilities that indicate a tool is potentially destructive / requires
 # explicit human approval in production. Mapped to AF's
 # ``approval_mode="always_require"`` so that AF surfaces an approval event
@@ -506,10 +514,22 @@ class GantryToolBridge:
         # tools that were dropped — without that, "score_threshold filtered
         # every candidate" warnings are blind and the relative-threshold
         # mode is impossible to implement.
+        #
+        # Relative mode also needs the full candidate pool so the cutoff
+        # is computed correctly, so we over-fetch by 4×. Clamp to
+        # ``ToolQuery.limit``'s upper bound (50) — without the clamp,
+        # callers using ``limit >= 13`` with a relative threshold hit a
+        # Pydantic validation error on the ``ToolQuery`` construction
+        # below.
+        if mode == "relative":
+            store_limit = min(_TOOL_QUERY_MAX_LIMIT, max(limit * 4, limit))
+        else:
+            store_limit = limit
+
         return await self._gantry.retrieve(
             ToolQuery(
                 context=ConversationContext(query=query, **context_kwargs),
-                limit=max(limit * 4, limit) if mode == "relative" else limit,
+                limit=store_limit,
                 score_threshold=0.0,
                 **tq_kwargs,
             )
@@ -542,7 +562,15 @@ class GantryToolBridge:
 
         if mode == "relative" and numeric is not None:
             top_score = max(st.semantic_score for st in scored)
-            cutoff = top_score * numeric
+            # ``ScoredTool.semantic_score`` is Pydantic-clamped to ``[0, 1]``
+            # so this is the common path. Guard against the degenerate
+            # ``top_score <= 0`` case anyway — multiplying a negative top
+            # by a positive fraction produces a cutoff *above* the top
+            # score and silently drops every candidate including the
+            # best one. When that happens, fall back to ``0.0`` so the
+            # ranking is preserved and the (zero-scoring) candidates are
+            # at least visible to the caller via the decision record.
+            cutoff = top_score * numeric if top_score > 0 else 0.0
         else:
             cutoff = numeric or 0.0
 
@@ -700,14 +728,24 @@ class GantryToolBridge:
                 pass
 
             # If threshold filtered everything out, surface a WARNING so
-            # users don't see "empty surface" without context.
+            # users don't see "empty surface" without context. Always log
+            # the configured threshold (and the resolved cutoff for the
+            # relative mode) so the message explains *which* cutoff
+            # dropped the candidates, not just the mode name.
             if result.tools and not kept_top:
+                if decision.threshold_mode.startswith("relative") and (
+                    decision.effective_threshold is not None
+                ):
+                    threshold_repr = (
+                        f"{decision.threshold} "
+                        f"(cutoff={decision.effective_threshold:.3f})"
+                    )
+                else:
+                    threshold_repr = repr(decision.threshold)
                 logger.warning(
                     "GantryToolBridge: score_threshold %s filtered out all %d "
                     "candidates for query %r. Top scores: %s",
-                    decision.threshold_mode
-                    if decision.threshold == 0.0
-                    else decision.threshold,
+                    threshold_repr,
                     len(result.tools),
                     query[:80],
                     ", ".join(

--- a/agent_gantry/integrations/agent_framework_middleware.py
+++ b/agent_gantry/integrations/agent_framework_middleware.py
@@ -41,6 +41,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _import_af_chat_middleware() -> Any:
+    """Lazy import of ``agent_framework.chat_middleware``."""
+    try:
+        from agent_framework import chat_middleware
+    except ImportError as exc:  # pragma: no cover - depends on install
+        raise ImportError(
+            "Agent-Framework chat middleware requires the 'agent-framework' "
+            "package. Install with: pip install 'agent-gantry[agent-frameworks]'"
+        ) from exc
+    return chat_middleware
+
+
 def _import_af_middleware_bits() -> tuple[Any, Any]:
     """Lazy import of AF symbols; raises a helpful ImportError otherwise.
 
@@ -204,7 +216,85 @@ class GantryObservabilityMiddleware:
         return observability_cls(gantry)
 
 
+class GantryToolChoiceMiddleware:
+    """Chat middleware that modulates ``tool_choice`` per round.
+
+    AF's ``tool_choice`` is a single global setting on the agent; a
+    common pattern is "force a tool call for the first N rounds of a
+    pipeline so the model can't bail to text, then allow text on the
+    summarisation turn". This middleware solves that by re-deriving
+    ``tool_choice`` on every chat-completion round from a user-supplied
+    callable.
+
+    The callable receives the AF chat-middleware ``context`` and may
+    return any of:
+
+    - ``"auto"`` (let the model choose),
+    - ``"required"`` (force a tool call),
+    - ``"none"`` (text only),
+    - A dict in AF / OpenAI tool-choice shape (e.g.
+      ``{"type": "function", "function": {"name": "..."}}``),
+    - ``None`` (don't touch the existing value).
+
+    The callable may be sync or async. Counting rounds is left to the
+    caller — the simplest pattern is to close over a counter::
+
+        rounds = {"n": 0}
+        def choice(ctx):
+            rounds["n"] += 1
+            return "required" if rounds["n"] <= 5 else "auto"
+        agent = Agent(client, "...", middleware=[
+            provider.as_chat_middleware(),
+            GantryToolChoiceMiddleware(choice),
+        ])
+    """
+
+    def __new__(cls, decider: Any) -> Any:
+        chat_middleware = _import_af_chat_middleware()
+        import inspect
+
+        is_async = inspect.iscoroutinefunction(decider)
+
+        @chat_middleware
+        async def _tool_choice_mw(context: Any, call_next: Any) -> None:
+            try:
+                choice = (
+                    await decider(context) if is_async else decider(context)
+                )
+            except Exception:
+                logger.exception(
+                    "GantryToolChoiceMiddleware: decider raised; leaving "
+                    "tool_choice unchanged."
+                )
+                choice = None
+
+            if choice is not None:
+                options = getattr(context, "options", None)
+                if isinstance(options, dict):
+                    options["tool_choice"] = choice
+                elif options is not None:
+                    try:
+                        setattr(options, "tool_choice", choice)
+                    except (AttributeError, TypeError, ValueError):
+                        if hasattr(options, "model_copy"):
+                            try:
+                                context.options = options.model_copy(
+                                    update={"tool_choice": choice}
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "GantryToolChoiceMiddleware: could not "
+                                    "set tool_choice on options of type %r.",
+                                    type(options).__name__,
+                                )
+
+            await call_next()
+
+        return _tool_choice_mw
+
+
 __all__ = [
     "GantryApprovalMiddleware",
     "GantryObservabilityMiddleware",
+    "GantryToolChoiceMiddleware",
 ]

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -877,7 +877,7 @@ class GantryContextProvider:
                         "GantryContextProvider: query_generator raised; falling "
                         "back to last_user_text."
                     )
-                    return _default_query_generator(messages)
+                    return last_user_text(messages)
 
             def _resolve_skill_registry(self) -> SkillRegistry | None:
                 if self._skill_registry is not None:

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -73,8 +73,27 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
-from agent_gantry.query import last_user_text as _default_query_generator
+from agent_gantry.integrations.agent_framework_bridge import (
+    GantryToolBridge,
+    RetrievalDecision,
+)
+from agent_gantry.query import (
+    fallback_chain,
+    last_tool_result,
+    last_user_text,
+)
+
+_DEFAULT_PER_RUN_QUERY = last_user_text
+
+
+def _default_per_call_query() -> Any:
+    """Recommended ``per_call`` default — tool result, then user text.
+
+    Built lazily so the composed callable is fresh each time
+    (``fallback_chain`` is cheap; the indirection just avoids a global).
+    """
+    return fallback_chain(last_tool_result, last_user_text)
+
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -146,19 +165,31 @@ class GantryContextProvider:
             providing semantic retrieval and execution.
         top_k: Maximum number of dynamically retrieved tools per chat-completion
             round (or per ``agent.run`` call in ``per_run`` mode). Defaults
-            to ``5``.
+            to ``5``. Note: ``top_k`` governs only the *dynamic* selection.
+            Tools contributed by skills, by ``always_include`` / ``required``,
+            and by ``static_tools`` are appended on top of the ``top_k``
+            slice. A user setting ``top_k=6`` with one skill and one
+            always-include tool will see ``6 + 2 = 8`` tools.
         score_threshold: Minimum semantic relevance score for retrieved
-            tools. Defaults to ``0.3``.
+            tools. Defaults to ``0.0`` (no filtering). Long queries dilute
+            absolute cosine similarities, so the previous ``0.3`` default
+            silently filtered relevant tools on multi-step pipelines.
+            Accepts either a ``float`` (absolute cosine cutoff) or the
+            string ``"relative:<frac>"`` (e.g. ``"relative:0.8"`` retains
+            anything within 80% of the top score) for length-robust
+            filtering.
         query_strategy: ``"per_run"`` (default) refreshes the tool selection
             once at the start of ``agent.run()``. ``"per_call"`` re-runs
             retrieval on every chat-completion round; pair this mode with
             :meth:`as_chat_middleware` to install the per-round refresher.
         query_generator: Callable used to derive the retrieval query string
-            from the conversation messages. Defaults to
-            :func:`agent_gantry.query.last_user_text`. Sync or async are both
-            accepted. See :mod:`agent_gantry.query` for built-in alternatives
-            (``last_tool_result``, ``last_assistant_text``, ``concatenate_recent``,
-            ``fallback_chain``).
+            from the conversation messages. When ``None`` the default
+            depends on ``query_strategy``: ``last_user_text`` for
+            ``per_run`` (back-compat), and ``fallback_chain(last_tool_result,
+            last_user_text)`` for ``per_call`` — the latter is what makes
+            ``per_call`` actually adapt across rounds. Sync or async are
+            both accepted. See :mod:`agent_gantry.query` for the built-in
+            alternatives.
         skills: When ``True``, every invocation also injects the union of
             tools bound to all registered Gantry skills (from the supplied
             ``skill_registry`` if any, else the registry attached to the
@@ -191,6 +222,16 @@ class GantryContextProvider:
         bridge: Optional pre-built :class:`GantryToolBridge` to reuse its
             wrapper cache across multiple providers. When ``None`` a new
             bridge is built from the supplied ``gantry``.
+        static_tools: AF-native tools (or any objects accepted by
+            ``Agent(tools=[...])``) that should be appended to every
+            round's surface. Unlike ``always_include`` — which pins
+            *gantry-registered* tools by name — ``static_tools`` is for
+            tools that live outside the gantry registry. They are never
+            filtered by the per-call refresh.
+        verbose: When ``True`` (default ``False``), the provider logs a
+            one-line INFO summary of every retrieval round:
+            ``gantry: query="…" → top5: [name:0.61, …]``. Sets the
+            ``agent_gantry`` logger to INFO if it has no level set.
         **query_kwargs: Additional keyword arguments forwarded to
             :meth:`GantryToolBridge.get_tools` (e.g. ``namespaces``,
             ``required_capabilities``, ``enable_reranking``).
@@ -227,16 +268,18 @@ class GantryContextProvider:
         gantry: AgentGantry,
         *,
         top_k: int = 5,
-        score_threshold: float = 0.3,
+        score_threshold: float | str = 0.0,
         query_strategy: str = "per_run",
         query_generator: Callable[..., Any] | None = None,
         skills: bool = False,
         skill_registry: SkillRegistry | None = None,
         always_include: list[str] | None = None,
         required: list[str] | None = None,
+        static_tools: list[Any] | None = None,
         as_function_tool: bool | None = None,
         source_id: str = "agent_gantry",
         bridge: GantryToolBridge | None = None,
+        verbose: bool = False,
         **query_kwargs: Any,
     ) -> Any:
         if query_strategy not in ("per_run", "per_call"):
@@ -253,7 +296,27 @@ class GantryContextProvider:
         )
         always_include = list(always_include or [])
         required = list(required or [])
-        query_generator = query_generator or _default_query_generator
+        static_tools_list: list[Any] = list(static_tools or [])
+
+        # Default query generator depends on strategy: per_call wants
+        # round-to-round adaptation, so the historical last_user_text
+        # default (which returns the same string every round) would
+        # silently disable the very thing per_call enables.
+        if query_generator is None:
+            if query_strategy == "per_call":
+                query_generator = _default_per_call_query()
+            else:
+                query_generator = _DEFAULT_PER_RUN_QUERY
+        elif (
+            query_strategy == "per_call"
+            and query_generator is last_user_text
+        ):
+            logger.warning(
+                "GantryContextProvider: query_strategy='per_call' was set "
+                "but query_generator=last_user_text returns the same string "
+                "every round, defeating per-call adaptation. Consider "
+                "fallback_chain(last_tool_result, last_user_text) instead."
+            )
 
         if required:
             known = gantry.list_tools_sync()
@@ -291,8 +354,20 @@ class GantryContextProvider:
                 self._always_include = always_include_effective
                 self._declared_always_include = list(always_include)
                 self._required = list(required)
+                self._static_tools = list(static_tools_list)
                 self._query_kwargs = dict(query_kwargs)
                 self._source_id = source_id
+                self._verbose = verbose
+                self._last_selection: RetrievalDecision | None = None
+                # One-shot warnings: we don't want to spam the log every
+                # round even when the misconfiguration persists.
+                self._warned_about_missing_chat_middleware = False
+                self._logged_top_k_math = False
+                if verbose:
+                    # Don't override a user-configured level; only nudge
+                    # when the logger has no explicit level set.
+                    if logger.level == logging.NOTSET:
+                        logger.setLevel(logging.INFO)
 
             # ----- Public, read-only configuration accessors --------------
             @property
@@ -323,6 +398,21 @@ class GantryContextProvider:
             def bridge(self) -> GantryToolBridge:
                 return self._bridge
 
+            @property
+            def static_tools(self) -> tuple[Any, ...]:
+                return tuple(self._static_tools)
+
+            @property
+            def last_selection(self) -> RetrievalDecision | None:
+                """The most recent retrieval decision, or ``None``.
+
+                Cleared/replaced on every ``before_run`` (per_run mode) or
+                every chat-middleware tick (per_call mode). Read this from
+                middleware, tests, or interactive sessions to diagnose
+                "why did the LLM not see tool X this round?".
+                """
+                return self._last_selection
+
             # ----- AF lifecycle ------------------------------------------
             async def before_run(
                 self,
@@ -332,6 +422,26 @@ class GantryContextProvider:
                 context: Any,
                 state: dict[str, Any],
             ) -> None:
+                # per_call mode requires the chat middleware to do the
+                # actual per-round refresh. If the user forgot to attach
+                # it, the agent silently degrades to per_run behaviour
+                # with extra plumbing — warn once so the misconfiguration
+                # is visible without strangers reading the source.
+                if (
+                    self._query_strategy == "per_call"
+                    and not self._warned_about_missing_chat_middleware
+                    and not self._chat_middleware_attached(agent)
+                ):
+                    self._warned_about_missing_chat_middleware = True
+                    logger.warning(
+                        "GantryContextProvider: query_strategy='per_call' is "
+                        "enabled but as_chat_middleware() does not appear to "
+                        "be attached to the agent — the provider will fall "
+                        "back to per_run behaviour. Pass "
+                        "middleware=[provider.as_chat_middleware()] to your "
+                        "Agent(...) or use provider.attach_to(agent)."
+                    )
+
                 # In per_call mode, the chat_middleware does the dynamic
                 # retrieval per LLM round; we still inject always_include /
                 # skill tools at run-start so they are present even if the
@@ -348,6 +458,110 @@ class GantryContextProvider:
                         len(tools),
                         self._query_strategy,
                     )
+
+            # ----- Setup helpers -----------------------------------------
+            def attach_to(self, agent: Any) -> Any:
+                """Register this provider and its chat middleware on ``agent``.
+
+                Single-call helper for the common ``per_call`` setup. Does
+                the dance of appending to ``agent.context_providers`` and
+                ``agent.middleware`` (whichever attribute the AF version
+                exposes), creating the lists if missing. Returns
+                ``agent`` for chaining.
+
+                The chat middleware is only attached when
+                ``query_strategy='per_call'`` — in ``per_run`` mode it's
+                a no-op and would just add overhead. The context
+                provider is always attached.
+                """
+                # context_providers
+                providers_attr = self._first_present_attr(
+                    agent, ("context_providers", "_context_providers")
+                )
+                if providers_attr is not None:
+                    current = getattr(agent, providers_attr) or []
+                    if self not in current:
+                        try:
+                            setattr(agent, providers_attr, [*current, self])
+                        except (AttributeError, TypeError):
+                            try:
+                                current.append(self)
+                            except Exception:
+                                logger.warning(
+                                    "GantryContextProvider.attach_to: could "
+                                    "not attach context provider to agent %r.",
+                                    type(agent).__name__,
+                                )
+                else:
+                    logger.warning(
+                        "GantryContextProvider.attach_to: agent %r has no "
+                        "context_providers attribute; the provider was not "
+                        "attached.",
+                        type(agent).__name__,
+                    )
+
+                # middleware (per_call only)
+                if self._query_strategy == "per_call":
+                    middleware_attr = self._first_present_attr(
+                        agent, ("middleware", "_middleware")
+                    )
+                    mw = self.as_chat_middleware()
+                    if middleware_attr is not None:
+                        current_mw = getattr(agent, middleware_attr) or []
+                        try:
+                            setattr(agent, middleware_attr, [*current_mw, mw])
+                        except (AttributeError, TypeError):
+                            try:
+                                current_mw.append(mw)
+                            except Exception:
+                                logger.warning(
+                                    "GantryContextProvider.attach_to: could "
+                                    "not attach chat middleware to agent %r.",
+                                    type(agent).__name__,
+                                )
+                    else:
+                        logger.warning(
+                            "GantryContextProvider.attach_to: agent %r has "
+                            "no middleware attribute; chat middleware was "
+                            "not attached.",
+                            type(agent).__name__,
+                        )
+                return agent
+
+            @staticmethod
+            def _first_present_attr(obj: Any, names: tuple[str, ...]) -> str | None:
+                for n in names:
+                    if hasattr(obj, n):
+                        return n
+                return None
+
+            def _chat_middleware_attached(self, agent: Any) -> bool:
+                """Best-effort check for ``as_chat_middleware`` on the agent.
+
+                Heuristic: look for any middleware whose qualified name
+                contains the provider's sentinel ``_per_call_retrieval``.
+                AF wraps the decorated coroutine into different objects
+                across versions, so we just match on the name.
+                """
+                if agent is None:
+                    return True  # don't warn when there's nothing to inspect
+                mw_attr = self._first_present_attr(
+                    agent, ("middleware", "_middleware")
+                )
+                if mw_attr is None:
+                    return True
+                middlewares = getattr(agent, mw_attr) or []
+                for m in middlewares:
+                    candidates = (
+                        getattr(m, "__name__", None),
+                        getattr(m, "__qualname__", None),
+                        getattr(getattr(m, "func", None), "__name__", None),
+                        type(m).__name__,
+                    )
+                    for c in candidates:
+                        if isinstance(c, str) and "_per_call_retrieval" in c:
+                            return True
+                return False
 
             # ----- Per-call middleware factory ---------------------------
             def as_chat_middleware(self) -> Any:
@@ -423,13 +637,24 @@ class GantryContextProvider:
                 fresh, _ = await self._collect_tools(
                     messages, include_dynamic=True
                 )
+                # _collect_tools sets self._last_selection on every
+                # dynamic refresh, so the per-call middleware path
+                # automatically exposes the latest decision via the
+                # provider's `last_selection` property.
                 gantry_names = self._all_known_tool_names()
+                static_names = {
+                    _tool_name(t) for t in self._static_tools if _tool_name(t)
+                }
 
                 preserved = []
                 dropped = 0
                 for t in existing:
                     name = _tool_name(t)
-                    if name and name in gantry_names:
+                    # Drop stale gantry-known tools so the per-round
+                    # surface stays bounded. Static tools may appear in
+                    # both `existing` (carried across rounds) and `fresh`
+                    # (we re-add them ourselves); dedup happens below.
+                    if name and name in gantry_names and name not in static_names:
                         dropped += 1
                         continue
                     preserved.append(t)
@@ -524,16 +749,19 @@ class GantryContextProvider:
             ) -> tuple[list[Any], set[str]]:
                 tools: list[Any] = []
                 seen: set[str] = set()
+                decision: RetrievalDecision | None = None
 
                 if include_dynamic:
                     query = await self._build_query(messages)
                     if query:
                         try:
-                            retrieved = await self._bridge.get_tools(
-                                query,
-                                limit=self._top_k,
-                                score_threshold=self._score_threshold,
-                                **self._query_kwargs,
+                            retrieved, decision = (
+                                await self._bridge.get_tools_with_decision(
+                                    query,
+                                    limit=self._top_k,
+                                    score_threshold=self._score_threshold,
+                                    **self._query_kwargs,
+                                )
                             )
                         except Exception:
                             logger.exception(
@@ -550,19 +778,95 @@ class GantryContextProvider:
                             tools.append(t)
 
                 # Skills: always-on tools bound to registered Gantry skills.
+                skill_count = 0
                 if self._skills_enabled:
                     skill_tool_names = self._collect_skill_tool_names()
                     extra = self._wrap_named(skill_tool_names, seen, source="skill")
                     tools.extend(extra)
+                    skill_count = len(extra)
 
                 # Explicit always_include / required pins.
+                always_count = 0
                 if self._always_include:
                     extra = self._wrap_named(
                         self._always_include, seen, source="always_include"
                     )
                     tools.extend(extra)
+                    always_count = len(extra)
+
+                # Static AF-native tools that live outside the gantry registry.
+                static_count = 0
+                for t in self._static_tools:
+                    name = _tool_name(t)
+                    if name and name in seen:
+                        continue
+                    if name:
+                        seen.add(name)
+                    tools.append(t)
+                    static_count += 1
+
+                if include_dynamic and decision is not None:
+                    self._last_selection = decision
+                    if self._verbose:
+                        logger.info("gantry: %s", decision.summary())
+
+                # One-shot info log clarifying the top_k math whenever
+                # non-dynamic contributions raise the surface above top_k.
+                extra_total = skill_count + always_count + static_count
+                if (
+                    include_dynamic
+                    and extra_total > 0
+                    and not self._logged_top_k_math
+                ):
+                    self._logged_top_k_math = True
+                    logger.info(
+                        "GantryContextProvider: dynamic top_k=%d + %d preserved "
+                        "(skills=%d, always_include=%d, static=%d). The final "
+                        "tool surface is the dynamic slice plus preserved tools.",
+                        self._top_k,
+                        extra_total,
+                        skill_count,
+                        always_count,
+                        static_count,
+                    )
 
                 return tools, seen
+
+            async def dry_run_retrieve(
+                self,
+                query: str,
+                *,
+                limit: int | None = None,
+                score_threshold: float | str | None = None,
+            ) -> RetrievalDecision:
+                """Run the live retrieval path against a synthetic query.
+
+                Uses the *exact same* threshold, top_k, and ``query_kwargs``
+                as the live middleware. Use this to diagnose why a tool
+                is or is not surfacing without spinning up an agent.
+
+                Args:
+                    query: The query string to retrieve against.
+                    limit: Override ``top_k`` for this call only.
+                    score_threshold: Override the threshold for this call
+                        only (accepts the same forms as the constructor).
+
+                Returns:
+                    The :class:`RetrievalDecision` produced by the bridge.
+                """
+                eff_limit = self._top_k if limit is None else limit
+                eff_threshold = (
+                    self._score_threshold
+                    if score_threshold is None
+                    else score_threshold
+                )
+                _, decision = await self._bridge.get_tools_with_decision(
+                    query,
+                    limit=eff_limit,
+                    score_threshold=eff_threshold,
+                    **self._query_kwargs,
+                )
+                return decision
 
             async def _build_query(self, messages: Any) -> str:
                 try:

--- a/agent_gantry/query/__init__.py
+++ b/agent_gantry/query/__init__.py
@@ -47,15 +47,19 @@ from __future__ import annotations
 from agent_gantry.query.strategies import (
     concatenate_recent,
     fallback_chain,
+    keyword_focused,
     last_assistant_text,
     last_tool_result,
     last_user_text,
+    truncated,
 )
 
 __all__ = [
     "concatenate_recent",
     "fallback_chain",
+    "keyword_focused",
     "last_assistant_text",
     "last_tool_result",
     "last_user_text",
+    "truncated",
 ]

--- a/agent_gantry/query/strategies.py
+++ b/agent_gantry/query/strategies.py
@@ -190,6 +190,137 @@ def concatenate_recent(
     return separator.join(p.strip() for p in parts)
 
 
+# Imperative scaffolding tokens that crowd out content nouns/verbs in
+# instruction-style queries. Lowered for case-insensitive matching.
+_SCAFFOLD_TOKENS: frozenset[str] = frozenset(
+    {
+        "please", "kindly", "thanks", "thank", "you", "your", "yours",
+        "must", "should", "shall", "will", "would", "could", "can",
+        "do", "don't", "dont", "not", "no", "never", "always",
+        "i", "me", "my", "we", "us", "our", "ours",
+        "the", "a", "an", "this", "that", "these", "those",
+        "is", "are", "was", "were", "be", "been", "being", "am",
+        "have", "has", "had", "having",
+        "to", "from", "of", "in", "on", "at", "by", "for", "with",
+        "and", "or", "but", "if", "then", "else", "so", "as",
+        "step", "steps", "first", "next", "last", "final", "finally",
+        "use", "using", "run", "make", "ensure", "remember",
+        "different", "each", "every", "any", "some", "one", "two",
+        "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+        "pipeline", "task", "instruction", "instructions",
+        "it", "its", "they", "them", "their",
+    }
+)
+
+
+_KEYWORD_TOKEN_RE = None  # type: ignore[var-annotated]
+
+
+def _tokenize_for_keywords(text: str) -> list[str]:
+    """Split into alpha/numeric tokens, lowercase."""
+    import re
+
+    global _KEYWORD_TOKEN_RE
+    if _KEYWORD_TOKEN_RE is None:
+        _KEYWORD_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_]*")
+    return [m.group(0).lower() for m in _KEYWORD_TOKEN_RE.finditer(text)]
+
+
+def keyword_focused(
+    messages: Iterable[Any] | None,
+    *,
+    max_tokens: int = 32,
+    base: Callable[[Iterable[Any] | None], str] | None = None,
+) -> str:
+    """Strip imperative scaffolding from the conversation tail.
+
+    Long instructional queries ("Please run this five-step pipeline. Do
+    not skip steps...") dilute the embedding signal because most of the
+    text is verbs of obligation and connective tissue rather than the
+    nouns/verbs that describe what tool you actually want. This
+    generator pulls a base text out of the messages (default:
+    :func:`last_user_text`), drops obvious scaffolding tokens, and keeps
+    the residual content words.
+
+    Args:
+        messages: Conversation history (most recent last).
+        max_tokens: Cap on the number of retained tokens. Defaults to 32.
+        base: Generator used to extract the source text. Defaults to
+            :func:`last_user_text`.
+
+    Returns:
+        A space-joined string of retained tokens (lowercased). Returns
+        the empty string when the base generator does.
+    """
+    base_fn = base or last_user_text
+    raw = base_fn(messages)
+    if not raw or not raw.strip():
+        return ""
+    tokens = _tokenize_for_keywords(raw)
+    kept: list[str] = []
+    for tok in tokens:
+        if len(tok) < 2:
+            continue
+        if tok in _SCAFFOLD_TOKENS:
+            continue
+        kept.append(tok)
+        if len(kept) >= max_tokens:
+            break
+    return " ".join(kept)
+
+
+def truncated(
+    generator: Callable[..., Any],
+    *,
+    max_chars: int = 200,
+    keep: str = "tail",
+) -> Callable[[Iterable[Any] | None], Any]:
+    """Wrap a generator to cap the produced query length.
+
+    Sync and async generators are both supported; the returned wrapper
+    mirrors the underlying coroutine-ness so it plugs into
+    ``GantryContextProvider`` without further adaptation.
+
+    Args:
+        generator: The generator to wrap.
+        max_chars: Maximum number of characters in the output. Defaults
+            to 200.
+        keep: ``"tail"`` (default) keeps the final ``max_chars``
+            characters — typically the latest tool output. ``"head"``
+            keeps the leading ``max_chars`` characters.
+
+    Returns:
+        A new generator with the same call shape as ``generator``.
+    """
+    if keep not in ("head", "tail"):
+        raise ValueError(f"keep must be 'head' or 'tail', got {keep!r}")
+
+    def _cap(text: str) -> str:
+        if not text:
+            return ""
+        if len(text) <= max_chars:
+            return text
+        if keep == "tail":
+            return text[-max_chars:]
+        return text[:max_chars]
+
+    import inspect
+
+    if inspect.iscoroutinefunction(generator):
+
+        async def _async_wrapper(messages: Iterable[Any] | None) -> str:
+            value = await generator(messages)
+            return _cap(value or "")
+
+        return _async_wrapper
+
+    def _wrapper(messages: Iterable[Any] | None) -> str:
+        value = generator(messages)
+        return _cap(value or "")
+
+    return _wrapper
+
+
 def fallback_chain(
     *generators: Callable[[Iterable[Any] | None], str],
 ) -> Callable[[Iterable[Any] | None], str]:

--- a/agent_gantry/skills/__init__.py
+++ b/agent_gantry/skills/__init__.py
@@ -1,0 +1,88 @@
+"""
+Bundled Claude Skill describing how to use Agent-Gantry.
+
+The skill itself lives at ``agent_gantry/skills/agent-gantry/SKILL.md`` and
+is shipped inside the wheel so it is discoverable without extra downloads.
+Two helpers are exposed for callers:
+
+- :func:`skill_path` returns the absolute path to the bundled skill so it
+  can be passed to ``SkillsProvider(skill_paths=[...])`` (Microsoft Agent
+  Framework) or to Claude Code's ``--skill`` flag.
+- :func:`install_to` copies the skill into a target directory — useful
+  for projects that maintain a ``skills/`` folder in their own repo and
+  want to vendor the Agent-Gantry skill alongside their own skills.
+
+Both helpers fall back gracefully when the package was installed without
+the skill files (e.g. someone vendored the source tree by hand and
+trimmed it).
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+_SKILL_DIR_NAME = "agent-gantry"
+
+
+def skill_path() -> Path:
+    """Return the absolute path to the bundled Agent-Gantry skill.
+
+    Use to wire the skill into an agent without copying files:
+
+    .. code-block:: python
+
+        from agent_framework import SkillsProvider
+        from agent_gantry.skills import skill_path
+
+        provider = SkillsProvider(skill_paths=[str(skill_path().parent)])
+
+    Returns:
+        ``Path`` pointing at the ``agent-gantry/`` skill directory inside
+        the installed package. The returned path is guaranteed to exist
+        when the package was installed from the wheel — :exc:`FileNotFoundError`
+        is raised otherwise so the caller can fall back to a downloaded copy.
+    """
+    path = Path(__file__).parent / _SKILL_DIR_NAME
+    if not path.is_dir():
+        raise FileNotFoundError(
+            f"Agent-Gantry skill directory not found at {path!s}. "
+            "This usually means the package was installed from a source "
+            "tree that doesn't include skills/. Reinstall via "
+            "'pip install agent-gantry' to get the bundled skill."
+        )
+    return path
+
+
+def install_to(target: str | Path, *, overwrite: bool = False) -> Path:
+    """Copy the bundled skill into ``target/agent-gantry/``.
+
+    Args:
+        target: Destination directory. Created if missing.
+        overwrite: When True, replace an existing ``agent-gantry``
+            directory inside ``target``. Defaults to False.
+
+    Returns:
+        Absolute path to the freshly installed skill directory.
+
+    Raises:
+        FileExistsError: When the destination already exists and
+            ``overwrite=False``.
+        FileNotFoundError: When the bundled skill is missing (see
+            :func:`skill_path`).
+    """
+    src = skill_path()
+    dst_root = Path(target).expanduser().resolve()
+    dst_root.mkdir(parents=True, exist_ok=True)
+    dst = dst_root / _SKILL_DIR_NAME
+    if dst.exists():
+        if not overwrite:
+            raise FileExistsError(
+                f"{dst!s} already exists; pass overwrite=True to replace it."
+            )
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)
+    return dst
+
+
+__all__ = ["install_to", "skill_path"]

--- a/agent_gantry/skills/agent-gantry/SKILL.md
+++ b/agent_gantry/skills/agent-gantry/SKILL.md
@@ -1,0 +1,536 @@
+---
+name: agent-gantry
+description: Use this skill when the user is writing or debugging code that uses the `agent-gantry` Python library (semantic tool routing for LLM agents). Triggers on `import agent_gantry`, mentions of `AgentGantry`, `GantryContextProvider`, `GantryToolBridge`, `gantry.register`, `with_semantic_tools`, tool retrieval / surfacing problems with Microsoft Agent Framework, LangChain, AutoGen, CrewAI, LlamaIndex, Semantic Kernel, Google ADK, A2A, or MCP. Use proactively when the code imports `agent_gantry` even if the user did not explicitly invoke the skill.
+---
+
+# Agent-Gantry
+
+Universal semantic tool router for LLM agents. Register tools once with `@gantry.register`, sync them into a vector store, then have the router surface only the top-K relevant tools per query — typically cutting prompt token spend by ~80% versus listing every tool.
+
+This skill is the canonical reference for using the library. Read the section that matches the user's framework before writing code. When a user reports "the LLM doesn't see tool X" or "my surface is empty", jump straight to **Debugging routing** below — that's the most common failure mode and the library ships first-class introspection for it.
+
+## When to use which integration path
+
+| User's framework | API to use | Section |
+|---|---|---|
+| Microsoft Agent Framework (AF 1.x) | `GantryContextProvider` (dynamic, per-turn or per-call) or `GantryToolBridge` (static) | [Microsoft Agent Framework](#microsoft-agent-framework) |
+| LangChain / LangGraph | `fetch_framework_tools(..., framework="langchain")` then pass to `bind_tools` | [LangChain](#langchain--langgraph) |
+| AutoGen | `fetch_framework_tools(..., framework="autogen")` | [AutoGen](#autogen) |
+| CrewAI | `fetch_framework_tools(..., framework="crewai")` | [CrewAI](#crewai) |
+| LlamaIndex | `fetch_framework_tools(..., framework="llamaindex")` | [LlamaIndex](#llamaindex) |
+| Semantic Kernel | `fetch_framework_tools(..., framework="semantic_kernel")` | [Semantic Kernel](#semantic-kernel) |
+| Google ADK | `fetch_framework_tools(..., framework="google_adk")` | [Google ADK](#google-adk) |
+| Plain OpenAI / Anthropic / Gemini SDK | `@with_semantic_tools(dialect=...)` decorator | [LLM-SDK direct](#llm-sdk-direct) |
+| MCP server (expose Gantry as MCP) | `gantry.serve_mcp(mode="dynamic")` | [MCP](#mcp) |
+| A2A (expose Gantry as an A2A agent) | `gantry.serve_a2a(...)` | [A2A](#a2a) |
+| CLI inspection / linting | `agent-gantry lint / sim / sync --dry-run` | [CLI](#cli) |
+
+## Core concepts (read first)
+
+1. **Tools are functions decorated with `@gantry.register`.** Type hints + docstring become the schema and the embedding text. Tags and `examples=[...]` improve recall.
+
+2. **`await gantry.sync()` embeds every tool.** Fingerprint-based change detection means only modified tools re-embed on subsequent calls. With paid embedders, wrap the embedder in `CachedEmbedder` to persist across cold starts.
+
+3. **`gantry.retrieve(...)` returns a `RetrievalResult`.** That's the universal API. The high-level integrations (`GantryContextProvider`, `GantryToolBridge`, `fetch_framework_tools`, `@with_semantic_tools`) are thin wrappers around it that emit framework-specific schema shapes.
+
+4. **`score_threshold` is opt-in filtering.** Default is `0.0` (no filtering). Use `score_threshold="relative:0.8"` for length-robust filtering — that keeps anything within 80% of the top score. Fixed absolute cutoffs degrade badly on long, instruction-style queries because the embedding gets diluted.
+
+5. **`query_strategy="per_call"` re-runs retrieval every chat-completion round.** This is the right choice for multi-step agents. Pair it with `provider.attach_to(agent)` or `middleware=[provider.as_chat_middleware()]`. Without the middleware, `per_call` silently degrades to `per_run` and the provider will warn you once.
+
+## Installing
+
+```bash
+pip install agent-gantry                # core
+pip install "agent-gantry[nomic]"       # local embeddings (recommended)
+pip install "agent-gantry[openai]"      # OpenAI/Azure embeddings + custom OpenAI-compatible base_url
+pip install "agent-gantry[agent-frameworks]"  # Microsoft AF, LangChain, AutoGen, CrewAI, LlamaIndex, Semantic Kernel, Google ADK
+pip install "agent-gantry[lancedb]"     # disk-persistent vector store
+pip install "agent-gantry[mcp]"         # MCP client/server
+pip install "agent-gantry[a2a]"         # A2A agent
+pip install "agent-gantry[all]"         # everything
+```
+
+The `[nomic]` extra is the recommended default for getting started — local, free, and accurate enough for production. `SimpleEmbedder` (the fallback when no embedder extra is installed) is hash-based and only useful for tests.
+
+## Minimum-viable code
+
+Every Agent-Gantry program has this shape:
+
+```python
+import asyncio
+from agent_gantry import AgentGantry
+
+gantry = AgentGantry()
+
+@gantry.register
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    return f"Weather in {city}: sunny"
+
+@gantry.register
+def book_flight(origin: str, destination: str) -> str:
+    """Book a flight between two cities."""
+    return f"Booked {origin} -> {destination}"
+
+async def main():
+    await gantry.sync()                                          # embed
+    tools = await gantry.retrieve_tools("weather in Paris", limit=3)
+    print(tools)  # OpenAI-shape schemas for the top 3 matches
+
+asyncio.run(main())
+```
+
+`retrieve_tools(...)` returns OpenAI-shape tool schemas by default. Pass `dialect="anthropic"`, `"gemini"`, `"agent_framework"`, etc. to convert.
+
+## Microsoft Agent Framework
+
+The native, idiomatic integration. `GantryContextProvider` is an AF `ContextProvider` that runs at `before_run` (per-run mode) or on every chat-completion round (per-call mode, via a paired middleware).
+
+### Per-run mode (default — fixed tool set for one `agent.run(...)` call)
+
+```python
+from agent_framework import Agent
+from agent_framework.openai import OpenAIChatClient
+from agent_gantry import AgentGantry, GantryContextProvider
+
+gantry = AgentGantry()
+# ... register tools, await gantry.sync() ...
+
+provider = GantryContextProvider(gantry, top_k=5)
+
+agent = Agent(
+    OpenAIChatClient(),
+    "You are a helpful assistant.",
+    context_providers=[provider],
+)
+
+result = await agent.run("Book me a flight to Tokyo")
+```
+
+### Per-call mode (re-runs retrieval every chat round)
+
+Use when the agent reasons in multiple steps and needs different tools at different stages. The chat middleware is **required** — without it the per-call mode silently degrades to per-run.
+
+```python
+from agent_gantry import GantryContextProvider
+from agent_gantry.query import fallback_chain, last_tool_result, last_user_text
+
+provider = GantryContextProvider(
+    gantry,
+    top_k=3,
+    query_strategy="per_call",
+    # Default for per_call is already fallback_chain(last_tool_result, last_user_text).
+    # Pass query_generator=... only if you want a different rotation.
+)
+
+agent = Agent(
+    OpenAIChatClient(),
+    "...",
+    context_providers=[provider],
+    middleware=[provider.as_chat_middleware()],  # REQUIRED for per_call
+)
+```
+
+Or use the one-call helper:
+
+```python
+agent = Agent(OpenAIChatClient(), "...")
+provider.attach_to(agent)        # appends provider + middleware in one shot
+```
+
+### Pinning tools that must always be visible
+
+```python
+provider = GantryContextProvider(
+    gantry,
+    top_k=5,
+    required=["validate_input"],     # MissingRequiredToolError at construction if absent
+    always_include=["log_event"],    # warning + skip if absent
+    static_tools=[some_af_native_tool],  # tool not registered with gantry
+)
+```
+
+`required` and `always_include` reference *gantry-registered* tool names. `static_tools` is for AF-native `@tool` callables that live outside the gantry registry — they're appended every round and never filtered.
+
+### Static (no per-turn retrieval — bake once)
+
+Use `GantryToolBridge` directly when the tool set is fixed at construction:
+
+```python
+from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+bridge = GantryToolBridge(gantry)
+tools = await bridge.get_tools("customer support tasks", limit=5)
+agent = Agent(OpenAIChatClient(), "...", tools=tools)
+```
+
+The bridge also exposes one-call agent constructors: `bridge.as_agent(...)`, `bridge.build_handoff_workflow(...)`, `bridge.build_sequential_workflow(...)`, `bridge.build_workflow(...)`.
+
+### Approval middleware + observability
+
+```python
+from agent_gantry.core.security import SecurityPolicy
+from agent_gantry.integrations.agent_framework_middleware import (
+    GantryApprovalMiddleware,
+    GantryObservabilityMiddleware,
+    GantryToolChoiceMiddleware,
+)
+
+policy = SecurityPolicy(require_confirmation=["delete_*", "refund_*"])
+
+# tool_choice modulation: force tool calls for the first N rounds, then auto.
+rounds = {"n": 0}
+def choose(_ctx):
+    rounds["n"] += 1
+    return "required" if rounds["n"] <= 5 else "auto"
+
+agent = Agent(
+    OpenAIChatClient(),
+    "...",
+    context_providers=[provider],
+    middleware=[
+        provider.as_chat_middleware(),
+        GantryApprovalMiddleware(policy),
+        GantryObservabilityMiddleware(gantry),
+        GantryToolChoiceMiddleware(choose),
+    ],
+)
+```
+
+## LangChain / LangGraph
+
+```python
+from langchain_openai import ChatOpenAI
+from agent_gantry import AgentGantry
+from agent_gantry.integrations import fetch_framework_tools
+
+gantry = AgentGantry()
+# ... register tools, await gantry.sync() ...
+
+tools = await fetch_framework_tools(
+    gantry, "search the web for X", framework="langchain", limit=5
+)
+
+llm = ChatOpenAI(model="gpt-4o").bind_tools(tools)
+response = await llm.ainvoke("...")
+```
+
+LangGraph: build the tools the same way, then add them to the graph's `ToolNode` or pass to `create_react_agent(llm, tools)`.
+
+## AutoGen
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from agent_gantry.integrations import fetch_framework_tools
+
+tools = await fetch_framework_tools(
+    gantry, "math operations", framework="autogen", limit=3
+)
+
+agent = AssistantAgent(
+    name="assistant",
+    model_client=OpenAIChatCompletionClient(model="gpt-4o"),
+    tools=tools,
+)
+```
+
+## CrewAI
+
+```python
+from crewai import Agent, Task, Crew
+from agent_gantry.integrations import fetch_framework_tools
+
+tools = await fetch_framework_tools(
+    gantry, "research and writing", framework="crewai", limit=4
+)
+
+researcher = Agent(
+    role="Researcher",
+    goal="Find accurate information",
+    backstory="...",
+    tools=tools,
+)
+```
+
+## LlamaIndex
+
+```python
+from llama_index.llms.openai import OpenAI
+from agent_gantry.integrations import fetch_framework_tools
+
+tools = await fetch_framework_tools(
+    gantry, "data retrieval", framework="llamaindex", limit=3
+)
+# LlamaIndex consumes OpenAI-shape tool schemas directly.
+```
+
+## Semantic Kernel
+
+```python
+from agent_gantry.integrations import fetch_framework_tools
+
+tools = await fetch_framework_tools(
+    gantry, "translate documents", framework="semantic_kernel", limit=3
+)
+```
+
+## Google ADK
+
+```python
+from agent_gantry.integrations import fetch_framework_tools
+
+tools = await fetch_framework_tools(
+    gantry, "code execution", framework="google_adk", limit=3
+)
+```
+
+## LLM-SDK direct
+
+For minimal stack — no agent framework — use the `@with_semantic_tools` decorator:
+
+```python
+from openai import AsyncOpenAI
+from agent_gantry import AgentGantry, set_default_gantry, with_semantic_tools
+
+gantry = AgentGantry()
+set_default_gantry(gantry)
+
+@gantry.register
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    return "..."
+
+client = AsyncOpenAI()
+
+@with_semantic_tools(limit=3)   # default dialect="openai"
+async def chat(prompt: str, *, tools=None):
+    return await client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+        tools=tools,
+    )
+
+await chat("weather in Paris?")
+```
+
+Dialect support: `dialect="anthropic"`, `"gemini"`, `"mistral"`, `"groq"`, `"openai_responses"`. Each emits the right schema for that provider; the call shape stays identical.
+
+Mistral note: the official `mistralai` SDK is quarantined on PyPI. Use `AsyncOpenAI` pointed at `https://api.mistral.ai/v1` — Mistral's API is OpenAI-compatible. With `agent-gantry`, the OpenAI dialect works directly.
+
+OpenAI-compatible custom endpoints (Requesty, OpenRouter, Together, vLLM, …) are first-class: pass `api_base` in the `EmbedderConfig` or set `OPENAI_BASE_URL`, and `OpenAIEmbedder` forwards it to the client.
+
+## MCP
+
+Expose Gantry as an MCP server (Claude Desktop, Cline, etc.):
+
+```python
+gantry = AgentGantry()
+# ... register tools, await gantry.sync() ...
+await gantry.serve_mcp(transport="stdio", mode="dynamic")
+```
+
+`mode="dynamic"` exposes only two meta-tools (`find_relevant_tools`, `execute_tool`) — the MCP client semantic-searches Gantry on demand. ~90% smaller tool list footprint than `mode="static"`.
+
+Consume external MCP servers:
+
+```python
+from agent_gantry.schema.config import MCPServerConfig
+
+await gantry.add_mcp_server(MCPServerConfig(
+    name="filesystem",
+    command=["npx", "-y", "@modelcontextprotocol/server-filesystem"],
+    args=["--path", "/tmp"],
+    namespace="fs",
+))
+```
+
+## A2A
+
+```python
+gantry.serve_a2a(host="0.0.0.0", port=8080)
+# Agent Card at: http://localhost:8080/.well-known/agent.json
+```
+
+Skills exposed: `tool_discovery` (semantic search) and `tool_execution` (run a tool).
+
+## CLI
+
+The `agent-gantry` command ships with the package:
+
+```bash
+agent-gantry list                              # list registered demo tools
+agent-gantry search "refund order" --limit 3   # semantic search
+agent-gantry lint                              # detect tool-description authoring mistakes
+agent-gantry sim toolA toolB                   # cosine similarity between two tools
+agent-gantry sync --dry-run                    # which tools would (re-)embed and why
+```
+
+`lint` flags three patterns that silently degrade routing quality:
+
+1. Descriptions that mention other registered tools (embedding pulls them toward each other).
+2. Pairs of tools with >0.85 cosine similarity (probably should be one tool, or differentiated).
+3. Tags that appear on more than half the registry (low discriminative value).
+
+## Debugging routing
+
+When a user says "the LLM doesn't see my tool" / "my surface is empty" / "wrong tools are being selected", use these in order:
+
+### 1. `provider.last_selection` — what just happened
+
+```python
+provider = GantryContextProvider(gantry, top_k=5)
+result = await agent.run("...")
+
+decision = provider.last_selection
+print(decision.summary())           # one-line: query + top scores
+print(decision.injected)            # tool names that made it to the LLM
+for c in decision.candidates:
+    print(c.name, c.score, c.kept)  # full ranked list, kept/dropped flag
+```
+
+`RetrievalDecision` carries: the query, every candidate the gantry returned, the threshold mode used, the effective numeric cutoff, and the final injected list.
+
+### 2. `provider.dry_run_retrieve(query)` — same code path as live, no agent
+
+```python
+decision = await provider.dry_run_retrieve("find boundaries in OCR text")
+for c in decision.candidates:
+    print(f"{c.score:.3f}  {c.qualified_name}  kept={c.kept}")
+```
+
+This uses the exact same threshold, `top_k`, and `query_kwargs` as the live middleware — so the answer is "what the LLM would see for that query".
+
+### 3. `verbose=True` — one-line INFO log per round
+
+```python
+provider = GantryContextProvider(gantry, top_k=5, verbose=True)
+# logs: gantry: query="..." → top5: [tool_a:0.61, tool_b:0.58, ...]
+```
+
+### 4. `score_threshold` filtered everything?
+
+When the threshold drops all candidates, the bridge logs a WARNING with the top scores so you can tell "threshold issue" from "relevance issue". Default is `0.0`. If a user has set `score_threshold=0.3` (the legacy default) on a long pipeline query, **lower it or switch to relative**:
+
+```python
+provider = GantryContextProvider(
+    gantry,
+    score_threshold="relative:0.8",   # keep anything within 80% of top score
+)
+```
+
+### 5. Long queries silently degrade routing
+
+Long imperative scaffolding ("Please run this five-step pipeline. Use a different tool for each step…") dilutes the embedding. Strip it with `keyword_focused`:
+
+```python
+from agent_gantry.query import keyword_focused, truncated, last_user_text
+
+provider = GantryContextProvider(
+    gantry,
+    query_strategy="per_call",
+    query_generator=keyword_focused,       # drops scaffolding tokens
+)
+
+# Or cap the query length, biasing toward the latest tool output:
+provider = GantryContextProvider(
+    gantry,
+    query_strategy="per_call",
+    query_generator=truncated(last_user_text, max_chars=200, keep="tail"),
+)
+```
+
+### 6. Lint the registry — author-side bugs
+
+```bash
+agent-gantry lint
+```
+
+Or programmatically:
+
+```python
+analysis = await gantry.analyze_registry()
+print(analysis.format_text())
+```
+
+This catches the headline mistakes: a tool description that names another tool (which pulls it toward the wrong queries), pairs of tools that are too similar to disambiguate, and tags that are too generic.
+
+## Common pitfalls
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Empty tool surface | `score_threshold` too aggressive for query length | Lower to `0.0` or use `"relative:0.8"` |
+| `per_call` not adapting | `as_chat_middleware()` not attached | Use `provider.attach_to(agent)` or add to `middleware=[...]` |
+| `per_call` set but identical surface each round | Default `query_generator=last_user_text` doesn't change | The new default is `fallback_chain(last_tool_result, last_user_text)`; if you overrode it, switch back |
+| Wrong tools selected | Description names another tool ("unrelated to factorial…") | Run `agent-gantry lint`; remove cross-references |
+| `top_k=6` but I see 8 tools | Skills / `always_include` / `static_tools` add on top of dynamic top_k | Expected; subtract those |
+| Cold-start re-embeds every time | Default `InMemoryVectorStore` is ephemeral | Wrap embedder in `CachedEmbedder` or use `[lancedb]` |
+| OpenAI embedder can't reach my proxy | Custom base_url not configured | Pass `api_base=...` in `EmbedderConfig` or set `OPENAI_BASE_URL` |
+
+## Persistent embedding cache
+
+Re-embedding costs API spend at every cold start. Wrap any embedder:
+
+```python
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.openai import OpenAIEmbedder
+from agent_gantry.adapters.embedders.cached import CachedEmbedder
+from agent_gantry.schema.config import EmbedderConfig
+
+base = OpenAIEmbedder(EmbedderConfig(type="openai", model="text-embedding-3-large"))
+embedder = CachedEmbedder(base)   # default: ~/.cache/agent_gantry/embeddings.sqlite
+
+gantry = AgentGantry(embedder=embedder)
+```
+
+Cache is keyed by `(embedder_id, sha256(text))` — different models / dimensions never collide.
+
+## Query generators reference
+
+| Generator | Use when |
+|---|---|
+| `last_user_text` (default for `per_run`) | Tool selection driven by the user's most recent message |
+| `last_tool_result` | Next tool should match the *content* of the last tool's output |
+| `last_assistant_text` | Tool selection driven by the model's most recent reasoning |
+| `concatenate_recent(n=3)` | Multi-message context window matters |
+| `fallback_chain(*gens)` | Try each in order until one returns non-empty |
+| `keyword_focused` | Long instructional queries dilute the signal |
+| `truncated(gen, max_chars=200)` | Cap the query length, defaults to keeping the tail |
+
+Default for `query_strategy="per_call"` is `fallback_chain(last_tool_result, last_user_text)` — it adapts as the agent reasons.
+
+## API reference quick-card
+
+```python
+from agent_gantry import (
+    AgentGantry,                  # main facade
+    GantryContextProvider,        # AF native provider (per-run / per-call)
+    MissingRequiredToolError,     # raised when required=[...] tool absent
+    RetrievalDecision,            # introspection: what the bridge surfaced
+    RetrievalCandidate,           # one row in RetrievalDecision.candidates
+    with_semantic_tools,          # decorator for plain LLM SDK calls
+    set_default_gantry,           # bind a gantry to with_semantic_tools
+    create_default_gantry,        # quick factory (auto-picks Nomic if available)
+    ToolCall, ToolResult,
+    ToolQuery, ConversationContext,
+    ToolCapability, ToolCost, ToolDefinition, ToolHealth, ToolSource,
+)
+from agent_gantry.integrations import (
+    GantryToolBridge,             # static AF bridge + workflow builders
+    GantryApprovalMiddleware,
+    GantryObservabilityMiddleware,
+    GantryToolChoiceMiddleware,   # round-by-round tool_choice modulation
+    fetch_framework_tools,        # multi-framework adapter (OpenAI-shape)
+)
+from agent_gantry.query import (
+    last_user_text, last_assistant_text, last_tool_result,
+    concatenate_recent, fallback_chain,
+    keyword_focused, truncated,
+)
+from agent_gantry.adapters.embedders.cached import CachedEmbedder
+from agent_gantry.utils.registry_linter import (
+    analyze_registry, pairwise_similarity, RegistryAnalysis,
+)
+```
+
+For detailed reference on individual modules, see `references/` next to this file.

--- a/agent_gantry/skills/agent-gantry/references/cookbook.md
+++ b/agent_gantry/skills/agent-gantry/references/cookbook.md
@@ -1,0 +1,193 @@
+# Agent-Gantry Cookbook
+
+Recipes for the patterns that come up most often when building real agents with Agent-Gantry. Each section is self-contained — jump to the one matching the user's question.
+
+## Recipe 1: Multi-step pipeline with per-call retrieval
+
+Goal: an agent that runs a fixed N-step pipeline (e.g. fetch → transform → validate → write), where each step needs a different tool, and the user wants the LLM to see only the relevant tool at each step.
+
+```python
+from agent_framework import Agent
+from agent_framework.openai import OpenAIChatClient
+from agent_gantry import AgentGantry, GantryContextProvider
+from agent_gantry.query import fallback_chain, last_tool_result, last_user_text
+from agent_gantry.integrations.agent_framework_middleware import GantryToolChoiceMiddleware
+
+gantry = AgentGantry()
+# ... register fetch_*, transform_*, validate_*, write_* tools, await gantry.sync() ...
+
+provider = GantryContextProvider(
+    gantry,
+    top_k=3,
+    query_strategy="per_call",
+    # Default for per_call already adapts to tool output; spelled out for clarity:
+    query_generator=fallback_chain(last_tool_result, last_user_text),
+    score_threshold="relative:0.8",
+)
+
+# Force tool calls for the first 4 rounds (the pipeline) then allow text on the
+# 5th (summarisation) — keeps the model from bailing to text mid-pipeline.
+rounds = {"n": 0}
+def choose_tool_choice(_ctx):
+    rounds["n"] += 1
+    return "required" if rounds["n"] <= 4 else "auto"
+
+agent = Agent(
+    OpenAIChatClient(),
+    "You run a 4-step pipeline. Use the suggested tool at each step.",
+    context_providers=[provider],
+    middleware=[
+        provider.as_chat_middleware(),
+        GantryToolChoiceMiddleware(choose_tool_choice),
+    ],
+)
+```
+
+## Recipe 2: Pipe a custom embedding endpoint (Requesty / OpenRouter / vLLM)
+
+```python
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.openai import OpenAIEmbedder
+from agent_gantry.schema.config import EmbedderConfig
+
+embedder = OpenAIEmbedder(EmbedderConfig(
+    type="openai",
+    model="text-embedding-3-large",
+    api_key="...",
+    api_base="https://router.requesty.ai/v1",
+))
+
+gantry = AgentGantry(embedder=embedder)
+```
+
+Or via env var: `export OPENAI_BASE_URL=https://router.requesty.ai/v1`.
+
+## Recipe 3: Persistent embedding cache (avoid cold-start cost)
+
+```python
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.openai import OpenAIEmbedder
+from agent_gantry.adapters.embedders.cached import CachedEmbedder
+from agent_gantry.schema.config import EmbedderConfig
+
+base = OpenAIEmbedder(EmbedderConfig(type="openai", model="text-embedding-3-large"))
+embedder = CachedEmbedder(base)  # default cache: ~/.cache/agent_gantry/embeddings.sqlite
+gantry = AgentGantry(embedder=embedder)
+```
+
+Inspect cache effectiveness: `print(embedder.hits, embedder.misses)`.
+
+## Recipe 4: Pinning AF-native tools alongside dynamic Gantry tools
+
+```python
+from agent_framework import tool
+
+@tool
+def log_event(message: str) -> str:
+    """Write an audit event."""
+    return "ok"
+
+provider = GantryContextProvider(
+    gantry,
+    top_k=4,
+    static_tools=[log_event],  # always visible to the LLM, never filtered
+)
+```
+
+`static_tools` is the right slot for AF-native `@tool` callables that don't live in the gantry registry. For gantry-registered tools, use `always_include=["log_event"]` (by name) instead.
+
+## Recipe 5: Diagnosing "the LLM doesn't see my tool"
+
+The five-step debugging path the issue tracker keeps surfacing. Run them in order.
+
+```python
+# Step 1: Is the tool even registered?
+print([t.name for t in gantry.list_tools_sync()])
+
+# Step 2: Would semantic search find it for this query?
+decision = await provider.dry_run_retrieve("the user's actual query")
+for c in decision.candidates:
+    print(f"  {c.score:.3f}  {c.qualified_name}  kept={c.kept}")
+
+# Step 3: After a real run, what did the LLM actually see?
+result = await agent.run("...")
+print(provider.last_selection.summary())
+print(provider.last_selection.injected)
+
+# Step 4: Threshold issue?
+# If "filtered out all N candidates" WARNING appears in logs, lower or switch
+# to relative mode.
+
+# Step 5: Author-side bug? Run the registry linter.
+analysis = await gantry.analyze_registry()
+print(analysis.format_text())
+```
+
+## Recipe 6: A2A — expose Gantry as an agent network endpoint
+
+```python
+gantry.serve_a2a(host="0.0.0.0", port=8080)
+# Agent Card lives at http://localhost:8080/.well-known/agent.json
+# Skills exposed: tool_discovery (semantic search), tool_execution (run a tool)
+```
+
+Consume another A2A agent's skills as gantry-managed tools:
+
+```python
+from agent_gantry.schema.config import A2AAgentConfig
+
+await gantry.add_a2a_agent(A2AAgentConfig(
+    name="translator",
+    url="https://translator.example.com",
+    namespace="ext",
+))
+# Translator's skills are now registered as gantry tools in the "ext" namespace.
+```
+
+## Recipe 7: MCP — dynamic server selection
+
+```python
+# Register servers with metadata so the router can pick which one(s) to connect to.
+gantry.register_mcp_server(
+    name="filesystem",
+    command=["npx", "-y", "@modelcontextprotocol/server-filesystem"],
+    description="Read and write files on the local filesystem",
+    tags=["filesystem", "files", "io"],
+)
+gantry.register_mcp_server(
+    name="db",
+    command=["python", "-m", "mcp_postgresql"],
+    description="Query and mutate PostgreSQL databases",
+    tags=["database", "sql"],
+)
+
+await gantry.sync_mcp_servers()
+
+# Semantic search to pick servers, then connect only those:
+servers = await gantry.retrieve_mcp_servers("read config.yaml", limit=1)
+for s in servers:
+    await gantry.discover_tools_from_server(s.name)
+
+tools = await gantry.retrieve_tools("read my config.yaml")
+```
+
+## Recipe 8: Many-tool registry — keep recall high with the linter + verbose logging
+
+For registries >50 tools, two practices keep routing quality high:
+
+1. **CI lint**: add `agent-gantry lint` to your test pipeline.
+2. **Verbose provider in staging**: `GantryContextProvider(gantry, verbose=True)` prints one line per round so accuracy regressions are caught before production.
+
+## Recipe 9: Token-savings benchmarking
+
+```python
+from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+bridge = GantryToolBridge(gantry)
+tools_full = bridge.wrap_tools(gantry.list_tools_sync())          # all tools
+tools_top5 = await bridge.get_tools("the query", limit=5)         # gantry top-5
+
+# Call your LLM with each list and compare prompt_tokens from the usage block.
+```
+
+`tests/test_token_savings_and_accuracy.py` in the repo is a full reference benchmark.

--- a/agent_gantry/utils/registry_linter.py
+++ b/agent_gantry/utils/registry_linter.py
@@ -109,9 +109,18 @@ def _detect_cross_references(
 ) -> list[CrossReferenceFinding]:
     findings: list[CrossReferenceFinding] = []
     names = {t.name for t in tools}
-    # Tokens to scan: description + extended_description + tags + examples.
+    # Pre-compile one pattern per tool name so we don't pay the regex
+    # compilation cost inside the nested loop. For a registry with N
+    # tools, this turns an O(N²) compile cost into O(N).
     # Match whole-word, case-insensitive, with non-word boundaries so we
     # don't match the tool's *own* name when it's a substring of another.
+    # Short names (< 3 chars) produce too many false positives — skip them.
+    patterns: dict[str, re.Pattern[str]] = {
+        n: re.compile(rf"(?<!\w){re.escape(n.lower())}(?!\w)")
+        for n in names
+        if len(n) >= 3
+    }
+    # Tokens to scan: description + extended_description + tags + examples.
     for tool in tools:
         text_blobs: list[str] = [tool.description or ""]
         if tool.extended_description:
@@ -120,13 +129,9 @@ def _detect_cross_references(
         text_blobs.extend(tool.examples or [])
         full = " ".join(text_blobs).lower()
         refs: list[str] = []
-        for other in names:
+        for other, pattern in patterns.items():
             if other == tool.name:
                 continue
-            if len(other) < 3:
-                # Skip short names that produce too many false positives.
-                continue
-            pattern = re.compile(rf"(?<!\w){re.escape(other.lower())}(?!\w)")
             if pattern.search(full):
                 refs.append(other)
         if refs:
@@ -214,7 +219,7 @@ async def analyze_registry(
     cross_refs = _detect_cross_references(tools)
     tag_overlaps = _detect_overlapping_tags(tools, max_share=tag_overlap_share)
 
-    eff_embedder = embedder if embedder is not None else gantry._embedder
+    eff_embedder = embedder if embedder is not None else gantry.embedder
     similar_pairs = await _detect_similar_pairs(
         tools, eff_embedder, similarity_threshold=similarity_threshold
     )
@@ -254,7 +259,7 @@ async def pairwise_similarity(
         raise LookupError(f"Tool {tool_a!r} not found in registry.")
     if tool_b not in lookup:
         raise LookupError(f"Tool {tool_b!r} not found in registry.")
-    eff_embedder = embedder if embedder is not None else gantry._embedder
+    eff_embedder = embedder if embedder is not None else gantry.embedder
     texts = [
         _searchable_text(lookup[tool_a]),
         _searchable_text(lookup[tool_b]),

--- a/agent_gantry/utils/registry_linter.py
+++ b/agent_gantry/utils/registry_linter.py
@@ -1,0 +1,273 @@
+"""
+Registry linter — flags common tool-description authoring mistakes.
+
+Embedding similarity doesn't understand negation, and it doesn't
+understand cross-tool references. A description that *names* another
+tool — "Different from counting characters", "Prefer SHA-256 when …" —
+will be semantically pulled *toward* the queries that the named tool
+was meant to differentiate from. This module catches those mistakes
+before they ship.
+
+The two entry points are:
+
+- :func:`analyze_registry` — Python API, returns a structured
+  :class:`RegistryAnalysis` so callers can post-process the findings
+  (pre-commit hooks, CI checks, dashboards).
+- :func:`pairwise_similarity` — score two registered tools head-to-head.
+
+The CLI mirrors both as ``gantry lint`` and ``gantry sim``.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_gantry.adapters.embedders.base import EmbeddingAdapter
+    from agent_gantry.core.gantry import AgentGantry
+    from agent_gantry.schema.tool import ToolDefinition
+
+
+@dataclass
+class CrossReferenceFinding:
+    """A tool's text mentions another registered tool by name."""
+
+    tool: str
+    references: list[str]
+
+
+@dataclass
+class SimilarPairFinding:
+    """Two tools whose searchable texts are highly similar."""
+
+    tool_a: str
+    tool_b: str
+    cosine: float
+
+
+@dataclass
+class OverlappingTagFinding:
+    """A tag that appears on more than a threshold number of tools."""
+
+    tag: str
+    tools: list[str]
+
+
+@dataclass
+class RegistryAnalysis:
+    """Aggregated analysis output."""
+
+    cross_references: list[CrossReferenceFinding] = field(default_factory=list)
+    similar_pairs: list[SimilarPairFinding] = field(default_factory=list)
+    overlapping_tags: list[OverlappingTagFinding] = field(default_factory=list)
+    embedder_used: str | None = None
+
+    @property
+    def empty(self) -> bool:
+        return (
+            not self.cross_references
+            and not self.similar_pairs
+            and not self.overlapping_tags
+        )
+
+    def format_text(self) -> str:
+        """Human-readable rendering for the CLI."""
+        if self.empty:
+            return "No issues found."
+        lines: list[str] = []
+        if self.cross_references:
+            lines.append("Cross-references (descriptions naming other tools):")
+            for f in self.cross_references:
+                lines.append(f"  - {f.tool}: references {', '.join(f.references)}")
+        if self.similar_pairs:
+            lines.append("")
+            lines.append("Similar tool pairs (cosine > threshold):")
+            for f in self.similar_pairs:
+                lines.append(f"  - {f.tool_a} ⇄ {f.tool_b}: {f.cosine:.3f}")
+        if self.overlapping_tags:
+            lines.append("")
+            lines.append("Overlapping tags (low discriminative value):")
+            for f in self.overlapping_tags:
+                lines.append(f"  - {f.tag}: {', '.join(f.tools)}")
+        return "\n".join(lines)
+
+
+def _searchable_text(tool: ToolDefinition) -> str:
+    return tool.to_searchable_text()
+
+
+def _qualified(tool: ToolDefinition) -> str:
+    return f"{tool.namespace}.{tool.name}"
+
+
+def _detect_cross_references(
+    tools: list[ToolDefinition],
+) -> list[CrossReferenceFinding]:
+    findings: list[CrossReferenceFinding] = []
+    names = {t.name for t in tools}
+    # Tokens to scan: description + extended_description + tags + examples.
+    # Match whole-word, case-insensitive, with non-word boundaries so we
+    # don't match the tool's *own* name when it's a substring of another.
+    for tool in tools:
+        text_blobs: list[str] = [tool.description or ""]
+        if tool.extended_description:
+            text_blobs.append(tool.extended_description)
+        text_blobs.extend(tool.tags or [])
+        text_blobs.extend(tool.examples or [])
+        full = " ".join(text_blobs).lower()
+        refs: list[str] = []
+        for other in names:
+            if other == tool.name:
+                continue
+            if len(other) < 3:
+                # Skip short names that produce too many false positives.
+                continue
+            pattern = re.compile(rf"(?<!\w){re.escape(other.lower())}(?!\w)")
+            if pattern.search(full):
+                refs.append(other)
+        if refs:
+            findings.append(CrossReferenceFinding(tool=tool.name, references=refs))
+    return findings
+
+
+def _detect_overlapping_tags(
+    tools: list[ToolDefinition], *, max_share: float = 0.5
+) -> list[OverlappingTagFinding]:
+    if not tools:
+        return []
+    tag_to_tools: dict[str, list[str]] = defaultdict(list)
+    for tool in tools:
+        for tag in tool.tags or []:
+            tag_to_tools[tag].append(tool.name)
+    cutoff = max(2, math.ceil(len(tools) * max_share))
+    return [
+        OverlappingTagFinding(tag=tag, tools=names)
+        for tag, names in sorted(tag_to_tools.items())
+        if len(names) >= cutoff
+    ]
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    num = sum(x * y for x, y in zip(a, b))
+    da = math.sqrt(sum(x * x for x in a))
+    db = math.sqrt(sum(y * y for y in b))
+    if da == 0.0 or db == 0.0:
+        return 0.0
+    return num / (da * db)
+
+
+async def _detect_similar_pairs(
+    tools: list[ToolDefinition],
+    embedder: EmbeddingAdapter,
+    *,
+    similarity_threshold: float,
+) -> list[SimilarPairFinding]:
+    if len(tools) < 2:
+        return []
+    texts = [_searchable_text(t) for t in tools]
+    embeddings = await embedder.embed_batch(texts)
+    findings: list[SimilarPairFinding] = []
+    for i in range(len(tools)):
+        for j in range(i + 1, len(tools)):
+            score = _cosine(embeddings[i], embeddings[j])
+            if score >= similarity_threshold:
+                findings.append(
+                    SimilarPairFinding(
+                        tool_a=_qualified(tools[i]),
+                        tool_b=_qualified(tools[j]),
+                        cosine=score,
+                    )
+                )
+    findings.sort(key=lambda f: f.cosine, reverse=True)
+    return findings
+
+
+async def analyze_registry(
+    gantry: AgentGantry,
+    *,
+    similarity_threshold: float = 0.85,
+    tag_overlap_share: float = 0.5,
+    embedder: EmbeddingAdapter | None = None,
+) -> RegistryAnalysis:
+    """Analyse a gantry's registry for common authoring mistakes.
+
+    Args:
+        gantry: The :class:`AgentGantry` instance to analyse.
+        similarity_threshold: Pairs of tools whose searchable-text
+            cosine similarity is at least this value are flagged as
+            potential merge / differentiate candidates. Defaults to
+            ``0.85``.
+        tag_overlap_share: Tags that appear on more than this fraction
+            of the registry are flagged as having low discriminative
+            value. Defaults to ``0.5``.
+        embedder: Override the embedder used for similarity. Defaults
+            to the gantry's configured embedder.
+
+    Returns:
+        A :class:`RegistryAnalysis` summarising the findings.
+    """
+    tools = gantry.list_tools_sync()
+    cross_refs = _detect_cross_references(tools)
+    tag_overlaps = _detect_overlapping_tags(tools, max_share=tag_overlap_share)
+
+    eff_embedder = embedder if embedder is not None else gantry._embedder
+    similar_pairs = await _detect_similar_pairs(
+        tools, eff_embedder, similarity_threshold=similarity_threshold
+    )
+    embedder_id = getattr(eff_embedder, "model_name", type(eff_embedder).__name__)
+    return RegistryAnalysis(
+        cross_references=cross_refs,
+        similar_pairs=similar_pairs,
+        overlapping_tags=tag_overlaps,
+        embedder_used=str(embedder_id),
+    )
+
+
+async def pairwise_similarity(
+    gantry: AgentGantry,
+    tool_a: str,
+    tool_b: str,
+    *,
+    embedder: EmbeddingAdapter | None = None,
+) -> float:
+    """Return the cosine similarity between two registered tools' texts.
+
+    Args:
+        gantry: The gantry instance.
+        tool_a: Name (or ``namespace.name``) of the first tool.
+        tool_b: Name (or ``namespace.name``) of the second tool.
+        embedder: Override the embedder used. Defaults to the gantry's.
+
+    Raises:
+        LookupError: If either tool is not registered.
+    """
+    tools = gantry.list_tools_sync()
+    lookup: dict[str, ToolDefinition] = {}
+    for t in tools:
+        lookup[t.name] = t
+        lookup[f"{t.namespace}.{t.name}"] = t
+    if tool_a not in lookup:
+        raise LookupError(f"Tool {tool_a!r} not found in registry.")
+    if tool_b not in lookup:
+        raise LookupError(f"Tool {tool_b!r} not found in registry.")
+    eff_embedder = embedder if embedder is not None else gantry._embedder
+    texts = [
+        _searchable_text(lookup[tool_a]),
+        _searchable_text(lookup[tool_b]),
+    ]
+    embs = await eff_embedder.embed_batch(texts)
+    return _cosine(embs[0], embs[1])
+
+
+__all__ = [
+    "CrossReferenceFinding",
+    "OverlappingTagFinding",
+    "RegistryAnalysis",
+    "SimilarPairFinding",
+    "analyze_registry",
+    "pairwise_similarity",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,22 @@ Repository = "https://github.com/CodeHalwell/Agent-Gantry"
 [tool.hatch.build.targets.wheel]
 packages = ["agent_gantry"]
 
+[tool.hatch.build.targets.wheel.shared-data]
+"agent_gantry/skills/agent-gantry" = "share/claude/skills/agent-gantry"
+
+[tool.hatch.build]
+# Make sure SKILL.md and the references/ tree ship inside the wheel
+# alongside the package itself. The shared-data table above also
+# publishes a copy under ``share/claude/skills/`` so Claude Code can
+# find the skill via the standard discovery path
+# (``$VENV/share/claude/skills/`` is searched at startup).
+include = [
+    "agent_gantry/**/*.py",
+    "agent_gantry/**/*.md",
+    "agent_gantry/**/*.txt",
+    "agent_gantry/skills/**/*",
+]
+
 [tool.ruff]
 target-version = "py310"
 line-length = 100

--- a/tests/test_agent_framework_provider.py
+++ b/tests/test_agent_framework_provider.py
@@ -239,12 +239,162 @@ class TestGantryContextProvider:
         async def _boom(*_a: object, **_k: object) -> list:
             raise RuntimeError("retrieval down")
 
-        # Patch the bridge's get_tools rather than gantry.retrieve so the
-        # provider's own try/except path is exercised.
-        monkeypatch.setattr(provider._bridge, "get_tools", _boom)
+        # Patch the bridge's decision-returning retrieval (the provider's
+        # actual call path) so the provider's own try/except is exercised.
+        monkeypatch.setattr(
+            provider._bridge, "get_tools_with_decision", _boom
+        )
 
         ctx = af.SessionContext(input_messages=[_user_msg("weather")])
         await provider.before_run(agent=None, session=None, context=ctx, state={})
 
         # No exception, no tools injected — agent.run continues.
         assert ctx.tools == []
+
+    # ------------------------------------------------------------------
+    # New surface area: last_selection / dry_run_retrieve / static_tools
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_last_selection_exposes_decision_after_before_run(
+        self, gantry_with_tools: AgentGantry
+    ) -> None:
+        """After each retrieval the provider exposes the structured decision."""
+        provider = GantryContextProvider(
+            gantry_with_tools, top_k=2, score_threshold=0.0
+        )
+        ctx = af.SessionContext(input_messages=[_user_msg("weather")])
+        await provider.before_run(agent=None, session=None, context=ctx, state={})
+
+        decision = provider.last_selection
+        assert decision is not None
+        assert decision.query == "weather"
+        assert decision.injected
+        # Candidates is the ranked list and is non-empty.
+        assert decision.candidates
+        # Every injected tool was kept.
+        assert all(c.kept for c in decision.candidates if c.name in decision.injected)
+
+    @pytest.mark.asyncio
+    async def test_dry_run_retrieve_uses_same_code_path(
+        self, gantry_with_tools: AgentGantry
+    ) -> None:
+        """dry_run_retrieve must mirror the live retrieval (same threshold,
+        same kwargs) so users can validate "would the LLM see X?" offline."""
+        provider = GantryContextProvider(
+            gantry_with_tools, top_k=2, score_threshold=0.0
+        )
+        decision = await provider.dry_run_retrieve("book me a flight")
+        names = {c.name for c in decision.candidates}
+        # The fixture's book_flight should rank for a "flight" query.
+        assert "book_flight" in names
+        # Same path => same threshold mode reported.
+        assert decision.threshold_mode == "absolute"
+
+    @pytest.mark.asyncio
+    async def test_static_tools_injected_on_every_run(
+        self, gantry_with_tools: AgentGantry
+    ) -> None:
+        """Tools that live outside the gantry registry must still be
+        injected when supplied via static_tools."""
+
+        async def af_native_tool(x: str) -> str:
+            """A tool not registered with gantry."""
+            return x
+
+        af_native_tool.__name__ = "af_native_tool"
+        provider = GantryContextProvider(
+            gantry_with_tools,
+            top_k=1,
+            score_threshold=0.0,
+            static_tools=[af_native_tool],
+        )
+        ctx = af.SessionContext(input_messages=[_user_msg("weather")])
+        await provider.before_run(agent=None, session=None, context=ctx, state={})
+        names = _tool_names(ctx.tools)
+        assert "af_native_tool" in names
+
+    @pytest.mark.asyncio
+    async def test_per_call_default_generator_is_fallback_chain(
+        self, gantry_with_tools: AgentGantry
+    ) -> None:
+        """per_call mode must pick a generator that actually adapts each
+        round; the per_run default (last_user_text) would silently
+        disable the very thing per_call enables."""
+        from agent_gantry.query import last_user_text
+
+        provider = GantryContextProvider(
+            gantry_with_tools, top_k=1, query_strategy="per_call"
+        )
+        # The selected generator is *not* the bare last_user_text default.
+        assert provider._query_generator is not last_user_text  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_per_call_with_last_user_text_warns(
+        self,
+        gantry_with_tools: AgentGantry,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Explicitly pairing per_call with last_user_text — the
+        misconfiguration the issue calls out — must warn."""
+        import logging
+
+        from agent_gantry.query import last_user_text
+
+        with caplog.at_level(logging.WARNING):
+            GantryContextProvider(
+                gantry_with_tools,
+                query_strategy="per_call",
+                query_generator=last_user_text,
+            )
+        assert "per_call" in caplog.text and "last_user_text" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_per_call_warns_when_chat_middleware_not_attached(
+        self,
+        gantry_with_tools: AgentGantry,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """per_call mode without the chat middleware on the agent must
+        warn so the user knows retrieval is silently per_run-only."""
+        import logging
+
+        class FakeAgent:
+            middleware: list = []
+
+        provider = GantryContextProvider(
+            gantry_with_tools, top_k=1, query_strategy="per_call"
+        )
+        ctx = af.SessionContext(input_messages=[_user_msg("weather")])
+        with caplog.at_level(logging.WARNING):
+            await provider.before_run(
+                agent=FakeAgent(), session=None, context=ctx, state={}
+            )
+        assert "as_chat_middleware" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_attach_to_appends_provider_and_middleware(
+        self, gantry_with_tools: AgentGantry
+    ) -> None:
+        """attach_to is the one-call setup helper for the per_call flow."""
+
+        class FakeAgent:
+            context_providers: list = []
+            middleware: list = []
+
+        agent = FakeAgent()
+        provider = GantryContextProvider(
+            gantry_with_tools, query_strategy="per_call"
+        )
+        provider.attach_to(agent)
+        assert provider in agent.context_providers
+        assert len(agent.middleware) == 1
+
+    def test_relative_threshold_accepted_at_construction(
+        self, gantry_with_tools: AgentGantry
+    ) -> None:
+        """A 'relative:<frac>' string is accepted and not rejected as a float."""
+        provider = GantryContextProvider(
+            gantry_with_tools, score_threshold="relative:0.8"
+        )
+        assert provider.score_threshold == "relative:0.8"

--- a/tests/test_query_strategies.py
+++ b/tests/test_query_strategies.py
@@ -292,3 +292,258 @@ def test_rerankers_module_exposes_optional_classes_via_dir():
     listed = set(dir(rk))
     expected = {"RerankerAdapter", "CohereReranker", "CrossEncoderReranker"}
     assert expected.issubset(listed)
+
+
+# ---------------------------------------------------------------------------
+# New: keyword_focused + truncated query helpers
+# ---------------------------------------------------------------------------
+
+
+def test_keyword_focused_strips_scaffolding_and_keeps_content_words():
+    """Imperative scaffolding ("please", "step", "the", …) must be
+    dropped so the remaining tokens carry the actual content signal."""
+    from agent_gantry.query import keyword_focused
+
+    msg = _Msg(
+        "user",
+        "Please run this five-step pipeline. Use a different tool for "
+        "each step. Compute the factorial of 7 and the sha256 hash.",
+    )
+    out = keyword_focused([msg])
+    tokens = out.split()
+    # Content words survive.
+    assert "factorial" in tokens
+    assert "sha256" in tokens
+    assert "compute" in tokens
+    # Scaffolding is dropped.
+    for scaffold in ("please", "the", "this", "step", "use", "of"):
+        assert scaffold not in tokens, f"{scaffold!r} should be stripped"
+
+
+def test_keyword_focused_handles_empty_messages():
+    from agent_gantry.query import keyword_focused
+
+    assert keyword_focused([]) == ""
+    assert keyword_focused(None) == ""
+
+
+def test_truncated_caps_length_keeping_tail_by_default():
+    from agent_gantry.query import last_user_text, truncated
+
+    msg = _Msg("user", "the quick brown fox jumps over the lazy dog")
+    gen = truncated(last_user_text, max_chars=10, keep="tail")
+    out = gen([msg])
+    assert len(out) <= 10
+    # Tail is preserved (defaults to "tail"), so "dog" should remain.
+    assert "dog" in out
+
+
+def test_truncated_keep_head():
+    from agent_gantry.query import last_user_text, truncated
+
+    msg = _Msg("user", "the quick brown fox jumps over the lazy dog")
+    gen = truncated(last_user_text, max_chars=10, keep="head")
+    out = gen([msg])
+    assert len(out) <= 10
+    assert "the" in out
+
+
+def test_truncated_supports_async_generator():
+    """Wrapper must mirror the underlying coroutine-ness."""
+    import asyncio
+    import inspect
+
+    from agent_gantry.query import truncated
+
+    async def async_gen(_messages):
+        return "this is a long async result string"
+
+    wrapped = truncated(async_gen, max_chars=12, keep="tail")
+    assert inspect.iscoroutinefunction(wrapped)
+    out = asyncio.run(wrapped([]))
+    assert len(out) == 12
+
+
+# ---------------------------------------------------------------------------
+# New: AgentGantry.analyze_registry + pairwise_similarity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_analyze_registry_detects_cross_references():
+    """A tool description naming another registered tool is the
+    headline mistake from the issue — verify the linter catches it."""
+    g = AgentGantry()
+
+    @g.register
+    def factorial(n: int) -> int:
+        """Compute factorial of n recursively."""
+        return n
+
+    @g.register
+    def fibonacci(n: int) -> int:
+        """Unrelated to factorial — different recurrence relation."""
+        return n
+
+    await g.sync()
+    analysis = await g.analyze_registry()
+    refs = {f.tool: f.references for f in analysis.cross_references}
+    assert "fibonacci" in refs
+    assert "factorial" in refs["fibonacci"]
+    assert not analysis.empty
+
+
+@pytest.mark.asyncio
+async def test_analyze_registry_clean_registry_reports_empty():
+    g = AgentGantry()
+
+    @g.register
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    await g.sync()
+    analysis = await g.analyze_registry()
+    assert analysis.cross_references == []
+
+
+@pytest.mark.asyncio
+async def test_pairwise_similarity_returns_cosine_score():
+    g = AgentGantry()
+
+    @g.register
+    def add_numbers(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    @g.register
+    def subtract_numbers(a: int, b: int) -> int:
+        """Subtract one number from another."""
+        return a - b
+
+    await g.sync()
+    score = await g.pairwise_similarity("add_numbers", "subtract_numbers")
+    assert 0.0 <= score <= 1.0
+
+    with pytest.raises(LookupError):
+        await g.pairwise_similarity("add_numbers", "nope")
+
+
+# ---------------------------------------------------------------------------
+# New: GantryToolBridge — threshold parsing + RetrievalDecision
+# ---------------------------------------------------------------------------
+
+
+def test_parse_threshold_accepts_float_relative_and_none():
+    from agent_gantry.integrations.agent_framework_bridge import _parse_threshold
+
+    assert _parse_threshold(None) == ("absolute", None)
+    assert _parse_threshold(0.3) == ("absolute", 0.3)
+    assert _parse_threshold("relative:0.8") == ("relative", 0.8)
+    assert _parse_threshold("0.5") == ("absolute", 0.5)
+
+    with pytest.raises(ValueError):
+        _parse_threshold("relative:abc")
+    with pytest.raises(ValueError):
+        _parse_threshold("relative:1.5")
+    with pytest.raises(TypeError):
+        _parse_threshold([0.3])  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_bridge_emits_retrieval_decision_with_kept_and_dropped():
+    """The bridge's decision-returning API must list both kept and
+    dropped candidates so callers can self-diagnose threshold issues
+    without re-running retrieval."""
+    from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+    g = AgentGantry()
+
+    @g.register
+    def get_weather(city: str) -> str:
+        """Get the current weather for a city."""
+        return "x"
+
+    @g.register
+    def book_flight(origin: str, destination: str) -> str:
+        """Book a flight between two cities."""
+        return "x"
+
+    await g.sync()
+    bridge = GantryToolBridge(g, score_threshold=0.0)
+
+    # Use a very high absolute threshold to force everything to be dropped.
+    _tools, decision = await bridge.get_tools_with_decision(
+        "weather", limit=5, score_threshold=0.99
+    )
+    assert decision.injected == []
+    # Candidates must still be populated so the user can see what was filtered.
+    assert len(decision.candidates) >= 1
+    assert all(not c.kept for c in decision.candidates)
+    # And the summary string is well-formed.
+    assert "query=" in decision.summary()
+
+
+@pytest.mark.asyncio
+async def test_bridge_relative_threshold_keeps_top_band():
+    """``relative:0.9`` should retain only candidates within 90% of the
+    top score and report the effective cutoff."""
+    from agent_gantry.integrations.agent_framework_bridge import GantryToolBridge
+
+    g = AgentGantry()
+
+    @g.register
+    def get_weather(city: str) -> str:
+        """Get the current weather for a city."""
+        return "x"
+
+    @g.register
+    def book_flight(origin: str, destination: str) -> str:
+        """Book a flight between two cities."""
+        return "x"
+
+    @g.register
+    def lookup_user(user_id: str) -> str:
+        """Look up a user by ID."""
+        return "x"
+
+    await g.sync()
+    bridge = GantryToolBridge(g)
+    _tools, decision = await bridge.get_tools_with_decision(
+        "weather", limit=5, score_threshold="relative:0.9"
+    )
+    assert decision.threshold_mode.startswith("relative")
+    assert decision.effective_threshold is not None
+    # At least one tool should pass; not all should pass (otherwise the
+    # threshold did nothing).
+    kept_count = sum(c.kept for c in decision.candidates)
+    assert kept_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# New: CachedEmbedder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cached_embedder_persists_across_instances(tmp_path):
+    """Re-opening the cache file must yield hits, not re-embed work."""
+    from agent_gantry.adapters.embedders.cached import CachedEmbedder
+    from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+    cache = tmp_path / "embed.sqlite"
+    first = CachedEmbedder(SimpleEmbedder(), cache_path=cache)
+    v1 = await first.embed_batch(["alpha", "beta"])
+    assert first.hits == 0 and first.misses == 2
+    # Second call to same instance: all hits.
+    v2 = await first.embed_batch(["alpha", "beta"])
+    assert v2 == v1
+    assert first.hits == 2
+    first.close()
+
+    # Fresh instance reopens the same file: must still hit.
+    second = CachedEmbedder(SimpleEmbedder(), cache_path=cache)
+    v3 = await second.embed_batch(["alpha"])
+    assert v3 == [v1[0]]
+    assert second.hits == 1 and second.misses == 0
+    second.close()


### PR DESCRIPTION
## Summary

This PR adds comprehensive introspection and diagnostic capabilities to the tool retrieval pipeline, including structured decision tracking, relative score thresholds for length-robust filtering, and a registry linter to catch common tool-description mistakes.

## Key Changes

### Retrieval Decision Introspection
- **New `RetrievalDecision` dataclass**: Captures the complete state of each retrieval round—query, ranked candidates (with kept/dropped flags), injected tools, and effective threshold. Includes helper methods (`kept`, `dropped`, `summary()`, `as_span_attributes()`) for easy inspection and telemetry.
- **`GantryToolBridge.get_tools_with_decision()`**: Returns both tools and the structured decision for offline validation and debugging.
- **`GantryContextProvider.last_selection`**: Exposes the most recent retrieval decision; `dry_run_retrieve(query)` uses the exact same code path for "would the LLM see X?" diagnostics.
- **Verbose logging**: New `verbose=True` parameter on `GantryContextProvider` logs one-line INFO summaries per round (e.g., `query="…" → top5: [name:0.61, …]`).

### Relative Score Thresholds
- **`_parse_threshold()` helper**: Decodes `score_threshold` into mode + numeric value, supporting:
  - `None` → no filtering
  - `float` → absolute cosine cutoff (e.g., `0.3`)
  - `"relative:<frac>"` → multiplier on top score (e.g., `"relative:0.8"` keeps anything ≥80% of best)
- **Length-robust filtering**: Absolute thresholds collapse on long pipeline-style queries; relative mode adapts per round.
- **Default changed to `0.0`**: Previous `0.3` default silently filtered relevant tools on multi-step pipelines.

### Registry Linting
- **New `agent_gantry.utils.registry_linter` module**: Detects three classes of authoring mistakes:
  - Cross-references: tool descriptions naming other registered tools (pulls them toward wrong queries)
  - Similar pairs: tools with highly overlapping searchable text (>0.85 cosine by default)
  - Overlapping tags: tags appearing on >50% of tools (low discriminative value)
- **`AgentGantry.analyze_registry()`**: Convenience wrapper returning structured `RegistryAnalysis`.
- **CLI commands**: `gantry lint` and `gantry sim` for offline validation.

### Query Generators
- **`keyword_focused()`**: Strips imperative scaffolding ("please", "step", "the", etc.) to keep content words, reducing noise in instruction-style queries.
- **`truncated()`**: Caps query length while preserving head or tail, with async support.
- **Smart defaults**: `per_call` strategy now defaults to `fallback_chain(last_tool_result, last_user_text)` instead of `last_user_text` alone, enabling round-to-round adaptation.

### Provider Enhancements
- **`static_tools=[...]`**: Pin AF-native tools (outside gantry registry) into every round's surface.
- **`provider.attach_to(agent)` helper**: Appends provider and chat middleware in one call.
- **`GantryToolChoiceMiddleware`**: Modulate `tool_choice` per round via a user-supplied callable (e.g., force tools for first N rounds, then allow text).
- **Improved docstrings**: Clarified `top_k` (governs only dynamic selection; skills/always_include/required are appended), threshold modes, and query strategy defaults.

### Embedder Improvements
- **`CachedEmbedder`**: Disk-backed SQLite cache wrapper for any embedder, keyed by `(embedder_id, sha256(text))`. Avoids re-embedding on cold starts with paid APIs.
- **OpenAI custom endpoints**: Honor `config.api_base` or `OPENAI_BASE_URL` env var for compatible services (Requesty

https://claude.ai/code/session_01XkXCSJxDegVVS4AkQyaB6p