### PR TITLE
Update Agent Framework to 1.4.0 and fix LangChain import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`agent-framework` floor bumped to `>=1.4.0`** (was `>=1.3.0`). Agent Framework
+  1.4.0 released 2026-05-15. Changes in 1.4.0: MCP tool-call metadata forwarding,
+  path-traversal fix in checkpoint storage, A2A SDK v1.0 alignment. Two breaking
+  changes in 1.4.0 that do NOT affect Gantry: (1) SkillFrontmatter extraction in the
+  experimental file-based skills API; (2) DevUI CORS tightening. Lock file updated:
+  `agent-framework` and `agent-framework-core` both moved from 1.3.0 → 1.4.0.
+  *Risk: safe internal — no changes to Agent, WorkflowBuilder, ContextProvider,
+  FunctionMiddleware, or any other API surface that Gantry consumes.*
+  Source: https://pypi.org/pypi/agent-framework/json
+
+- **`google-adk` comment updated** — upgrade to 1.33.0 now blocked by a second
+  independent conflict. Previously documented: `pydantic>=2.12` requirement vs
+  `semantic-kernel<=1.41.x` (`pydantic<2.12`). Newly identified: `langgraph<0.4.8`
+  requirement in google-adk 1.33.0 is mutually exclusive with `langgraph>=1.2.0` in
+  this extra. The langgraph conflict cannot be resolved by bumping semantic-kernel.
+  Floor stays at `>=1.14.1`.
+  *Risk: safe internal — comment only, floor unchanged.*
+  Source: https://pypi.org/pypi/google-adk/1.33.0/json
+
+- **`semantic-kernel` comment updated** — 1.42.0 is the current stable release.
+  1.42.0 relaxes the pydantic upper bound from `<2.12` to `<2.14`, resolving the
+  pydantic conflict with google-adk 1.33.0 as far as semantic-kernel is concerned.
+  However, (a) the opentelemetry-api conflict with agent-framework on some Python
+  versions is unresolved, keeping the floor at `>=1.36.0`; and (b) google-adk 1.33.0
+  has an independent langgraph<0.4.8 conflict that blocks it regardless.
+  Floor stays at `>=1.36.0` until opentelemetry conflict is confirmed resolved.
+  *Risk: safe internal — comment only, floor unchanged.*
+  Source: https://pypi.org/pypi/semantic-kernel/1.42.0/json
+
+- **`google-genai` comment updated** — latest stable is now 2.3.0 (was 2.2.0).
+  No change to floor or installation instructions.
+  *Risk: safe internal — comment only.*
+  Source: https://pypi.org/pypi/google-genai/json
+
+- **`examples/agent_frameworks/langchain_example.py`**: Changed
+  `from langchain.tools import tool` to `from langchain_core.tools import tool`.
+  The canonical location in LangChain 1.x is `langchain_core.tools`; the shim in
+  `langchain.tools` may be removed in a future 1.x minor release.
+  *Risk: safe with compatibility shim.*
+  Source: https://python.langchain.com/docs/concepts/tools/
+
+- **`examples/agent_frameworks/agent_framework_example.py`** and
+  **`agent_framework_orchestration_example.py`**: Version reference in docstring
+  updated from 1.3.0 to 1.4.0 to match the bumped `agent-framework` floor.
+  *Risk: safe internal — documentation only.*
+
 - **`anthropic` floor bumped to `>=0.102.0`** (was `>=0.101.0`). Anthropic 0.102.0
   released 2026-05-13; no breaking changes for Gantry's Messages API call sites.
   *Risk: safe internal — floor bump only.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   FunctionMiddleware, or any other API surface that Gantry consumes.*
   Source: https://pypi.org/pypi/agent-framework/json
 
-- **`google-adk` comment updated** — upgrade to 1.33.0 now blocked by a second
-  independent conflict. Previously documented: `pydantic>=2.12` requirement vs
-  `semantic-kernel<=1.41.x` (`pydantic<2.12`). Newly identified: `langgraph<0.4.8`
-  requirement in google-adk 1.33.0 is mutually exclusive with `langgraph>=1.2.0` in
-  this extra. The langgraph conflict cannot be resolved by bumping semantic-kernel.
-  Floor stays at `>=1.14.1`.
+- **`google-adk` floor stays at `>=1.14.1`** — upgrade to 1.33.0 blocked by two
+  independent conflicts. (1) **langgraph** (primary blocker): google-adk 1.33.0
+  requires `langgraph<0.4.8`, which is mutually exclusive with `langgraph>=1.2.0` in
+  the `agent-frameworks` extra; no floor bump resolves this. (2) **pydantic**
+  (partially resolved): google-adk 1.33.0 requires `pydantic>=2.12`; semantic-kernel
+  1.42.0 has relaxed its upper bound to `<2.14`, but the langgraph conflict still
+  blocks co-installation regardless. `pyproject.toml` comment updated to document
+  both blockers. To use google-adk 1.33.0, install it in a standalone environment
+  without LangChain/LangGraph.
   *Risk: safe internal — comment only, floor unchanged.*
   Source: https://pypi.org/pypi/google-adk/1.33.0/json
 
@@ -32,8 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   1.42.0 relaxes the pydantic upper bound from `<2.12` to `<2.14`, resolving the
   pydantic conflict with google-adk 1.33.0 as far as semantic-kernel is concerned.
   However, (a) the opentelemetry-api conflict with agent-framework on some Python
-  versions is unresolved, keeping the floor at `>=1.36.0`; and (b) google-adk 1.33.0
-  has an independent langgraph<0.4.8 conflict that blocks it regardless.
+  versions remains unresolved, keeping the floor at `>=1.36.0`; and (b) google-adk
+  1.33.0 has an independent langgraph<0.4.8 conflict that blocks it regardless.
   Floor stays at `>=1.36.0` until opentelemetry conflict is confirmed resolved.
   *Risk: safe internal — comment only, floor unchanged.*
   Source: https://pypi.org/pypi/semantic-kernel/1.42.0/json
@@ -43,10 +46,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   *Risk: safe internal — comment only.*
   Source: https://pypi.org/pypi/google-genai/json
 
-- **`examples/agent_frameworks/langchain_example.py`**: Changed
-  `from langchain.tools import tool` to `from langchain_core.tools import tool`.
-  The canonical location in LangChain 1.x is `langchain_core.tools`; the shim in
-  `langchain.tools` may be removed in a future 1.x minor release.
+- **`crewai` comment updated** — latest stable is 1.14.4. The co-installation
+  conflict with `agent-framework` via `opentelemetry-api` version incompatibility
+  is documented. Floor stays at `>=1.6.1`.
+  *Risk: safe internal — comment only.*
+
+- **LangChain `tool` import migrated to `langchain_core`** in
+  `examples/agent_frameworks/langchain_example.py` (this PR) and
+  `examples/agent_frameworks/langgraph_example.py` (prior commit). Both now use
+  `from langchain_core.tools import tool` at module level. The `langchain.tools`
+  shim may be removed in a future LangChain 1.x minor release.
   *Risk: safe with compatibility shim.*
   Source: https://python.langchain.com/docs/concepts/tools/
 
@@ -70,26 +79,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   LangChain 1.3.0 GA. LangGraph 1.2.0 is the current stable release.
   *Risk: safe internal — floor bump only.*
   Source: https://pypi.org/pypi/langgraph/json
-
-- **`google-adk` floor stays at `>=1.14.1`** — upgrade to 1.33.0 blocked.
-  `google-adk 1.33.0` requires `pydantic>=2.12`, which is mutually exclusive with
-  `semantic-kernel>=1.36.0` (`pydantic<2.12`). Both are in the `agent-frameworks`
-  extra, so the floor remains `1.14.1`. The comment is updated to document this
-  specific conflict. To use google-adk 1.33.0, install it in a standalone environment
-  without semantic-kernel.
-  *Risk: safe internal — note only, floor unchanged.*
-  Source: https://pypi.org/pypi/google-adk/1.33.0/json
-
-- **`examples/agent_frameworks/langgraph_example.py`**: Changed
-  `from langchain.tools import tool` to `from langchain_core.tools import tool`.
-  The canonical location in LangChain 1.x is `langchain_core.tools`; the shim in
-  `langchain.tools` may be removed in a future 1.x minor release.
-  *Risk: safe with compatibility shim.*
-
-- **`pyproject.toml` comments updated**: `crewai`, `google-adk`, and `google-genai`
-  comments updated to reflect current latest stable versions (crewai 1.14.4,
-  google-adk 1.33.0 blocked by pydantic conflict, google-genai 2.2.0) and
-  co-installation status. `uv.lock` regenerated to reflect all floor bumps.
 
 ## [0.3.0] - 2026-05-13
 

--- a/examples/agent_frameworks/agent_framework_example.py
+++ b/examples/agent_frameworks/agent_framework_example.py
@@ -1,14 +1,15 @@
 """
-Microsoft Agent Framework (1.3.0) integration example.
+Microsoft Agent Framework (1.4.0) integration example.
 
 Demonstrates how Agent-Gantry's semantic routing reduces token usage in
 multi-agent systems by surfacing only the relevant tools per query.
 
-The ``agent-framework`` floor in ``pyproject.toml`` is ``>=1.3.0,<2.0.0``.
+The ``agent-framework`` floor in ``pyproject.toml`` is ``>=1.4.0,<2.0.0``.
 ``GantryToolBridge`` works against any AF release in that range; the bridge
-itself is API-stable across 1.2.x → 1.3.x and is unaffected by the 1.3.0
-breaking changes (skills multi-source restructuring and the Foundry-toolbox
-removal — both upstream-only APIs that Gantry does not consume).
+itself is API-stable across 1.3.x → 1.4.x and is unaffected by the 1.4.0
+changes (MCP tool-call metadata, SkillFrontmatter extraction, A2A SDK v1.0
+migration, and DevUI security hardening — all upstream-only APIs or
+infrastructure that Gantry does not consume).
 
 Covers three construction patterns:
 

--- a/examples/agent_frameworks/agent_framework_orchestration_example.py
+++ b/examples/agent_frameworks/agent_framework_orchestration_example.py
@@ -1,5 +1,5 @@
 """
-Microsoft Agent Framework 1.3.0 — multi-agent orchestration with Agent-Gantry.
+Microsoft Agent Framework 1.4.0 — multi-agent orchestration with Agent-Gantry.
 
 Demonstrates three production orchestration patterns, each powered by Gantry's
 semantic tool routing:

--- a/examples/agent_frameworks/langchain_example.py
+++ b/examples/agent_frameworks/langchain_example.py
@@ -9,6 +9,7 @@ import asyncio
 
 from dotenv import load_dotenv
 from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
@@ -43,8 +44,6 @@ async def main():
     print(f"Gantry retrieved {len(retrieved_tools)} tools.")
 
     # 4. Wrap Gantry tools as LangChain tools for use in LangGraph
-    from langchain_core.tools import tool
-
     def make_langchain_tool(tool_name: str, tool_desc: str, gantry_instance: AgentGantry):
         """Factory that binds the captured tool_name into a LangChain tool."""
 

--- a/examples/agent_frameworks/langchain_example.py
+++ b/examples/agent_frameworks/langchain_example.py
@@ -43,7 +43,7 @@ async def main():
     print(f"Gantry retrieved {len(retrieved_tools)} tools.")
 
     # 4. Wrap Gantry tools as LangChain tools for use in LangGraph
-    from langchain.tools import tool
+    from langchain_core.tools import tool
 
     def make_langchain_tool(tool_name: str, tool_desc: str, gantry_instance: AgentGantry):
         """Factory that binds the captured tool_name into a LangChain tool."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,15 +50,16 @@ dev = [
     "python-dotenv>=1.0.0",
 ]
 agent-frameworks = [
-    # Bump to 1.3.0 (released 2026-05-08): picks up ClassSkill for class-based skill
-    # definitions, allowed_tools support for OpenAI and Gemini tool-choice, experimental
-    # session/todo-list/memory context providers, and function approval flow in Foundry
-    # hosted agents. Two breaking changes in 1.3.0: (1) skills multi-source architecture
-    # restructuring (only affects the experimental skills API, not used by Gantry);
-    # (2) removal of bespoke Foundry toolbox helpers in favour of MCP (not used by
+    # Bump to 1.4.0 (released 2026-05-15): picks up MCP tool-call metadata forwarding,
+    # path-traversal fix in checkpoint storage, and A2A SDK v1.0 alignment inside AF.
+    # Two breaking changes in 1.4.0: (1) SkillFrontmatter extraction from file-based
+    # skills (experimental skills API, not used by Gantry); (2) DevUI CORS tightening
+    # (not relevant to library code). 1.3.0 breaking changes also apply: (3) skills
+    # multi-source architecture restructuring (experimental, not used by Gantry);
+    # (4) removal of bespoke Foundry toolbox helpers in favour of MCP (not used by
     # Gantry). Prior 1.2.2 note retained: sequential-approval and concurrent workflow
     # terminal outputs return as AgentResponse — use str() or .content to extract text.
-    "agent-framework>=1.3.0,<2.0.0",
+    "agent-framework>=1.4.0,<2.0.0",
     "autogen-agentchat>=0.7.5",
     "autogen-ext[openai]>=0.7.5",
     # crewai 1.14.4 (latest stable) pins opentelemetry-api~=1.34.0 (<1.35), which
@@ -73,17 +74,26 @@ agent-frameworks = [
     "langgraph>=1.2.0",
     "llama-index-core>=0.14.21",
     "llama-index-llms-openai>=0.7.7",
-    # semantic-kernel>=1.41.3 conflicts with agent-framework>=1.2.1 on some
-    # Python versions due to opentelemetry-api version incompatibility.
-    # Upgrade semantic-kernel in a standalone environment without agent-framework.
-    # Floor bumped to >=1.36.0 to match the uv.lock-resolved version; full
-    # upgrade to 1.41.3 requires standalone testing without agent-framework.
+    # semantic-kernel 1.42.0 (latest stable 2026-05-15) relaxes the pydantic
+    # upper bound to <2.14 (was <2.12 in <=1.41.x), but retains an opentelemetry-api
+    # version incompatibility with agent-framework on some Python versions. Until that
+    # conflict is confirmed resolved, the floor stays at >=1.36.0. Upgrade to 1.42.0
+    # in a standalone environment without agent-framework. Note: the previous pydantic
+    # conflict with google-adk 1.33.0 is now moot for semantic-kernel alone (1.42.0
+    # allows pydantic>=2.12), but google-adk 1.33.0 also requires langgraph<0.4.8
+    # which conflicts with langgraph>=1.2.0 in this extra (see google-adk comment).
     "semantic-kernel>=1.36.0",
-    # google-adk 1.33.0 (latest, 2026-05-08) requires pydantic>=2.12, which
-    # conflicts with semantic-kernel>=1.36.0 (requires pydantic<2.12). Both
-    # packages co-exist in the agent-frameworks extra, so the google-adk floor
-    # stays at 1.14.1. To use google-adk 1.33.0, install it in a standalone
-    # environment without semantic-kernel.
+    # google-adk 1.33.0 (latest, 2026-05-08) has two separate conflicts in this
+    # combined extra:
+    # (1) Requires pydantic>=2.12, which conflicted with semantic-kernel<=1.41.x
+    #     (pydantic<2.12). semantic-kernel 1.42.0 relaxes to pydantic<2.14, so
+    #     the pydantic conflict is resolved once semantic-kernel is upgraded there.
+    # (2) Requires langgraph<0.4.8, which is incompatible with langgraph>=1.2.0
+    #     in this extra. This conflict cannot be resolved by a simple floor bump
+    #     and remains the primary blocker for google-adk 1.33.0 in the combined
+    #     agent-frameworks extra.
+    # Floor stays at 1.14.1. To use google-adk 1.33.0, install it in a standalone
+    # environment without langchain/langgraph.
     "google-adk>=1.14.1",
 ]
 example-tools = [
@@ -158,10 +168,10 @@ anthropic = [
     "anthropic>=0.102.0",
 ]
 google-genai = [
-    # google-genai 2.2.0 (latest stable) introduces breaking changes only in the
-    # Interactions API; GenerateContent and function calling are entirely unaffected.
-    # google-adk (in the agent-frameworks extra) requires google-genai<2.0.0 across
-    # all versions up to 1.33.0, so the all[] extra stays at the 1.x floor.
+    # google-genai 2.3.0 (latest stable 2026-05-15) introduces breaking changes only
+    # in the Interactions API; GenerateContent and function calling are entirely
+    # unaffected. google-adk (in the agent-frameworks extra) requires google-genai<2.0.0
+    # across all versions up to 1.33.0, so the all[] extra stays at the 1.x floor.
     # Standalone 2.x upgrade: pip install "agent-gantry[google-genai]"
     "google-genai>=1.75.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -60,14 +60,14 @@ wheels = [
 
 [[package]]
 name = "agent-framework"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-framework-core", extra = ["all"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/e8/c2ee1c4dae4a86b95091969426d11361232a0c554124ba321852a6b6b9bd/agent_framework-1.3.0.tar.gz", hash = "sha256:a13423aceaf587cf28180138151d445bd2d4ce82908cef4a6fbb85fa1771bac1", size = 5509571, upload-time = "2026-05-08T00:09:16.022Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/06/2a1a95e4d87ef8e156fe96d956bb25f3fb45d6680638d75496b7d2419f27/agent_framework-1.4.0.tar.gz", hash = "sha256:d67bc4539707b1ed920af5982ff52e398921c4739e9e9918cf9109a48d498a47", size = 5538169, upload-time = "2026-05-15T00:55:06.676Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/81/050f8f8bce8c629a88197837b4beb35cb287f880789fc01923fd5938f142/agent_framework-1.3.0-py3-none-any.whl", hash = "sha256:baaaa932639c87be99d43333f612c3b4112d6d976f0e1e72238e42a4bd572438", size = 5684, upload-time = "2026-05-08T00:09:54.064Z" },
+    { url = "https://files.pythonhosted.org/packages/76/d6/15a1938778deb50fffb59f1286e5626f5dd9f4c53f48aa946dec934ddbbf/agent_framework-1.4.0-py3-none-any.whl", hash = "sha256:46e31bfe3f9ac8b36f99999d22de1796a12af6f8d80f49dc48421ac001cf6b4e", size = 5686, upload-time = "2026-05-15T00:55:32.975Z" },
 ]
 
 [[package]]
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework-core"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -244,9 +244,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/59/4c212abdb93074677d643e31a3c21e33ff26a3ccc351145475cd1ffffad7/agent_framework_core-1.3.0.tar.gz", hash = "sha256:91c3659718b733f70dde6fb3626edb044733e0f7aa5f9726c9774e17fae328ef", size = 365395, upload-time = "2026-05-08T00:09:09.36Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/e0/81b7cd52b37cd690a3fd361e57367c5c9792e70817386ae5cfccca232261/agent_framework_core-1.4.0.tar.gz", hash = "sha256:aad76bf01ed99c211076de778d29525c955ac4cce10f3a8e084e1e3053c7eacb", size = 369652, upload-time = "2026-05-15T00:55:10.121Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/f2/c4258333f2691ee10869bf72f51d423808962ccf0c195b1f893c06c348ad/agent_framework_core-1.3.0-py3-none-any.whl", hash = "sha256:b7a5baf2beb383e9042af057df79dae4fda0b836cbc8530b3b2a57a3c12bb7ac", size = 407978, upload-time = "2026-05-08T00:09:32.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/cc1d27e0af5bc88cc3ea59b33bdab2ef64512fea086b3f522eaf1499cf87/agent_framework_core-1.4.0-py3-none-any.whl", hash = "sha256:04335f6d85999061e01ce3f727efd7cb45214a695131488ccbef0cb17959163b", size = 412273, upload-time = "2026-05-15T00:55:08.65Z" },
 ]
 
 [package.optional-dependencies]
@@ -659,7 +659,7 @@ vector-stores = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.3.0,<2.0.0" },
+    { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.4.0,<2.0.0" },
     { name = "agent-gantry", extras = ["dev", "embeddings", "openai", "cohere", "vector-stores", "lancedb", "nomic", "mcp", "a2a", "llm-providers", "agent-frameworks", "example-tools"], marker = "extra == 'all'" },
     { name = "agent-gantry", extras = ["openai", "anthropic", "google-genai", "google-vertexai", "mistral", "groq"], marker = "extra == 'llm-providers'" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.102.0" },


### PR DESCRIPTION
## Summary
This PR updates the Agent Framework dependency floor to 1.4.0 and corrects a LangChain import to use the canonical location in langchain_core. Documentation and comments are updated to reflect the latest package versions and known compatibility constraints.

## Key Changes

- **Agent Framework floor bumped to 1.4.0**: Updated `pyproject.toml` dependency from `>=1.3.0` to `>=1.4.0`. Agent Framework 1.4.0 (released 2026-05-15) includes MCP tool-call metadata forwarding, path-traversal fixes, and A2A SDK v1.0 alignment. The breaking changes in 1.4.0 (SkillFrontmatter extraction and DevUI CORS tightening) do not affect Gantry's API surface.

- **LangChain import corrected**: Changed `from langchain.tools import tool` to `from langchain_core.tools import tool` in `examples/agent_frameworks/langchain_example.py`. The canonical location in LangChain 1.x is `langchain_core.tools`; the shim in `langchain.tools` may be removed in future releases.

- **Documentation updates**:
  - Updated docstrings in `agent_framework_example.py` and `agent_framework_orchestration_example.py` from version 1.3.0 to 1.4.0
  - Clarified that `GantryToolBridge` is API-stable across 1.3.x → 1.4.x
  - Updated comments in `pyproject.toml` for `semantic-kernel` (1.42.0 now available, pydantic bound relaxed to `<2.14`), `google-adk` (identified secondary langgraph conflict), and `google-genai` (2.3.0 is latest stable)

## Implementation Details

- No breaking changes to Gantry's codebase; all changes are dependency updates and documentation
- The `google-adk` floor remains at `>=1.14.1` due to an unresolvable langgraph version conflict (google-adk 1.33.0 requires `langgraph<0.4.8` while this extra requires `langgraph>=1.2.0`)
- The `semantic-kernel` floor remains at `>=1.36.0` pending confirmation that the opentelemetry-api conflict with agent-framework is resolved

https://claude.ai/code/session_01G1xXYYWQ32ysNXbYhAsTN6