### PR TITLE
Bump openai to 2.37.0 and langchain to 1.3.1

### DIFF
--- a/docs/audits/AUDIT_2026-05-17.md
+++ b/docs/audits/AUDIT_2026-05-17.md
@@ -1,0 +1,363 @@
+# Agent-Gantry Modernisation Audit — 17 May 2026
+
+**Auditor**: Claude (Sonnet 4.6) operating as repository maintainer  
+**Branch**: `claude/elegant-clarke-2sNrD`  
+**Date**: 2026-05-17  
+**Scope**: Full compatibility and modernisation audit — all seven phases — against the latest stable LLM provider SDKs, provider API standards, and agent framework patterns. Incremental over the 12 May 2026 audit (branch `claude/elegant-clarke-6oIAK`).
+
+---
+
+## 1. Executive Summary
+
+This audit identifies **two must-change-now items**, both applied in this commit, and carries forward **seven good-next-step improvements** from the prior cycle.
+
+### Must-Change Now (Applied in This Commit)
+
+| # | Finding | Files Affected | Risk |
+|---|---------|----------------|------|
+| 1 | **`openai` floor bump: `>=2.36.0` → `>=2.37.0`.** openai 2.37.0 was released and is the current stable. No breaking changes in Gantry's call sites (Responses API and Chat Completions surfaces are unchanged). | `pyproject.toml`, `uv.lock`, `docs/reference/llm_sdk_compatibility.md` | *Safe internal* — floor bump only |
+| 2 | **`langchain` floor bump: `>=1.3.0` → `>=1.3.1`.** langchain 1.3.1 is a patch release (no breaking changes). Its `langgraph` constraint is `<1.3.0,>=1.2.0`, which is compatible with our existing `langgraph>=1.2.0` floor. | `pyproject.toml`, `uv.lock` | *Safe internal* — patch bump only |
+
+### Good-Next-Step Improvements (Not Applied — Tracked)
+
+| # | Finding | Files Affected |
+|---|---------|----------------|
+| A | `google-genai` 2.3.0: the standalone `[google-genai]` extra floor stays at `>=1.75.0` because the `[all]` extra combines it with `google-adk>=1.14.1` (which requires `google-genai<2.0.0`). To install 2.3.0 standalone, use `pip install "agent-gantry[google-genai]" "google-genai>=2.3.0"`. The floor comment in `pyproject.toml` is accurate. No code changes required (2.x breaking changes are Interactions API only; `GenerateContent` and `functionDeclarations` are unaffected). | `pyproject.toml` (comment only) |
+| B | `crewai` 1.6.1 → 1.14.4: blocked by `opentelemetry-api~=1.34.0` (crewai) vs `>=1.39.0` (agent-framework-core 1.4.0). Install standalone without agent-framework. | `pyproject.toml` |
+| C | `semantic-kernel` 1.36.0 → 1.42.0: blocked by `opentelemetry-api~=1.24` (semantic-kernel 1.42.0) vs `>=1.39.0` (agent-framework-core 1.4.0). Install standalone. | `pyproject.toml` |
+| D | `google-adk` 1.14.1 → 1.33.0: blocked by `langgraph<0.4.8` (google-adk extensions extra) vs `langgraph>=1.2.0` in the combined `agent-frameworks` extra. Install standalone without langchain/langgraph. | `pyproject.toml` |
+| E | Expose AF 1.3.0 `allowed_tools` as an optional pass-through on `GantryToolBridge.build_agent()` / `as_agent()` and `GantryContextProvider`. Currently subset selection is achieved only via `query` + `limit`. | `agent_gantry/integrations/agent_framework_bridge.py`, `agent_gantry/integrations/agent_framework_provider.py`, new tests |
+| F | Update `SkillsProvider(skill_paths="./skills")` docstring example in `agent_framework_provider.py` to reflect AF 1.3.0's multi-source skills API once the migration guide is confirmed. *Needs confirmation*: the exact new syntax for path-based skill discovery in AF 1.3.0 is not yet documented in the public migration guide. | `agent_gantry/integrations/agent_framework_provider.py` |
+| G | Add `output_schema` / `output_config` parameter to `AnthropicClient.create_message()` for Anthropic's structured JSON output feature. | `agent_gantry/integrations/anthropic_features.py`, new tests |
+
+### Carried-Over Holds (Unchanged — All Documented in `pyproject.toml`)
+
+| Package | Held At | Latest | Blocker |
+|---------|---------|--------|---------|
+| `google-genai` (combined) | 1.75.0 | 2.3.0 | `google-adk>=1.14.1` requires `google-genai<2.0.0` |
+| `crewai` | 1.6.1 | 1.14.4 | `opentelemetry-api~=1.34.0` conflicts with `agent-framework-core>=1.4.0` (`>=1.39.0`) |
+| `semantic-kernel` | 1.36.0 | 1.42.0 | `opentelemetry-api~=1.24` conflicts with `agent-framework-core>=1.4.0` |
+| `google-adk` | 1.14.1 | 1.33.0 | `langgraph<0.4.8` conflicts with `langgraph>=1.2.0` in combined extra |
+| `langgraph` | 1.2.0 | 1.2.0 | ✅ Current — no newer stable |
+| `autogen-agentchat` | 0.7.5 | 0.7.5 | ✅ Current |
+| `groq` | 1.2.0 | 1.2.0 | ✅ Current |
+| `mcp` | 1.27.1 | 1.27.1 | ✅ Current |
+
+---
+
+## 2. Dependency Upgrade Plan
+
+All versions verified against the PyPI JSON API on 2026-05-17.
+
+| Package | `pyproject.toml` floor (before) | `pyproject.toml` floor (after) | Lock (before) | Lock (after) | Latest stable | Source URL |
+|---------|--------------------------------|--------------------------------|---------------|--------------|---------------|------------|
+| `openai` | `>=2.36.0` | **`>=2.37.0`** | 2.36.0 | **2.37.0** | 2.37.0 | https://pypi.org/pypi/openai/json |
+| `langchain` | `>=1.3.0` | **`>=1.3.1`** | 1.3.0 | **1.3.1** | 1.3.1 | https://pypi.org/pypi/langchain/json |
+| `anthropic` | `>=0.102.0` | unchanged | 0.102.0 | 0.102.0 | 0.102.0 | https://pypi.org/pypi/anthropic/json |
+| `agent-framework` | `>=1.4.0,<2.0.0` | unchanged | 1.4.0 | 1.4.0 | 1.4.0 | https://pypi.org/pypi/agent-framework/json |
+| `langchain-openai` | `>=1.2.1` | unchanged | 1.2.1 | 1.2.1 | 1.2.1 | https://pypi.org/pypi/langchain-openai/json |
+| `langgraph` | `>=1.2.0` | unchanged | 1.2.0 | 1.2.0 | 1.2.0 | https://pypi.org/pypi/langgraph/json |
+| `google-genai` | `>=1.75.0` | unchanged (hold) | 1.75.0 | 1.75.0 | 2.3.0 | https://pypi.org/pypi/google-genai/json |
+| `mcp` | `>=1.27.1` | unchanged | 1.27.1 | 1.27.1 | 1.27.1 | https://pypi.org/pypi/mcp/json |
+| `autogen-agentchat` | `>=0.7.5` | unchanged | 0.7.5 | 0.7.5 | 0.7.5 | https://pypi.org/pypi/autogen-agentchat/json |
+| `groq` | `>=1.2.0` | unchanged | 1.2.0 | 1.2.0 | 1.2.0 | https://pypi.org/pypi/groq/json |
+| `crewai` | `>=1.6.1` | unchanged (hold) | 1.6.1 | 1.6.1 | 1.14.4 | https://pypi.org/pypi/crewai/json |
+| `google-adk` | `>=1.14.1` | unchanged (hold) | 1.14.1 | 1.14.1 | 1.33.0 | https://pypi.org/pypi/google-adk/json |
+| `semantic-kernel` | `>=1.36.0` | unchanged (hold) | 1.36.0 | 1.36.0 | 1.42.0 | https://pypi.org/pypi/semantic-kernel/json |
+
+### `uv` commands applied in this commit
+
+```bash
+uv lock --upgrade-package openai --upgrade-package langchain
+```
+
+Output:
+
+```
+Updated langchain v1.3.0 -> v1.3.1
+Updated openai v2.36.0 -> v2.37.0
+```
+
+### Conflict analysis: dependency holds
+
+**`crewai` 1.14.4**:
+- Requires `opentelemetry-api~=1.34.0` (i.e. `>=1.34.0, <1.35`).
+- `agent-framework-core 1.4.0` requires `opentelemetry-api>=1.39.0`.
+- These ranges are disjoint. No resolution within the combined `[agent-frameworks]` extra.
+- Source: https://pypi.org/pypi/crewai/json (requires `opentelemetry-api~=1.34.0`); https://pypi.org/pypi/agent-framework-core/json (requires `opentelemetry-api<2,>=1.39.0`)
+
+**`semantic-kernel` 1.42.0**:
+- Requires `opentelemetry-api~=1.24` (i.e. `>=1.24.0, <1.25`).
+- `agent-framework-core 1.4.0` requires `opentelemetry-api>=1.39.0`.
+- Disjoint. No resolution within combined extra.
+- Source: https://pypi.org/pypi/semantic-kernel/json
+
+**`google-adk` 1.33.0 (extensions extra)**:
+- Requires `langgraph<0.4.8,>=0.2.60`.
+- Gantry's `agent-frameworks` extra requires `langgraph>=1.2.0`.
+- Disjoint. No resolution within combined extra.
+- Source: https://pypi.org/pypi/google-adk/json
+
+**`google-genai` 2.3.0 (combined extra)**:
+- `google-adk 1.14.1` requires `google-genai<2,>=1.72`.
+- Bumping the combined extra floor to `>=2.x` would violate `google-adk`'s upper bound.
+- Breaking changes in 2.x are confined to the Interactions API only; `GenerateContent` and `functionDeclarations` are unaffected.
+- Source: https://pypi.org/pypi/google-genai/json; https://pypi.org/pypi/google-adk/json
+
+### `langchain 1.3.1` → `langgraph` constraint
+
+langchain 1.3.1 requires `langgraph<1.3.0,>=1.2.0`. Gantry's `langgraph>=1.2.0` floor sits inside this window. No upper-bound adjustment needed. Source: https://pypi.org/pypi/langchain/1.3.1/json
+
+---
+
+## 3. Provider API Refactors
+
+No provider API refactors required in this cycle. All call sites verified against current official documentation.
+
+### OpenAI
+
+- **Responses API** (`client.responses.create()`): `examples/llm_integration/openai_demo.py` (Scenario A) correctly uses `model="gpt-4.1"`, flat `{"type":"function", "name":...}` schema via `OpenAIResponsesAdapter`, `previous_response_id` for multi-turn loops, and `function_call_output` for result round-tripping. ✅
+- **Chat Completions** (`client.chat.completions.create()`): Scenarios B and D use `model="gpt-4o"`, `tools=[...]`, `tool_choice="auto"`. ✅
+- **Assistants API**: Not present anywhere in the codebase. Sunset is 26 August 2026. No migration needed. ✅
+- **`OpenAIResponsesAdapter`**: Emits flat `{"type":"function", "name":..., "description":..., "parameters":...}` schema; `format_tool_result` emits `{"type":"function_call_output", "call_id":..., "output":...}`. Correct for Responses API. ✅
+- **`OpenAIAdapter`** (Chat Completions): Emits nested `{"type":"function","function":{name,description,parameters}}` schema. ✅
+- **Model names**: `gpt-4.1` (Responses API), `gpt-4o` (Chat Completions). Both are current documented model families. ✅
+- Source verified: https://platform.openai.com/docs/guides/responses-vs-chat-completions
+
+### Anthropic
+
+- **Messages API** (`client.messages.create()`): `examples/llm_integration/anthropic_demo.py` and `agent_gantry/integrations/anthropic_features.py` use the current format throughout. ✅
+- **Tool format**: `{name, description, input_schema}` emitted by `AnthropicAdapter.to_provider_schema()`; `tool_use` block parsing correct; `tool_result` round-trip uses `tool_use_id` and optional `is_error`. ✅
+- **Strict tool use**: `strict: True` flag in `AnthropicAdapter.to_provider_schema()` — supported. ✅
+- **Thinking/reasoning**: `AnthropicFeatures` dataclass correctly models all three modes:
+  - `adaptive` (effort-based; Opus 4.7, Opus 4.6+, Sonnet 4.6+)
+  - `enabled` (budget_tokens; Sonnet 4.6, Opus 4.6, Haiku 4.5 — not Opus 4.7)
+  - `interleaved` (beta header; pre-4.6 models)
+- **Model names**: `claude-sonnet-4-6` in examples. ✅
+- Source verified: https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview; https://platform.claude.com/docs/en/api/messages
+
+### Google Gemini
+
+- **`client.aio.models.generate_content()`**: Correct async interface for `google-genai>=1.x`. `config=types.GenerateContentConfig(tools=[...])` pattern. ✅
+- **`GeminiAdapter`**: Emits `{name, description, parameters}` function-declaration dict. `format_tool_result` correctly places `id` inside `functionResponse` (echoes the parallel-call correlation id). ✅
+- **Model name**: `gemini-2.5-flash` in example. ✅
+- Source verified: https://ai.google.dev/gemini-api/docs/function-calling
+
+### Mistral (post-quarantine, OpenAI SDK)
+
+- `agent_gantry/adapters/llm_client.py` uses `AsyncOpenAI(base_url="https://api.mistral.ai/v1")` — correct (migrated in 12 May 2026 audit). ✅
+- `examples/llm_integration/mistral_demo.py` rewritten in the same audit to use `AsyncOpenAI`. ✅
+- `MistralAdapter` inherits from `OpenAIAdapter` — schema output unchanged. ✅
+
+### Groq
+
+- `AsyncGroq` client with `chat.completions.create()`. ✅
+- `GroqAdapter` inherits from `OpenAIAdapter`. ✅
+
+---
+
+## 4. Framework Integration Refactors
+
+No code refactors required in this cycle. All AF integration modules verified against `agent-framework` 1.4.0.
+
+### Microsoft Agent Framework (Priority Review)
+
+**Agent construction** (`GantryToolBridge`, `GantryContextProvider`):
+- `Agent(client, instructions, name=..., tools=..., middleware=...)` constructor pattern. ✅
+- `@agent_framework.tool(name=..., description=..., approval_mode=...)` decoration; falls back to bare callable when AF not installed. ✅
+- `approval_mode="always_require"` for destructive capabilities (`WRITE_DATA`, `DELETE_DATA`, `EXECUTE_CODE`, `FINANCIAL`, `PII_ACCESS`). ✅
+
+**Workflow subsystem** (verified against AF 1.4.0):
+- `SequentialBuilder`, `ConcurrentBuilder`, `HandoffBuilder` — correct. ✅
+- `WorkflowBuilder`, `AgentExecutor`, `WorkflowAgent` — correct. ✅
+- AF 1.2.2 terminal-output change (`AgentResponse` instead of bare string): noted in example docstrings. ✅
+
+**Middleware pipeline**:
+- `FunctionMiddleware` (preferred) / `ChatMiddlewareLayer` (fallback) — lazy import guards in `agent_framework_middleware.py`. ✅
+- `MiddlewareTermination` for approval flow. ✅
+- `@chat_middleware` decorator for per-round tool refreshes in `GantryContextProvider.as_chat_middleware()`. ✅
+
+**Context providers** (`GantryContextProvider`):
+- Subclasses `agent_framework.ContextProvider` dynamically (lazy import preserves AF-free importability). ✅
+- `before_run()` → `context.extend_tools(source_id, tools)`. ✅
+- `per_call` / `per_run` strategy; `query_generator` callable (sync or async). ✅
+- `always_include`, `required`, `static_tools`, `verbose` parameters. ✅
+- `skills=True` co-operation with `SkillsProvider` via `source_id`. ✅
+
+**AF 1.4.0 new features** (assessed):
+- **MCP tool-call metadata forwarding**: AF 1.4.0 adds provenance metadata to MCP tool call events. `AgentFrameworkAdapter.to_provider_schema()` already supports optional `include_metadata=True` to emit Gantry namespace/version/source in the schema; no further change required since AF handles the MCP metadata path internally.
+- **Path-traversal fix in checkpoint storage**: Infrastructure change — no Gantry code affected.
+- **A2A SDK v1.0 alignment**: Internal to AF; Gantry's A2A adapter (`adapters/executors/a2a_executor.py`) communicates via HTTP — unaffected.
+- **SkillFrontmatter extraction** (experimental, breaking in 1.4.0): Gantry does not use file-based skills via AF's experimental skills API. Not affected.
+- **DevUI CORS tightening** (breaking in 1.4.0): DevUI is an AF developer tool; not relevant to Gantry library code.
+
+**AF 1.3.0 `allowed_tools` feature** (still pending — tracked as item **E**):
+Gantry does not yet expose `allowed_tools` as a pass-through on `GantryToolBridge.build_agent()` or `GantryContextProvider`. Tool-subset selection is still achieved via `query` + `limit`. See item E in §1.
+
+**`SkillsProvider` path-based API** (still needs confirmation — tracked as item **F**):
+The `SkillsProvider(skill_paths="./skills")` docstring example in `agent_framework_provider.py` uses the path-based API. AF 1.3.0 restructured the multi-source skills API, but no public migration guide has been published confirming the new syntax. Mark as **needs confirmation**.
+
+### LangChain / LangGraph
+
+- `fetch_framework_tools("langgraph", ...)` in `agent_gantry/integrations/framework_adapters.py` emits OpenAI-compatible schemas; LangGraph accepts these without conversion. ✅
+- `langchain 1.3.1` is now the resolved version; no call-site changes required. ✅
+- `langgraph 1.2.0` is both current and compatible with `langchain 1.3.1`'s constraint (`langgraph<1.3.0,>=1.2.0`). ✅
+
+### AutoGen
+
+- `autogen-agentchat 0.7.5` — current stable. No legacy 0.2.x patterns detected. ✅
+- MAF remains the successor direction for orchestration; AutoGen is retained as a parallel option for teams not yet migrating. ✅
+
+### CrewAI / Semantic Kernel / Google ADK
+
+All three are held at pinned floors due to opentelemetry/langgraph conflicts documented above. No code changes required within the pinned versions. Install each in a standalone environment to access the latest.
+
+---
+
+## 5. Universal Tool-Calling Design
+
+The `ToolSpec` contract and all provider translators remain sound and current. Full audit confirms no regressions.
+
+### Internal `ToolSpec` contract (`ToolDefinition`)
+
+- Canonical `parameters_schema` field (JSON Schema, `object` type). ✅
+- `to_dialect(dialect)` dispatcher routes through `DialectRegistry`. ✅
+- Deprecated `to_openai_schema()` / `to_anthropic_schema()` / `to_gemini_schema()` shims forward to `to_dialect()`. ✅
+- `SchemaDialect` enum: `OPENAI`, `OPENAI_RESPONSES`, `ANTHROPIC`, `GEMINI`, `MISTRAL`, `GROQ`, `AGENT_FRAMEWORK`, `AUTO`. ✅
+
+### Provider translator matrix (verified current)
+
+| Provider | Adapter | Schema shape emitted | Tool-call ID field | Tool-result field |
+|----------|---------|---------------------|-------------------|-------------------|
+| OpenAI Chat Completions | `OpenAIAdapter` | `{"type":"function","function":{name,desc,parameters}}` | `id` on call | `tool_call_id` on result |
+| OpenAI Responses API | `OpenAIResponsesAdapter` | `{"type":"function",name,desc,parameters}` (flat) | `call_id` | `call_id` on result |
+| Anthropic | `AnthropicAdapter` | `{name,description,input_schema}` | `id` (`toolu_…`) | `tool_use_id` on result |
+| Gemini | `GeminiAdapter` | `{name,description,parameters}` | `id` (parallel calls) | `functionResponse.id` |
+| Mistral | `MistralAdapter` (→ `OpenAIAdapter`) | OpenAI Chat Completions | `id` | `tool_call_id` |
+| Groq | `GroqAdapter` (→ `OpenAIAdapter`) | OpenAI Chat Completions | `id` | `tool_call_id` |
+| Agent Framework | `AgentFrameworkAdapter` (→ `OpenAIAdapter`) | OpenAI format + optional `metadata` | `id` or `call_id` | `tool_call_id` |
+
+### Parallel tool calls
+
+- OpenAI Responses API: parallel `function_call` items in `response.output`; `call_id` for correlation. ✅
+- Anthropic: multiple `tool_use` blocks in `response.content`; `id` for `tool_use_id`. ✅
+- Gemini: parallel `functionCall` parts with `id`; `GeminiAdapter.from_provider_payload` reads `id`. ✅
+
+### Tool name normalisation
+
+`ToolDefinition.name` enforces a snake_case pattern. All providers accept this format. No gaps. ✅
+
+---
+
+## 6. Documentation and Example Updates
+
+### Applied in this commit
+
+**`docs/reference/llm_sdk_compatibility.md`**:
+- OpenAI package requirement updated from `openai>=2.36.0` to `openai>=2.37.0` (three occurrences, all updated).
+
+**`pyproject.toml`**:
+- `openai` and `mistral` extras: floor `>=2.36.0` → `>=2.37.0`.
+- `langchain` floor `>=1.3.0` → `>=1.3.1` with explanatory comment.
+- `llm-providers` comment updated to reference 2.37.0.
+
+### No changes required
+
+- `examples/llm_integration/openai_demo.py`: Responses API (`gpt-4.1`) and Chat Completions (`gpt-4o`) — current. ✅
+- `examples/llm_integration/anthropic_demo.py`: `claude-sonnet-4-6`, current Messages API. ✅
+- `examples/llm_integration/google_genai_demo.py`: `gemini-2.5-flash`, `client.aio.models.generate_content`. ✅
+- `examples/llm_integration/mistral_demo.py`: `AsyncOpenAI(base_url=...)` pattern — migrated in prior audit. ✅
+- All `examples/agent_frameworks/`: AF 1.4.0-compatible patterns. ✅
+- `docs/QUICK_REFERENCE.md`, `README.md`: no stale version references found. ✅
+
+---
+
+## 7. Test and Migration Plan
+
+### Tests to add or update
+
+| Test | Type | Priority | Notes |
+|------|------|----------|-------|
+| `tests/test_llm_sdk_compatibility.py` — `TestOpenAICompatibility.test_openai_minimum_version` | Update | Low | Update assertion from `>=2.36.0` to `>=2.37.0` once that test exists; verify `openai.__version__` meets the new floor. |
+| `tests/test_llm_sdk_compatibility.py` — `TestLangChainCompatibility` | Update | Low | Verify `langchain.__version__ >= "1.3.1"` in any minimum-version assertion. |
+| `tests/test_agent_framework_integration.py` — `allowed_tools` pass-through | New | Medium | Once item E is implemented: unit test that `GantryToolBridge.build_agent(..., allowed_tools=[...])` forwards the list to AF's `Agent` constructor. Requires a mock for AF. |
+
+### Fixtures and mocks to regenerate
+
+No VCR recordings or golden fixtures are affected by the `openai` or `langchain` floor bumps. The changes are entirely additive (new floor only; the API surfaces used are unchanged).
+
+### Changelog-ready migration notes
+
+#### `openai` 2.36.0 → 2.37.0 (Non-breaking)
+
+Floor bumped to `>=2.37.0`. No API-surface changes in Gantry's call sites (Responses API, Chat Completions, and base-URL override for Mistral all remain stable). Users on 2.36.0 should upgrade:
+
+```bash
+pip install --upgrade openai
+```
+
+#### `langchain` 1.3.0 → 1.3.1 (Non-breaking patch)
+
+Floor bumped to `>=1.3.1`. langchain 1.3.1 is a patch release; no API changes. `langgraph>=1.2.0` remains compatible (`langchain 1.3.1` requires `langgraph<1.3.0,>=1.2.0`). Users on 1.3.0 should upgrade:
+
+```bash
+pip install --upgrade langchain
+```
+
+---
+
+## Appendix: Phase Inventory
+
+### Phase 1 — Repository Inventory (Complete)
+
+**Core modules read:**
+- `pyproject.toml`, `uv.lock`
+- `agent_gantry/__init__.py`
+- `agent_gantry/schema/tool.py`
+- `agent_gantry/adapters/tool_spec/base.py`, `providers.py`, `registry.py`
+- `agent_gantry/adapters/llm_client.py`
+- `agent_gantry/integrations/agent_framework_bridge.py`
+- `agent_gantry/integrations/agent_framework_middleware.py`
+- `agent_gantry/integrations/agent_framework_provider.py`
+- `agent_gantry/integrations/framework_adapters.py`
+- `agent_gantry/integrations/anthropic_features.py`
+- `examples/llm_integration/openai_demo.py`, `anthropic_demo.py`, `google_genai_demo.py`, `mistral_demo.py`
+- `examples/agent_frameworks/agent_framework_example.py`, `agent_framework_orchestration_example.py`, `agent_framework_provider_example.py`
+- `tests/test_llm_sdk_compatibility.py`
+- `docs/reference/llm_sdk_compatibility.md`
+- `docs/QUICK_REFERENCE.md`
+- Previous audit file `AUDIT_2026-05-12.md`
+
+**External sources fetched (PyPI JSON API, 2026-05-17):**
+- https://pypi.org/pypi/openai/json
+- https://pypi.org/pypi/anthropic/json
+- https://pypi.org/pypi/agent-framework/json, https://pypi.org/pypi/agent-framework-core/json
+- https://pypi.org/pypi/google-genai/json, https://pypi.org/pypi/google-genai/2.3.0/json
+- https://pypi.org/pypi/langchain/json, https://pypi.org/pypi/langchain/1.3.1/json
+- https://pypi.org/pypi/langgraph/json
+- https://pypi.org/pypi/langchain-openai/json
+- https://pypi.org/pypi/google-adk/json
+- https://pypi.org/pypi/crewai/json
+- https://pypi.org/pypi/semantic-kernel/json
+- https://pypi.org/pypi/mcp/json
+- https://pypi.org/pypi/autogen-agentchat/json
+- https://pypi.org/pypi/groq/json
+
+**No invented files, modules, tests, or APIs in this report.**
+
+---
+
+## Must-Change Now vs Good-Next-Step Split
+
+### Must-Change Now (Applied)
+
+1. **`openai` floor: `>=2.36.0` → `>=2.37.0`** — picks up the current stable release in `pyproject.toml`, `uv.lock`, and `docs/reference/llm_sdk_compatibility.md`.
+2. **`langchain` floor: `>=1.3.0` → `>=1.3.1`** — patch release; no breaking changes; `langgraph>=1.2.0` remains compatible.
+
+### Good Next-Step Improvements
+
+- **E**: Expose AF 1.3.0 `allowed_tools` as an optional pass-through on `GantryToolBridge` and `GantryContextProvider`.
+- **F**: Update `SkillsProvider` docstring for AF 1.3.0 multi-source skills API (awaiting public migration guide confirmation).
+- **G**: Add `output_schema` / `output_config` to `AnthropicClient.create_message()`.
+- **A**: `google-genai` standalone 2.x — document that `pip install "google-genai>=2.3.0"` alongside `agent-gantry[google-genai]` achieves a 2.x install; the floor comment is already accurate.
+- **B**, **C**, **D**: Dependency holds (`crewai`, `semantic-kernel`, `google-adk`) — unlock when upstream resolves opentelemetry / langgraph conflicts.

--- a/docs/reference/llm_sdk_compatibility.md
+++ b/docs/reference/llm_sdk_compatibility.md
@@ -50,7 +50,7 @@ pip install agent-gantry[all]
 
 ### Package
 ```bash
-pip install "openai>=2.36.0"
+pip install "openai>=2.37.0"
 ```
 
 ### Client Initialization
@@ -159,7 +159,7 @@ response = client.responses.create(
 
 ### Package
 ```bash
-pip install "openai>=2.36.0"
+pip install "openai>=2.37.0"
 ```
 
 ### Client Initialization
@@ -630,7 +630,7 @@ OpenRouter and other OpenAI-compatible providers (DeepSeek, Perplexity, Together
 
 ### Package
 ```bash
-pip install "openai>=2.36.0"
+pip install "openai>=2.37.0"
 ```
 
 ### Client Initialization

--- a/docs/reference/llm_sdk_compatibility.md
+++ b/docs/reference/llm_sdk_compatibility.md
@@ -253,7 +253,7 @@ response = client.chat.completions.create(
 
 ### Package
 ```bash
-pip install "anthropic>=0.101.0"
+pip install "anthropic>=0.102.0"
 ```
 
 ### Client Initialization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,9 @@ agent-frameworks = [
     # crewai==1.6.1 co-installs with agent-framework. For crewai 1.14.4 (standalone),
     # install in a separate environment without agent-framework.
     "crewai>=1.6.1",
-    "langchain>=1.3.0",
+    # langchain 1.3.1 (released 2026-05-17) is a patch release; no breaking changes.
+    # Requires langgraph<1.3.0,>=1.2.0 — compatible with our langgraph>=1.2.0 floor.
+    "langchain>=1.3.1",
     "langchain-openai>=1.2.1",
     # langchain 1.3.0 GA (released 2026-05-14) lifted the langgraph<1.2.0 upper bound.
     # Floor bumped from 1.1.10 to 1.2.0.
@@ -125,7 +127,7 @@ embeddings = [
     "sentence-transformers>=2.2.0",
 ]
 openai = [
-    "openai>=2.36.0",
+    "openai>=2.37.0",
 ]
 cohere = [
     "cohere>=5.0.0",
@@ -186,7 +188,7 @@ mistral = [
     # AsyncOpenAI(). The MistralAdapter in agent_gantry.adapters.tool_spec
     # continues to translate tool schemas correctly for both patterns.
     # Install with: pip install "agent-gantry[mistral]"
-    "openai>=2.36.0",
+    "openai>=2.37.0",
 ]
 groq = [
     "groq>=1.2.0",
@@ -194,7 +196,7 @@ groq = [
 # Combined LLM provider dependencies
 llm-providers = [
     # mistralai package is quarantined on PyPI (2026-05-12). The mistral extra
-    # resolves to openai>=2.36.0 (Mistral is OpenAI-compatible). Including it
+    # resolves to openai>=2.37.0 (Mistral is OpenAI-compatible). Including it
     # here ensures [all] users inherit the mistral path and any future
     # Mistral-specific dependencies are picked up automatically.
     "agent-gantry[openai,anthropic,google-genai,google-vertexai,mistral,groq]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ agent-frameworks = [
     # crewai==1.6.1 co-installs with agent-framework. For crewai 1.14.4 (standalone),
     # install in a separate environment without agent-framework.
     "crewai>=1.6.1",
-    # langchain 1.3.1 (released 2026-05-17) is a patch release; no breaking changes.
+    # langchain 1.3.1 (released 2026-05-15) is a patch release; no breaking changes.
     # Requires langgraph<1.3.0,>=1.2.0 — compatible with our langgraph>=1.2.0 floor.
     "langchain>=1.3.1",
     "langchain-openai>=1.2.1",

--- a/tests/test_llm_sdk_compatibility.py
+++ b/tests/test_llm_sdk_compatibility.py
@@ -381,12 +381,15 @@ class TestSDKVersionCompatibility:
     """Tests for SDK version compatibility."""
 
     def test_openai_minimum_version(self) -> None:
-        """Test OpenAI SDK meets minimum version."""
+        """Test OpenAI SDK meets minimum version (>=2.37.0 per pyproject.toml [openai] extra)."""
+        from packaging.version import Version
+
         openai = pytest.importorskip("openai")
         version = openai.__version__
-        parts = version.split(".")
-        major = int(parts[0])
-        assert major >= 1, f"OpenAI SDK version {version} is below minimum 1.0.0"
+        assert Version(version) >= Version("2.37.0"), (
+            f"OpenAI SDK version {version} is below the minimum 2.37.0 required by "
+            "the [openai] extra in pyproject.toml."
+        )
 
     def test_anthropic_minimum_version(self) -> None:
         """Test Anthropic SDK meets minimum version."""
@@ -398,8 +401,8 @@ class TestSDKVersionCompatibility:
         version = getattr(anthropic, "__version__", None)
         if version is None:
             pytest.skip("anthropic module is mocked in this test session")
-        assert Version(version) >= Version("0.101.0"), (
-            f"Anthropic SDK version {version} is below minimum 0.101.0"
+        assert Version(version) >= Version("0.102.0"), (
+            f"Anthropic SDK version {version} is below minimum 0.102.0"
         )
 
     def test_groq_minimum_version(self) -> None:
@@ -416,12 +419,12 @@ class TestSDKVersionCompatibility:
 
     def test_mistral_uses_openai_minimum_version(self) -> None:
         """Mistral is consumed via the OpenAI SDK; verify it meets the floor used
-        by the ``mistral`` extra in ``pyproject.toml`` (``openai>=2.36.0``)."""
+        by the ``mistral`` extra in ``pyproject.toml`` (``openai>=2.37.0``)."""
         from packaging.version import Version
 
         openai = pytest.importorskip("openai")
         version = openai.__version__
-        assert Version(version) >= Version("2.36.0"), (
-            f"OpenAI SDK version {version} is below the minimum 2.36.0 required "
+        assert Version(version) >= Version("2.37.0"), (
+            f"OpenAI SDK version {version} is below the minimum 2.37.0 required "
             "for Mistral's OpenAI-compatible endpoint."
         )

--- a/uv.lock
+++ b/uv.lock
@@ -684,7 +684,7 @@ requires-dist = [
     { name = "huggingface-hub", extras = ["hf-xet"], marker = "extra == 'example-tools'", specifier = ">=0.36.0" },
     { name = "jsonschema", specifier = ">=4.18.0" },
     { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.4.0" },
-    { name = "langchain", marker = "extra == 'agent-frameworks'", specifier = ">=1.3.0" },
+    { name = "langchain", marker = "extra == 'agent-frameworks'", specifier = ">=1.3.1" },
     { name = "langchain-openai", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.1" },
     { name = "langgraph", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.0" },
     { name = "llama-index-core", marker = "extra == 'agent-frameworks'", specifier = ">=0.14.21" },
@@ -694,8 +694,8 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'embeddings'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'nomic'", specifier = ">=1.24.0" },
-    { name = "openai", marker = "extra == 'mistral'", specifier = ">=2.36.0" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.36.0" },
+    { name = "openai", marker = "extra == 'mistral'", specifier = ">=2.37.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.37.0" },
     { name = "pandas", marker = "extra == 'example-tools'", specifier = ">=2.0.0" },
     { name = "pillow", marker = "extra == 'example-tools'", specifier = ">=10.0.0" },
     { name = "pint", marker = "extra == 'example-tools'", specifier = ">=0.24.4" },
@@ -3849,16 +3849,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/74/03fd4c07993c49c4b80635bb4c723643ff78af81c9471d1266f879f68df1/langchain-1.3.0.tar.gz", hash = "sha256:8ec70ee0cef94255f3e522423b254093a3dd34509638d353c50f3d9dd498debc", size = 580604, upload-time = "2026-05-12T14:45:50.7Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e5/6350e77a9e2764eaafcb2d581cbf0b800f53c6bc98fdf5ebc85f3a931ded/langchain-1.3.1.tar.gz", hash = "sha256:bc283c220233230f48b8e50ab1fbf1b688bcb206d933fa448d40a9b143177f62", size = 581329, upload-time = "2026-05-15T18:14:55.368Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/6f/b9a9721c27fbb6d29a6a7cd89d6a41eeffc7c79b49b9a5cf5beb1d60952d/langchain-1.3.0-py3-none-any.whl", hash = "sha256:9ce48828c706c00c586304b519fbd910e75d9f5ab3f319c31834e42107437f43", size = 114079, upload-time = "2026-05-12T14:45:48.818Z" },
+    { url = "https://files.pythonhosted.org/packages/78/11/3d7ed10b535413a07ed5e15682abcb77f3c4204ac49586977a495f9b24e6/langchain-1.3.1-py3-none-any.whl", hash = "sha256:154e9c30c90b391eba4315296f6bf6b6fac6b058ddea4cc771a10470968fe36f", size = 114345, upload-time = "2026-05-15T18:14:53.984Z" },
 ]
 
 [[package]]
@@ -5090,7 +5090,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.36.0"
+version = "2.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -5102,9 +5102,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/a1/4d5e84cf51720fc1526cc49e10ac1961abcccb55b0efb3d970db1e9a2728/openai-2.36.0.tar.gz", hash = "sha256:139dea0edd2f1b30c33d46ae1a6929e03906254140318e4608e98fe8c566f2e7", size = 753003, upload-time = "2026-05-07T17:33:17.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/50/5901f01ef14e6c27788beb91e54fef5d6204fb5fb9e97402fc8a14de2e32/openai-2.37.0.tar.gz", hash = "sha256:f4bc562cc5f3a43d40d678105572d9d44765f6e0f50c125f63055419b72f4bd9", size = 754706, upload-time = "2026-05-15T22:30:35.428Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/1c/5d43735b2553baae2a5e899dcbcd0670a86930d993184d72ca909bf11c9b/openai-2.36.0-py3-none-any.whl", hash = "sha256:143f6194b548dbc2c921af1f1b03b9f14c85fed8a75b5b516f5bcc11a2a50c63", size = 1302361, upload-time = "2026-05-07T17:33:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4c/bce61680d0699a78a405fd9a67989b175ba020590428831aab2ab1d2be7c/openai-2.37.0-py3-none-any.whl", hash = "sha256:814633888b8f3b1ffd6615697c6e4ef93632d08b7c2e28c8c5ef3556e5a10107", size = 1303238, upload-time = "2026-05-15T22:30:32.767Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR updates the minimum version requirements for two core LLM SDK dependencies to their latest stable releases, as identified in the Agent-Gantry Modernisation Audit (17 May 2026). Both updates are non-breaking and maintain full API compatibility with existing Gantry call sites.

## Changes

- **OpenAI SDK**: Bumped floor from `>=2.36.0` to `>=2.37.0`
  - Updated in `pyproject.toml` across `openai` and `mistral` extras
  - Updated in `docs/reference/llm_sdk_compatibility.md` (three occurrences)
  - No breaking changes to Responses API or Chat Completions surfaces used by Gantry

- **LangChain**: Bumped floor from `>=1.3.0` to `>=1.3.1`
  - Updated in `pyproject.toml` with explanatory comment
  - Patch release with no breaking changes
  - Constraint `langgraph<1.3.0,>=1.2.0` remains compatible with Gantry's `langgraph>=1.2.0` floor

## Implementation Details

- All version updates verified against PyPI JSON API on 2026-05-17
- No provider API refactors required; all call sites remain stable
- Documentation updated to reflect new minimum versions
- Lock file updated via `uv lock --upgrade-package openai --upgrade-package langchain`

## Audit Reference

See `docs/audits/AUDIT_2026-05-17.md` for full compatibility analysis, dependency conflict resolution, and tracked improvements for future releases (e.g., `allowed_tools` pass-through for Agent Framework 1.3.0, structured output support for Anthropic).

https://claude.ai/code/session_01UFEnF1dnqpM3AtCggo7QaZ