### PR TITLE
Document lint integration patterns for CI/CD workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,7 +790,7 @@ repos:
     hooks:
       - id: agent-gantry-lint
         name: agent-gantry lint
-        entry: python -m scripts.gantry_lint
+        entry: python scripts/gantry_lint.py
         language: system
         pass_filenames: false
         files: ^my_app/tools/.*\.py$
@@ -821,8 +821,11 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
+      # Install your project so `my_app.tools` is importable. Swap for
+      # `uv sync` / `poetry install` / `pip install -r requirements.txt`
+      # as appropriate.
       - run: pip install -e .
-      - run: python -m scripts.gantry_lint
+      - run: python scripts/gantry_lint.py
         env:
           # Provide whatever credentials your embedder needs — e.g. for
           # OpenAIEmbedder, set OPENAI_API_KEY. Without these, the
@@ -830,7 +833,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-The bundled CLI boots with demo tools and an in-memory embedder. For details and customization options, see [docs/cli.md](docs/cli.md).
+For more CLI details and customization options, see [docs/cli.md](docs/cli.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -766,7 +766,9 @@ The bundled `agent-gantry` entrypoint boots with demo tools, so for your own reg
 
 ```python
 # scripts/gantry_lint.py
-import asyncio, sys
+import asyncio
+import sys
+
 from my_app.tools import gantry  # your configured AgentGantry instance
 
 async def _run() -> int:
@@ -805,6 +807,7 @@ on:
   pull_request:
     paths:
       - 'my_app/tools/**'
+      - 'scripts/gantry_lint.py'
       - 'pyproject.toml'
   push:
     branches: [main]
@@ -820,6 +823,11 @@ jobs:
           cache: pip
       - run: pip install -e .
       - run: python -m scripts.gantry_lint
+        env:
+          # Provide whatever credentials your embedder needs — e.g. for
+          # OpenAIEmbedder, set OPENAI_API_KEY. Without these, the
+          # analyze_registry() call fails in the embedding phase.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
 The bundled CLI boots with demo tools and an in-memory embedder. For details and customization options, see [docs/cli.md](docs/cli.md).

--- a/README.md
+++ b/README.md
@@ -760,9 +760,69 @@ agent-gantry sync --dry-run                    # which tools would (re-)embed an
 agent-gantry install-skill --target ./skills   # install the bundled Claude Skill
 ```
 
-`lint` flags three patterns that silently degrade routing quality: tool descriptions that name *other* registered tools (the embedding pulls them toward the wrong queries), pairs of tools with >0.85 cosine similarity (probably should be merged or differentiated), and tags that appear on more than half the registry (low discriminative value).
+`lint` flags three patterns that silently degrade routing quality: tool descriptions that name *other* registered tools (the embedding pulls them toward the wrong queries), pairs of tools with >0.85 cosine similarity (probably should be merged or differentiated), and tags that appear on more than half the registry (low discriminative value). Exit code is `1` when any issues are flagged, `0` when the registry is clean — so it drops into any CI runner that respects exit codes.
 
-The CLI boots with demo tools and an in-memory embedder. For details and customization options, see [docs/cli.md](docs/cli.md).
+The bundled `agent-gantry` entrypoint boots with demo tools, so for your own registry wire a tiny wrapper that imports your `AgentGantry` instance and calls `analyze_registry()` directly:
+
+```python
+# scripts/gantry_lint.py
+import asyncio, sys
+from my_app.tools import gantry  # your configured AgentGantry instance
+
+async def _run() -> int:
+    analysis = await gantry.analyze_registry()
+    print(analysis.format_text())
+    return 1 if not analysis.empty else 0
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_run()))
+```
+
+### `lint` as a pre-commit hook
+
+Add a `local` hook to `.pre-commit-config.yaml` so the registry gets checked on every commit that touches tool definitions:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: agent-gantry-lint
+        name: agent-gantry lint
+        entry: python -m scripts.gantry_lint
+        language: system
+        pass_filenames: false
+        files: ^my_app/tools/.*\.py$
+```
+
+`pass_filenames: false` keeps the hook running once per commit instead of once per file, and the `files:` filter skips it on commits that don't touch the registry.
+
+### `lint` in GitHub Actions
+
+```yaml
+# .github/workflows/gantry-lint.yml
+name: gantry-lint
+on:
+  pull_request:
+    paths:
+      - 'my_app/tools/**'
+      - 'pyproject.toml'
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+      - run: pip install -e .
+      - run: python -m scripts.gantry_lint
+```
+
+The bundled CLI boots with demo tools and an in-memory embedder. For details and customization options, see [docs/cli.md](docs/cli.md).
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
Enhanced the README documentation to provide practical guidance on integrating the `lint` command into CI/CD workflows, including pre-commit hooks and GitHub Actions examples.

## Key Changes
- **Clarified exit code behavior**: Added explicit documentation that `lint` returns exit code `1` when issues are flagged and `0` when clean, making it compatible with standard CI runners
- **Added custom wrapper pattern**: Documented how to create a wrapper script that imports a configured `AgentGantry` instance and calls `analyze_registry()` directly, enabling integration with custom tool registries
- **Pre-commit hook integration**: Added `.pre-commit-config.yaml` example showing how to run `lint` on every commit that touches tool definitions, with explanation of `pass_filenames: false` and file filtering
- **GitHub Actions workflow**: Provided a complete `.github/workflows/gantry-lint.yml` example with appropriate path filters for tool definitions and configuration files

## Implementation Details
The documentation emphasizes that the bundled CLI entrypoint uses demo tools, so users should wire their own `AgentGantry` instance for production use. The examples show both local development (pre-commit) and CI/CD (GitHub Actions) integration patterns, with clear explanations of configuration options like file filtering to avoid unnecessary hook executions.

https://claude.ai/code/session_01Vau9wTjbRMDKtTsBsoTucs