### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled PermissionDeniedError in executor

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@
 **Prevention:** To explicitly reject newlines and avoid security bypasses in Pydantic models, use a custom `@field_validator` checking `"
 " in v or "" in v` across the entire string rather than relying on regex `$` or checking `.endswith('
 ')`.
+
+## 2024-05-18 - [MEDIUM] Fix unhandled PermissionDeniedError in executor
+**Vulnerability:** The `ExecutionEngine._check_security_policy` method caught `ConfirmationRequiredError` raised by `SecurityPolicy.check_permission` but failed to catch `PermissionDeniedError`. When a domain was restricted by the security policy or a rate limit was reached, an unhandled exception would bubble up instead of cleanly returning a failed `ToolResult`.
+**Learning:** Security policy exceptions (like authorization and permission errors) must be exhaustively caught within the tool execution pipeline to ensure the engine gracefully and securely fails, logging the outcome without crashing the parent application or exposing raw stack traces.
+**Prevention:** Always verify that every custom exception raised by a security or validation component is explicitly handled in the calling method, specifically when translating application exceptions into structured API or execution responses like `ToolResult`.

--- a/agent_gantry/core/executor.py
+++ b/agent_gantry/core/executor.py
@@ -344,7 +344,7 @@ class ExecutionEngine:
     ) -> ToolResult | None:
         """Check security policy permissions."""
         if self._security_policy:
-            from agent_gantry.core.security import ConfirmationRequiredError
+            from agent_gantry.core.security import ConfirmationRequiredError, PermissionDeniedError
 
             try:
                 self._security_policy.check_permission(call.tool_name, call.arguments)
@@ -353,6 +353,20 @@ class ExecutionEngine:
                     tool_name=call.tool_name,
                     status=ExecutionStatus.PENDING_CONFIRMATION,
                     error="Tool requires human confirmation",
+                    queued_at=queued_at,
+                    completed_at=datetime.now(timezone.utc),
+                    trace_id=trace_id,
+                    span_id=span_id,
+                )
+                if self._telemetry:
+                    await self._telemetry.record_execution(call, result)
+                return result
+            except PermissionDeniedError as e:
+                result = ToolResult(
+                    tool_name=call.tool_name,
+                    status=ExecutionStatus.FAILURE,
+                    error=str(e),
+                    error_type="PermissionDeniedError",
                     queued_at=queued_at,
                     completed_at=datetime.now(timezone.utc),
                     trace_id=trace_id,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The SecurityPolicy.check_permission method could raise PermissionDeniedError which was not caught in ExecutionEngine._check_security_policy, causing unhandled exceptions.
🎯 Impact: This could crash the executor when a tool was denied execution due to domain restrictions or rate limits.
🔧 Fix: Add try-except block to catch PermissionDeniedError and return a ToolResult with FAILURE status.
✅ Verification: Ran test suite to ensure the fix handles the error safely.

---
*PR created automatically by Jules for task [14204764332790203742](https://jules.google.com/task/14204764332790203742) started by @CodeHalwell*