### PR TITLE
Bump anthropic to 0.103.0 and llama-index-core to 0.14.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`anthropic` floor bumped to `>=0.103.0`** (was `>=0.102.0`). Released
+  2026-05-19; adds self-hosted sandbox helpers for Claude Managed Agents (CMA).
+  No breaking changes; no Gantry code changes required.
+  *Risk: safe internal — floor bump only.*
+  Source: https://pypi.org/pypi/anthropic/json
+
+- **`llama-index-core` floor bumped to `>=0.14.22`** (was `>=0.14.21`). Patch
+  release; no API changes.
+  *Risk: safe internal — floor bump only.*
+  Source: https://pypi.org/pypi/llama-index-core/json
+
+- **`pyproject.toml` held-package comments updated** to reflect latest stable
+  versions: `crewai` 1.14.5 (was 1.14.4), `google-adk` 1.34.0 (was 1.33.0),
+  `google-genai` 2.4.0 (was 2.3.0). Floor pins and conflict notes are unchanged.
+
+## [0.4.0+2026-05-16] — pre-release patch (CHANGELOG entry retroactively named)
+
 ### Added
 
 - **`AnthropicClient.create_message()` now accepts `output_schema`** — an optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`pyproject.toml` held-package comments updated** to reflect latest stable
   versions: `crewai` 1.14.5 (was 1.14.4), `google-adk` 1.34.0 (was 1.33.0),
   `google-genai` 2.4.0 (was 2.3.0). Floor pins and conflict notes are unchanged.
+  *Risk: safe internal — documentation only.*
+  Source: `pyproject.toml`
 
 ## [0.4.0+2026-05-16] — pre-release patch (CHANGELOG entry retroactively named)
 

--- a/docs/audits/AUDIT_2026-05-19.md
+++ b/docs/audits/AUDIT_2026-05-19.md
@@ -1,0 +1,346 @@
+# Agent-Gantry Modernisation Audit — 19 May 2026
+
+**Auditor**: Claude (Sonnet 4.6) operating as repository maintainer  
+**Branch**: `claude/elegant-clarke-imaWu`  
+**Date**: 2026-05-19  
+**Scope**: Full compatibility and modernisation audit — all seven phases — against the latest stable LLM provider SDKs, provider API standards, and agent framework patterns. Incremental over the 16 May 2026 audit (branch `claude/elegant-clarke-kCXfB`).
+
+---
+
+## 1. Executive Summary
+
+This audit identifies **three must-change-now items**, all applied in this commit, and carries forward several good-next-step improvements, two of which have updated status and one newly added.
+
+### Must-Change Now (Applied in This Commit)
+
+| # | Finding | Files Affected | Risk |
+|---|---------|----------------|------|
+| 1 | **`anthropic` floor: `>=0.102.0` → `>=0.103.0`.** Anthropic Python SDK 0.103.0 released 2026-05-19. Adds self-hosted sandbox helpers for Claude Managed Agents (CMA). No breaking changes; no Gantry code changes required. Floor bumped in the `anthropic` extra. | `pyproject.toml`, `uv.lock` | *Safe internal — floor bump only* |
+| 2 | **`llama-index-core` floor: `>=0.14.21` → `>=0.14.22`.** Patch release; no API changes. Lock file updated to 0.14.22. | `pyproject.toml`, `uv.lock` | *Safe internal — floor bump only* |
+| 3 | **Held-package comments updated** in `pyproject.toml` to reflect newly released latest-stable versions: `crewai` 1.14.5 (was 1.14.4), `google-adk` 1.34.0 (was 1.33.0), `google-genai` 2.4.0 (was 2.3.0). Floor pins and conflict notes are unchanged — the underlying dependency conflicts that block each upgrade remain. | `pyproject.toml` | *Documentation only — no install behaviour change* |
+
+### Good-Next-Step Improvements
+
+| # | Finding | Status |
+|---|---------|--------|
+| A | **`google-genai` 2.x upgrade** blocked: `google-adk>=1.14.1` requires `google-genai<2.0.0` (confirmed via PyPI: `google-adk 1.34.0` sets `google-genai<2,>=1.72`). Latest 2.4.0 introduces breaking changes only in the Interactions API; `generateContent` and `functionDeclarations` are unaffected. Upgrade in a standalone `[google-genai]` environment. | ⏳ Held — unchanged |
+| C | **Expose AF 1.3.0/1.4.0 `allowed_tools`** in `GantryToolBridge.build_agent()` / `as_agent()` and `GantryContextProvider`. The parameter allows specifying which tools the model may call in a given turn, enabling fine-grained per-turn tool-choice without switching agents. | ⏳ Pending — carried from 2026-05-12 audit |
+| D | **Update `SkillsProvider` docstring example** for AF 1.3.0+ multi-source skills API (`SkillsProvider(skills=[...])` vs path-based) once the migration guide is confirmed. Runtime code unchanged. | ⏳ Pending — carried from 2026-05-12 audit |
+| F | **`crewai` 1.6.1 → 1.14.5**: blocked by `opentelemetry-api~=1.34.0` (crewai) vs `>=1.39.0` (agent-framework-core 1.4.0). Install crewai 1.14.5 standalone without agent-framework. | ⏳ Held — latest is now 1.14.5 (was 1.14.4) |
+| G | **`semantic-kernel` 1.36.0 → 1.42.0** and **`google-adk` 1.14.1 → 1.34.0**: `semantic-kernel` pins `opentelemetry-api~=1.24`, conflicting with `agent-framework>=1.4.0` (`>=1.39.0`). `google-adk 1.34.0` requires `langgraph<0.4.8` (extensions extra), which conflicts with `langgraph>=1.2.0` in the combined extra. Install each standalone. | ⏳ Held — google-adk latest is now 1.34.0 (was 1.33.0) |
+| H | **AF 1.4.0 MCP tool-call metadata forwarding.** AF 1.4.0 can forward MCP tool-call metadata through the agent middleware pipeline. Gantry's `GantryObservabilityMiddleware` records tool invocations via `telemetry.span("af_function_invocation", {"tool_name": name})`; once the AF 1.4.0 API shape for MCP metadata is documented, the span attributes dict should be extended to include it. Needs confirmation once docs are published. | ⏳ Pending — from 2026-05-16 audit |
+| I (new) | **AutoGen → MAF migration pathway.** `examples/agent_frameworks/autogen_example.py` uses `autogen-agentchat>=0.7.5` (AG2) patterns. MAF is Microsoft's stated successor direction. The example is correct for current AG2 and does not need changing for compatibility; however, users migrating to MAF should be pointed to `agent_framework_example.py` and `agent_framework_orchestration_example.py` as the idiomatic replacement pattern. A migration note in the AutoGen example docstring would clarify intent. | 🆕 New — documentation suggestion |
+
+### Resolved Items from Previous Audits
+
+| # | Finding | Resolution |
+|---|---------|-----------|
+| B | **`langgraph>=1.2.0`** — unlock when `langchain 1.3.0 GA` published | ✅ Resolved in 0.4.0 |
+| E | **`output_schema` / `output_config` for `AnthropicClient.create_message()`** | ✅ Resolved in 2026-05-16 audit |
+
+### Carried-Over Holds (All Documented in `pyproject.toml`)
+
+| Package | Held At | Latest | Blocker |
+|---------|---------|--------|---------|
+| `crewai` | 1.6.1 | 1.14.5 | `opentelemetry-api~=1.34.0` conflicts with `agent-framework-core>=1.4.0` (`>=1.39.0`) |
+| `semantic-kernel` | 1.36.0 | 1.42.0 | `opentelemetry-api~=1.24` conflict; also `pydantic<2.14` |
+| `google-adk` | 1.14.1 | 1.34.0 | `langgraph<0.4.8` requirement (extensions extra) incompatible with `langgraph>=1.2.0` |
+| `google-genai` | 1.75.0 | 2.4.0 | `google-adk>=1.14.1` requires `<2.0.0`; safe to install at 2.x in standalone `[google-genai]` environment |
+
+---
+
+## 2. Dependency Upgrade Plan
+
+All versions verified against PyPI JSON API on 2026-05-19.
+
+| Package | `pyproject.toml` floor (before) | `pyproject.toml` floor (after) | Lock (before) | Lock (after) | Latest stable | Status |
+|---------|--------------------------------|--------------------------------|---------------|--------------|---------------|--------|
+| `anthropic` | `>=0.102.0` | **`>=0.103.0`** | 0.102.0 | 0.103.0 | 0.103.0 | ✅ Updated |
+| `llama-index-core` | `>=0.14.21` | **`>=0.14.22`** | 0.14.21 | 0.14.22 | 0.14.22 | ✅ Updated |
+| `agent-framework` | `>=1.4.0,<2.0.0` | unchanged | 1.4.0 | 1.4.0 | 1.4.0 | ✅ Current |
+| `openai` | `>=2.37.0` | unchanged | 2.37.0 | 2.37.0 | 2.37.0 | ✅ Current |
+| `langchain` | `>=1.3.1` | unchanged | 1.3.1 | 1.3.1 | 1.3.1 | ✅ Current |
+| `langgraph` | `>=1.2.0` | unchanged | 1.2.0 | 1.2.0 | 1.2.0 | ✅ Current |
+| `langchain-openai` | `>=1.2.1` | unchanged | 1.2.1 | 1.2.1 | 1.2.1 | ✅ Current |
+| `groq` | `>=1.2.0` | unchanged | 1.2.0 | 1.2.0 | 1.2.0 | ✅ Current |
+| `mcp` | `>=1.27.1` | unchanged | 1.27.1 | 1.27.1 | 1.27.1 | ✅ Current |
+| `autogen-agentchat` | `>=0.7.5` | unchanged | 0.7.5 | 0.7.5 | 0.7.5 | ✅ Current |
+| `autogen-ext` | `>=0.7.5` | unchanged | 0.7.5 | 0.7.5 | 0.7.5 | ✅ Current |
+| `llama-index-llms-openai` | `>=0.7.7` | unchanged | 0.7.7 | 0.7.7 | 0.7.7 | ✅ Current |
+| `google-genai` | `>=1.75.0` | unchanged (held) | 1.75.0 | 1.75.0 | 2.4.0 | ⏳ Held — see §A |
+| `crewai` | `>=1.6.1` | unchanged (held) | 1.6.1 | 1.6.1 | 1.14.5 | ⏳ Held — see §F |
+| `google-adk` | `>=1.14.1` | unchanged (held) | 1.14.1 | 1.14.1 | 1.34.0 | ⏳ Held — see §G |
+| `semantic-kernel` | `>=1.36.0` | unchanged (held) | 1.36.0 | 1.36.0 | 1.42.0 | ⏳ Held — see §G |
+
+### Source URLs used for verification
+
+- `anthropic` 0.103.0: https://pypi.org/pypi/anthropic/json
+- `anthropic` 0.103.0 release notes: https://github.com/anthropics/anthropic-sdk-python/releases
+- `llama-index-core` 0.14.22: https://pypi.org/pypi/llama-index-core/json
+- `openai` 2.37.0: https://pypi.org/pypi/openai/json
+- `agent-framework` 1.4.0: https://pypi.org/pypi/agent-framework/json
+- `langchain` 1.3.1: https://pypi.org/pypi/langchain/json
+- `langgraph` 1.2.0: https://pypi.org/pypi/langgraph/json
+- `groq` 1.2.0: https://pypi.org/pypi/groq/json
+- `mcp` 1.27.1: https://pypi.org/pypi/mcp/json
+- `autogen-agentchat` 0.7.5: https://pypi.org/pypi/autogen-agentchat/json
+- `crewai` 1.14.5 / `opentelemetry-api~=1.34.0`: https://pypi.org/pypi/crewai/json
+- `google-adk` 1.34.0 / `langgraph<0.4.8` / `google-genai<2`: https://pypi.org/pypi/google-adk/json
+- `google-genai` 2.4.0: https://pypi.org/pypi/google-genai/json
+- `semantic-kernel` 1.42.0 / `opentelemetry-api~=1.24`: https://pypi.org/pypi/semantic-kernel/json
+- Anthropic Messages API reference: https://platform.claude.com/docs/en/api/messages
+- Anthropic structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs
+
+### `uv` commands applied in this commit
+
+```bash
+uv lock --upgrade-package anthropic --upgrade-package llama-index-core
+```
+
+### `anthropic` 0.102.0 → 0.103.0 — breaking-change impact assessment
+
+Release notes confirm **no breaking changes**. Changes are:
+
+- v0.103.0: Adds `SandboxHelpers` for self-hosted sandboxes in Claude Managed Agents (CMA). This feature is specific to CMA workflows and does not affect the base `messages.create()` API used by Gantry's `AnthropicClient`.
+- v0.102.0: `BetaManagedAgentsSearchResultBlock` types; cache diagnostics beta support. No base API changes.
+
+Source: https://github.com/anthropics/anthropic-sdk-python/releases
+
+### `llama-index-core` 0.14.21 → 0.14.22 — breaking-change impact assessment
+
+Patch release; no API changes reported. Gantry's `agent-frameworks` extra uses `llama-index-core` as a transitive dependency for LlamaIndex integration. No Gantry code changes required.
+
+Source: https://pypi.org/pypi/llama-index-core/json
+
+---
+
+## 3. Provider API Refactors
+
+No provider-API refactors are required in this cycle. All call sites verified against current official documentation.
+
+### OpenAI
+
+- **Responses API** (`client.responses.create()`): Correct in `openai_demo.py` (Scenario A) with `gpt-4.1`, `input=[...]`, `previous_response_id` for multi-turn. ✅
+- **Chat Completions**: Correct in Scenarios B and D with `gpt-4o`. ✅
+- **Assistants API**: Not present in the codebase. Sunset 26 August 2026 — no migration needed. ✅
+- **`OpenAIResponsesAdapter`**: Emits flat `{"type":"function","name":...,"parameters":...}` schema. ✅
+- **`OpenAIAdapter`**: Emits nested `{"type":"function","function":{...}}` for Chat Completions. ✅
+- **Model names**: `gpt-4.1` (Responses API), `gpt-4o` (Chat Completions) — current documented families. ✅
+
+### Anthropic
+
+- **Messages API** (`client.messages.create()`): Correct throughout.  
+  Source: https://platform.claude.com/docs/en/api/messages ✅
+- **`AnthropicAdapter`**: `{name, description, input_schema}` format, `tool_use` handling, `format_tool_result` with `is_error`. ✅
+- **`output_config` structured output shape**: Code emits `{"format": {"type": "json_schema", "schema": {...}}}` — confirmed correct against `platform.claude.com/docs/en/build-with-claude/structured-outputs`. The Messages API reference page shows a simplified flat form; the structured-outputs guide shows the full correct nested shape, which matches the code. ✅
+- **Current model names** listed by the live API: `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`. Examples use `claude-sonnet-4-6` — current and correct. ✅
+- **Adaptive thinking**: `AnthropicFeatures` supports `adaptive_thinking_effort` correctly. ✅
+
+### Google Gemini
+
+- **`client.aio.models.generate_content()`**: Correct async interface for `google-genai>=1.x`. ✅
+- **`GeminiAdapter`**: `{name, description, parameters}` function-declaration dict; `format_tool_result` places `id` inside `functionResponse`. ✅
+- **Model name**: `gemini-2.5-flash` in example. ✅
+
+### Mistral (post-quarantine)
+
+- Uses `AsyncOpenAI(base_url="https://api.mistral.ai/v1")` — correct. ✅
+- `MistralAdapter` inherits from `OpenAIAdapter` — correct. ✅
+
+### Groq
+
+- `AsyncGroq` via `groq>=1.2.0` — current and correct. ✅
+- `GroqAdapter` inherits from `OpenAIAdapter` — correct. ✅
+
+---
+
+## 4. Framework Integration Refactors
+
+No code refactors required in this cycle. All integration modules verified against current SDK versions.
+
+### Microsoft Agent Framework (Priority Review)
+
+All AF integration modules remain fully compatible with `agent-framework` 1.4.0. Verified surfaces:
+
+**Agent construction:**
+- `Agent(client, instructions, name=..., tools=..., middleware=...)`: ✅
+- `@agent_framework.tool(name=..., description=..., approval_mode=...)`: ✅
+- `approval_mode="always_require"` for destructive capabilities: ✅
+
+**Workflow subsystem:**
+- `WorkflowBuilder`, `AgentExecutor`, `WorkflowAgent`: ✅
+- `SequentialBuilder`, `HandoffBuilder`: ✅
+
+**Middleware pipeline:**
+- `FunctionMiddleware` (preferred) / `ChatMiddlewareLayer` (fallback): ✅
+- `MiddlewareTermination` for approval flow: ✅
+- `@chat_middleware` decorator for per-round refreshes: ✅
+
+**Context providers (`GantryContextProvider`):**
+- Subclasses `agent_framework.ContextProvider` with `source_id` keyed injection. ✅
+- `before_run()` → `context.extend_tools(source_id, tools)`: ✅
+- `per_call` / `per_run` strategies: ✅
+
+**Pending (item C)**: `allowed_tools` pass-through on `build_agent()`, `as_agent()`, and `GantryContextProvider` — still not implemented; no correctness impact.
+
+**Pending (item H)**: AF 1.4.0 MCP tool-call metadata forwarding — API shape not yet publicly documented; tracked for assessment once documentation is published.
+
+### LangChain / LangGraph
+
+LangChain 1.3.1 and LangGraph 1.2.0 — both current. No changes required. The `langchain_core.tools` import in `langgraph_example.py` remains correct.
+
+### AutoGen (AG2)
+
+`autogen-agentchat 0.7.5` and `autogen-ext 0.7.5` — both current and correct. The example at `examples/agent_frameworks/autogen_example.py` uses the AG2 async API correctly:
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+```
+
+**New item I**: This example is correct for users who remain on AG2. For teams migrating to the Microsoft Agent Framework (MAF), the idiomatic replacement is shown in `agent_framework_example.py`. A short migration note in the AutoGen example docstring (pointing to the MAF example) would help users evaluate the migration path without implying a forced change. This is a documentation suggestion only — the code is functionally correct.
+
+### CrewAI
+
+Held at 1.6.1 due to opentelemetry conflict. No refactors within the current pinned version.
+
+### Semantic Kernel / Google ADK
+
+Both held due to dependency conflicts. No refactors required.
+
+---
+
+## 5. Universal Tool-Calling Design
+
+No changes required. The design in `agent_gantry/adapters/tool_spec/` is sound and current.
+
+### Internal `ToolSpec` contract (`ToolDefinition`)
+
+- Single canonical `parameters_schema` (JSON Schema, OpenAI-style). ✅
+- `to_dialect(dialect)` dispatcher via `DialectRegistry`. ✅
+
+### Provider translators (verified current)
+
+| Provider | Adapter | Schema emitted | Tool-call ID field | Tool-result field |
+|----------|---------|---------------|-------------------|-------------------|
+| OpenAI Chat Completions | `OpenAIAdapter` | `{"type":"function","function":{name,description,parameters}}` | `id` | `tool_call_id` |
+| OpenAI Responses API | `OpenAIResponsesAdapter` | `{"type":"function",name,description,parameters}` (flat) | `call_id` | `call_id` |
+| Anthropic | `AnthropicAdapter` | `{name,description,input_schema}` | `id` (`toolu_…`) | `tool_use_id` |
+| Gemini | `GeminiAdapter` | `{name,description,parameters}` | `id` (parallel) | `functionResponse.id` |
+| Mistral | `MistralAdapter` → `OpenAIAdapter` | OpenAI Chat format | `id` | `tool_call_id` |
+| Groq | `GroqAdapter` → `OpenAIAdapter` | OpenAI Chat format | `id` | `tool_call_id` |
+| Agent Framework | `AgentFrameworkAdapter` → `OpenAIAdapter` | OpenAI + optional metadata | `id` or `call_id` | `tool_call_id` |
+
+All adapters verified correct against current provider documentation. No changes required.
+
+### Parallel tool calls
+
+- OpenAI Responses API: parallel `function_call` items; `call_id` for correlation. ✅
+- Anthropic: multiple `tool_use` blocks; `id` for `tool_use_id`. ✅
+- Gemini: parallel `functionCall` parts with `id`; `GeminiAdapter.from_provider_payload` reads `id`. ✅
+
+---
+
+## 6. Documentation and Example Updates
+
+### No changes required
+
+All examples verified against current SDK versions and API surfaces:
+
+- `examples/llm_integration/openai_demo.py`: Responses API with `gpt-4.1`; Chat Completions with `gpt-4o`. ✅
+- `examples/llm_integration/anthropic_demo.py`: `claude-sonnet-4-6`, Messages API, correct tool handling. ✅
+- `examples/llm_integration/google_genai_demo.py`: `gemini-2.5-flash`, `client.aio.models.generate_content`. ✅
+- `examples/llm_integration/mistral_demo.py`: `AsyncOpenAI(base_url=...)` pattern; no mistralai SDK. ✅
+- `examples/agent_frameworks/agent_framework_example.py`: AF 1.4.x patterns, `SequentialBuilder`, `HandoffBuilder`. ✅
+- `examples/agent_frameworks/autogen_example.py`: AG2 0.7.5 patterns — correct; MAF migration note suggested (item I). ✅ (functionally)
+- `docs/QUICK_REFERENCE.md`: No stale references detected. ✅
+
+### Good-next-step documentation (item I)
+
+Add a brief note to `examples/agent_frameworks/autogen_example.py` pointing users considering MAF to `agent_framework_example.py`:
+
+```diff
+--- a/examples/agent_frameworks/autogen_example.py
++++ b/examples/agent_frameworks/autogen_example.py
+@@ -14,6 +14,10 @@ Compatibility:
+     - AutoGen v0.4+ (AG2): ✅ Compatible
+     - AutoGen v0.2: ❌ Not compatible (breaking changes)
+ 
++Migration Notes (AG2 → Microsoft Agent Framework):
++    Microsoft Agent Framework (MAF) is Microsoft's successor direction to AutoGen.
++    For teams evaluating MAF, see ``examples/agent_frameworks/agent_framework_example.py``
++    for the idiomatic Gantry + MAF integration pattern, including multi-agent workflows.
++
+ Migration Notes:
+     AutoGen v0.4 uses a new async, event-driven API:
+```
+
+Risk: *Safe additive — documentation only.*
+
+---
+
+## 7. Test and Migration Plan
+
+### Tests to add / update
+
+| Test | Type | Priority | Notes |
+|------|------|----------|-------|
+| `tests/test_anthropic_features.py` | Verify | Low | The three `output_schema` tests added in the 2026-05-16 audit are unaffected by the 0.103.0 SDK bump (no API surface changes). All pass without modification. |
+| `tests/test_agent_framework_integration.py` | Verify | Low | Confirm bridge and provider tests still pass with `anthropic 0.103.0`. No AF API changes in this cycle. |
+
+### Fixtures and mocks to regenerate
+
+No VCR recordings or golden fixtures are affected. The `anthropic 0.103.0` bump does not change the `messages.create()` signature used by Gantry.
+
+### Changelog-ready migration notes
+
+#### `anthropic` 0.102.0 → 0.103.0 (Non-breaking)
+
+Floor bumped to `>=0.103.0`. Users should upgrade: `pip install --upgrade anthropic`. This release adds CMA sandbox helpers — no behaviour changes for standard Messages API or tool-use workflows.
+
+#### `llama-index-core` 0.14.21 → 0.14.22 (Non-breaking)
+
+Patch release. No migration required.
+
+---
+
+## Appendix: Phase Inventory
+
+### Phase 1 — Repository Inventory (Complete)
+
+**Core modules read:**
+- `pyproject.toml`, `uv.lock`
+- `agent_gantry/integrations/anthropic_features.py`
+- `agent_gantry/integrations/agent_framework_bridge.py`
+- `agent_gantry/integrations/agent_framework_middleware.py`
+- `agent_gantry/integrations/agent_framework_provider.py`
+- `agent_gantry/integrations/framework_adapters.py`
+- `agent_gantry/adapters/tool_spec/providers.py`
+- `agent_gantry/adapters/tool_spec/base.py`
+- `agent_gantry/adapters/llm_client.py`
+- All examples under `examples/llm_integration/` and `examples/agent_frameworks/`
+- `CHANGELOG.md`
+- Previous audit files (`AUDIT_2026-05-16.md` and earlier)
+
+**No invented files, modules, tests, or APIs in this report.**
+
+---
+
+## Must-Change Now vs Good-Next-Step Split
+
+### Must-Change Now (Applied in This Commit)
+
+1. **`anthropic` floor: `>=0.102.0` → `>=0.103.0`** — picks up 2026-05-19 release; no Gantry code changes.
+2. **`llama-index-core` floor: `>=0.14.21` → `>=0.14.22`** — patch bump; no code changes.
+3. **`pyproject.toml` comment hygiene** — latest-stable references for held packages corrected: `crewai` 1.14.5, `google-adk` 1.34.0, `google-genai` 2.4.0.
+
+### Good Next-Step Improvements
+
+- **C**: Expose AF `allowed_tools` in `GantryToolBridge.build_agent()` / `as_agent()` and `GantryContextProvider` for per-turn tool-choice filtering.
+- **D**: Update `SkillsProvider` docstring example for AF 1.3.0+ multi-source skills API once migration guide is confirmed.
+- **H**: Assess AF 1.4.0 MCP tool-call metadata forwarding once the AF 1.4.0 API shape is documented; expose via `GantryObservabilityMiddleware` span attributes.
+- **I (new)**: Add MAF migration pointer to `examples/agent_frameworks/autogen_example.py` docstring.
+- **A**: Upgrade `google-genai` to 2.x when `google-adk` lifts its `<2.0.0` upper bound.
+- **F**: Upgrade `crewai` to 1.14.5 when opentelemetry conflict is resolved upstream.
+- **G**: Upgrade `semantic-kernel` to 1.42.0 and `google-adk` to 1.34.0 when opentelemetry/langgraph conflicts are resolved.

--- a/examples/agent_frameworks/autogen_example.py
+++ b/examples/agent_frameworks/autogen_example.py
@@ -11,7 +11,13 @@ Compatibility:
     - AutoGen v0.4+ (AG2): ✅ Compatible
     - AutoGen v0.2: ❌ Not compatible (breaking changes)
 
-Migration Notes:
+Migration Notes (AG2 → Microsoft Agent Framework):
+    Microsoft Agent Framework (MAF) is Microsoft's stated successor direction to AutoGen.
+    For teams evaluating MAF, see ``examples/agent_frameworks/agent_framework_example.py``
+    for the idiomatic Gantry + MAF integration pattern, including multi-agent workflows.
+    This example remains fully supported for teams staying on AG2.
+
+Migration Notes (AutoGen v0.2 → v0.4):
     AutoGen v0.4 uses a new async, event-driven API:
     - autogen_agentchat: High-level agent chat API
     - autogen_ext: Extensions for model providers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,9 @@ agent-frameworks = [
     "agent-framework>=1.4.0,<2.0.0",
     "autogen-agentchat>=0.7.5",
     "autogen-ext[openai]>=0.7.5",
-    # crewai 1.14.4 (latest stable) pins opentelemetry-api~=1.34.0 (<1.35), which
+    # crewai 1.14.5 (latest stable) pins opentelemetry-api~=1.34.0 (<1.35), which
     # conflicts with agent-framework>=1.2.1 (requires opentelemetry-api>=1.39.0).
-    # crewai==1.6.1 co-installs with agent-framework. For crewai 1.14.4 (standalone),
+    # crewai==1.6.1 co-installs with agent-framework. For crewai 1.14.5 (standalone),
     # install in a separate environment without agent-framework.
     "crewai>=1.6.1",
     # langchain 1.3.1 (released 2026-05-16) — patch release; no API changes.
@@ -73,7 +73,7 @@ agent-frameworks = [
     # langchain 1.3.0 GA (released 2026-05-14) lifted the langgraph<1.2.0 upper bound.
     # Floor bumped from 1.1.10 to 1.2.0.
     "langgraph>=1.2.0",
-    "llama-index-core>=0.14.21",
+    "llama-index-core>=0.14.22",
     "llama-index-llms-openai>=0.7.7",
     # semantic-kernel 1.42.0 (latest stable 2026-05-15) relaxes the pydantic
     # upper bound to <2.14 (was <2.12 in <=1.41.x), but retains an opentelemetry-api
@@ -84,16 +84,16 @@ agent-frameworks = [
     # allows pydantic>=2.12), but google-adk 1.33.0 also requires langgraph<0.4.8
     # which conflicts with langgraph>=1.2.0 in this extra (see google-adk comment).
     "semantic-kernel>=1.36.0",
-    # google-adk 1.33.0 (latest, 2026-05-08) has two separate conflicts in this
+    # google-adk 1.34.0 (latest, 2026-05-18) has two separate conflicts in this
     # combined extra:
     # (1) Requires pydantic>=2.12, which conflicted with semantic-kernel<=1.41.x
     #     (pydantic<2.12). semantic-kernel 1.42.0 relaxes to pydantic<2.14, so
     #     the pydantic conflict is resolved once semantic-kernel is upgraded there.
-    # (2) Requires langgraph<0.4.8, which is incompatible with langgraph>=1.2.0
-    #     in this extra. This conflict cannot be resolved by a simple floor bump
-    #     and remains the primary blocker for google-adk 1.33.0 in the combined
-    #     agent-frameworks extra.
-    # Floor stays at 1.14.1. To use google-adk 1.33.0, install it in a standalone
+    # (2) Requires langgraph<0.4.8 (via extensions extra), which is incompatible
+    #     with langgraph>=1.2.0 in this extra. This conflict cannot be resolved by
+    #     a simple floor bump and remains the primary blocker for google-adk 1.34.0
+    #     in the combined agent-frameworks extra.
+    # Floor stays at 1.14.1. To use google-adk 1.34.0, install it in a standalone
     # environment without langchain/langgraph.
     "google-adk>=1.14.1",
 ]
@@ -166,13 +166,15 @@ a2a = [
 ]
 # LLM provider SDK dependencies
 anthropic = [
-    "anthropic>=0.102.0",
+    # 0.103.0 (released 2026-05-19): adds self-hosted sandbox helpers for Claude
+    # Managed Agents. No breaking changes; no Gantry code changes required.
+    "anthropic>=0.103.0",
 ]
 google-genai = [
-    # google-genai 2.3.0 (latest stable 2026-05-15) introduces breaking changes only
+    # google-genai 2.4.0 (latest stable 2026-05-19) introduces breaking changes only
     # in the Interactions API; GenerateContent and function calling are entirely
     # unaffected. google-adk (in the agent-frameworks extra) requires google-genai<2.0.0
-    # across all versions up to 1.33.0, so the all[] extra stays at the 1.x floor.
+    # across all versions up to 1.34.0, so the all[] extra stays at the 1.x floor.
     # Standalone 2.x upgrade: pip install "agent-gantry[google-genai]"
     "google-genai>=1.75.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -662,7 +662,7 @@ requires-dist = [
     { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.4.0,<2.0.0" },
     { name = "agent-gantry", extras = ["dev", "embeddings", "openai", "cohere", "vector-stores", "lancedb", "nomic", "mcp", "a2a", "llm-providers", "agent-frameworks", "example-tools"], marker = "extra == 'all'" },
     { name = "agent-gantry", extras = ["openai", "anthropic", "google-genai", "google-vertexai", "mistral", "groq"], marker = "extra == 'llm-providers'" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.102.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.103.0" },
     { name = "asyncpg", marker = "extra == 'pgvector'", specifier = ">=0.29.0" },
     { name = "asyncpg", marker = "extra == 'vector-stores'", specifier = ">=0.29.0" },
     { name = "autogen-agentchat", marker = "extra == 'agent-frameworks'", specifier = ">=0.7.5" },
@@ -687,7 +687,7 @@ requires-dist = [
     { name = "langchain", marker = "extra == 'agent-frameworks'", specifier = ">=1.3.1" },
     { name = "langchain-openai", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.1" },
     { name = "langgraph", marker = "extra == 'agent-frameworks'", specifier = ">=1.2.0" },
-    { name = "llama-index-core", marker = "extra == 'agent-frameworks'", specifier = ">=0.14.21" },
+    { name = "llama-index-core", marker = "extra == 'agent-frameworks'", specifier = ">=0.14.22" },
     { name = "llama-index-llms-openai", marker = "extra == 'agent-frameworks'", specifier = ">=0.7.7" },
     { name = "matplotlib", marker = "extra == 'example-tools'", specifier = ">=3.7.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.27.1" },
@@ -921,7 +921,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.102.0"
+version = "0.103.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -933,9 +933,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/47/cb2a71f70431fb09af4db83e3ea89eb2dd8e0e348d27af53ed32e6c599dd/anthropic-0.102.0.tar.gz", hash = "sha256:96f747cad11886c4ae12d4080131b94eebd68b202bd2190fe27959031bb1fa9c", size = 763697, upload-time = "2026-05-13T18:12:41.624Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/9a/b12a645cc4b213eca72d07261c22fab81492582f3ec559c282bc102c878e/anthropic-0.103.0.tar.gz", hash = "sha256:69e5b9f63e4206a8845498426e7a27e87b56943cbd6fa9346fc7067fa4bc5e95", size = 846192, upload-time = "2026-05-19T07:08:04.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/75/0f6c603594876413bc858a00e7cc0d80a0cc14edf5c7b959a3ea6ec45e44/anthropic-0.102.0-py3-none-any.whl", hash = "sha256:ab96540bbd4b0f36564252d955a86f8abbe4f00944a24bc9931acc9b139bab6f", size = 763070, upload-time = "2026-05-13T18:12:43.474Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d7/cde7c37c43228a827af8390245045c48c6a1808daaae456ba3e260d2b154/anthropic-0.103.0-py3-none-any.whl", hash = "sha256:67a915b8e54c5bf1af20618d1db3682554fdef895a848fe082ae34d218e9887d", size = 831677, upload-time = "2026-05-19T07:08:02.608Z" },
 ]
 
 [[package]]
@@ -4024,7 +4024,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-core"
-version = "0.14.21"
+version = "0.14.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -4058,9 +4058,9 @@ dependencies = [
     { name = "typing-inspect" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/43/d6d2a368865e68c25d3400c017fb772daab71427f08c4e36c591f729dbc3/llama_index_core-0.14.21.tar.gz", hash = "sha256:29706defbe2f429d28330a4eea010f9d92d42db92539382f8c800e19590cae45", size = 11581087, upload-time = "2026-04-21T00:18:10.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/7f/94a4b940ef0d069840df0fd6d361a2aa832a2dd73b4cecdf86e8f8c353c8/llama_index_core-0.14.22.tar.gz", hash = "sha256:1384410f89bdbd32349aab444ef4f5c828c338787bc65bd1ffd8e86dfb44ac41", size = 11584786, upload-time = "2026-05-14T20:21:37.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/23/55ec5f35a5c7f35b60d3928bcd2e867076440036a280cf4d07481719c249/llama_index_core-0.14.21-py3-none-any.whl", hash = "sha256:4a807d31e54d066068e076eb4d066efbf95e2d2a00dcbe0eba3d9340a04cad42", size = 11916624, upload-time = "2026-04-21T00:18:12.966Z" },
+    { url = "https://files.pythonhosted.org/packages/39/15/e1a26d8d56aa55fa07587a3e9c7e85294d2df5af6c2229193019bc549ef6/llama_index_core-0.14.22-py3-none-any.whl", hash = "sha256:9cfffde46fd5b7937101e1c0c9bb5c21bd7ff8c8a56937810b87ba3542f31225", size = 11920774, upload-time = "2026-05-14T20:21:40.409Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR applies three safe, non-breaking dependency floor bumps and updates documentation to reflect the latest stable versions of held packages.

## Changes

- **`anthropic` floor: `>=0.102.0` → `>=0.103.0`** (released 2026-05-19)
  - Adds self-hosted sandbox helpers for Claude Managed Agents (CMA)
  - No breaking changes; no Gantry code changes required
  - All existing tool-use and Messages API call sites remain unchanged

- **`llama-index-core` floor: `>=0.14.21` → `>=0.14.22`** (patch release)
  - No API changes; transitive dependency for LlamaIndex integration
  - No Gantry code changes required

- **`pyproject.toml` held-package comments updated** to reflect latest stable versions:
  - `crewai` 1.14.5 (was 1.14.4)
  - `google-adk` 1.34.0 (was 1.33.0)
  - `google-genai` 2.4.0 (was 2.3.0)
  - Floor pins and conflict notes unchanged; documentation only

- **`examples/agent_frameworks/autogen_example.py` docstring enhanced**
  - Added migration note pointing users evaluating Microsoft Agent Framework (MAF) to the idiomatic Gantry + MAF integration pattern
  - Clarifies that the AutoGen example remains fully supported for teams staying on AG2
  - No code logic changes; documentation suggestion only

- **`CHANGELOG.md` updated** with migration notes for the three dependency bumps

## Risk Assessment

All changes are safe:
- Dependency floor bumps are non-breaking (verified against PyPI and release notes)
- No Gantry code changes required
- Documentation updates are additive only
- All existing tests pass without modification

https://claude.ai/code/session_019zuLthvGWCA9nq8m8T93Bj