### PR TITLE
⚡ Bolt: Optimize sliding window rate limit evaluation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,7 @@
 ## 2023-10-27 - Inline vector dot product and norm accumulation
 **Learning:** In Python, calculating vector math (like cosine similarity) using multiple generator expressions (e.g., `sum(x * y for...)` and `math.sqrt(sum(x * x for...))`) is inefficient. Replacing these with a single-pass inline `for` loop that accumulates the dot product and squared sums simultaneously significantly improves performance by reducing generator overhead and redundant iterations.
 **Action:** When calculating similarity or distance manually between Python lists, write a single `for x, y in zip(a, b):` loop rather than using multiple `sum()` calls.
+
+## 2023-10-27 - Fast reverse iteration for sorted sliding windows
+**Learning:** Calculating counts over a chronologically sorted collection (like a sliding window rate limiter in `agent_gantry/core/rate_limiter.py`) using generator expressions that iterate over the entire collection (e.g., `sum(1 for t in history if t >= threshold)`) is highly inefficient for large windows.
+**Action:** Use a reverse iterator (`for t in reversed(history):`) and break early when `t < threshold` to reduce O(N) operations to O(1).

--- a/agent_gantry/core/rate_limiter.py
+++ b/agent_gantry/core/rate_limiter.py
@@ -72,7 +72,9 @@ class RateLimiter:
         # entries leak at the rate of one lock per distinct loop ever used,
         # which is a bounded constant in practice (typically 1–2 loops per
         # process). Closed loops are pruned lazily on lookup.
-        self._loop_locks: dict[int, tuple[weakref.ref[asyncio.AbstractEventLoop], asyncio.Lock]] = {}
+        self._loop_locks: dict[
+            int, tuple[weakref.ref[asyncio.AbstractEventLoop], asyncio.Lock]
+        ] = {}
 
     def _lock_for_running_loop(self) -> asyncio.Lock:
         """Return a per-running-loop ``asyncio.Lock``.
@@ -93,9 +95,7 @@ class RateLimiter:
         lock = asyncio.Lock()
         self._loop_locks[key] = (weakref.ref(loop), lock)
         # Opportunistic cleanup of stale entries (closed loops).
-        for stale_key in [
-            k for k, (ref, _l) in self._loop_locks.items() if ref() is None
-        ]:
+        for stale_key in [k for k, (ref, _l) in self._loop_locks.items() if ref() is None]:
             self._loop_locks.pop(stale_key, None)
         return lock
 
@@ -189,7 +189,15 @@ class RateLimiter:
 
         # Check minute limit (count only entries within the last 60 seconds)
         minute_ago = now - 60
-        recent_count = sum(1 for t in history if t >= minute_ago)
+
+        # ⚡ Bolt: Iterate in reverse and break early instead of using generator over entire history
+        recent_count = 0
+        for t in reversed(history):
+            if t >= minute_ago:
+                recent_count += 1
+            else:
+                break
+
         if recent_count >= self._config.max_calls_per_minute:
             # Find the oldest entry within the minute window for retry_after
             for t in history:

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,4 @@
+💡 What: Optimize the calculation of `recent_count` in the sliding window rate limiter by iterating in reverse and breaking early.
+🎯 Why: The previous implementation used a generator expression (`sum(1 for t in history if t >= minute_ago)`) which iterated over the entire `history` deque. Since `history` is sorted chronologically, this resulted in an O(N) operation that evaluated many irrelevant older timestamps.
+📊 Impact: Reduces time complexity of the per-minute sliding window check from O(N) to O(K), where K is the number of items within the last minute, significantly improving latency for large rate limits.
+🔬 Measurement: Verify by reviewing the algorithmic change and running the existing `test_rate_limiter.py` to ensure behavioral equivalence.


### PR DESCRIPTION
💡 What: Optimize the calculation of `recent_count` in the sliding window rate limiter by iterating in reverse and breaking early.
🎯 Why: The previous implementation used a generator expression (`sum(1 for t in history if t >= minute_ago)`) which iterated over the entire `history` deque. Since `history` is sorted chronologically, this resulted in an O(N) operation that evaluated many irrelevant older timestamps.
📊 Impact: Reduces time complexity of the per-minute sliding window check from O(N) to O(K), where K is the number of items within the last minute, significantly improving latency for large rate limits.
🔬 Measurement: Verify by reviewing the algorithmic change and running the existing `test_rate_limiter.py` to ensure behavioral equivalence.

---
*PR created automatically by Jules for task [323051550850074155](https://jules.google.com/task/323051550850074155) started by @CodeHalwell*