### PR TITLE
🎨 Palette: [UX improvement] Add ARIA combobox pattern to search dropdown

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -65,3 +65,7 @@
 ## 2026-05-18 - [Visual Hierarchy in Search Inputs]
 **Learning:** When designing search inputs, the text placeholder alone isn't always enough to establish visual hierarchy. Adding a persistent search icon ensures immediate recognizability, while applying `pointer-events: none` prevents the icon from blocking the input's clickable area.
 **Action:** Always add a visual search icon (like a magnifying glass) inside search inputs to improve immediate recognizability, ensuring it has `pointer-events: none` and appropriate padding on the input text.
+
+## 2026-05-19 - [ARIA Combobox for Search Inputs]
+**Learning:** For accessibility in custom search dropdowns (input + results list), implement the ARIA combobox pattern. Screen readers need these explicit roles and attributes to understand the relationship between the input field and the dynamic list of results, and to announce the currently active item during keyboard navigation.
+**Action:** Add `role="combobox"`, `aria-expanded`, `aria-autocomplete`, and `aria-controls` to the input, `role="listbox"` to the dropdown container, and use `aria-activedescendant` on the input combined with `role="option"` and `aria-selected` on the results to announce active items.

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -141,14 +141,21 @@
         </div>
       `;
       searchResults.style.display = "block";
+      if (searchInput) {
+        searchInput.setAttribute("aria-expanded", "true");
+        searchInput.removeAttribute("aria-activedescendant");
+      }
       announceSearch("No results found. Try adjusting your search terms.");
       return;
     }
 
-    results.forEach((result) => {
+    results.forEach((result, index) => {
       const resultItem = document.createElement("a");
       resultItem.className = "search-result-item";
       resultItem.href = result.url;
+      resultItem.id = `search-result-item-${index}`;
+      resultItem.setAttribute("role", "option");
+      resultItem.setAttribute("aria-selected", "false");
 
       const resultTitle = document.createElement("div");
       resultTitle.className = "search-result-title";
@@ -164,6 +171,10 @@
     });
 
     searchResults.style.display = "block";
+    if (searchInput) {
+      searchInput.setAttribute("aria-expanded", "true");
+      searchInput.removeAttribute("aria-activedescendant");
+    }
     announceSearch(
       `${results.length} results found. Use up and down arrows to navigate.`,
     );
@@ -175,6 +186,10 @@
   function hideResults() {
     if (searchResults && searchResults.style.display !== "none") {
       searchResults.style.display = "none";
+      if (searchInput) {
+        searchInput.setAttribute("aria-expanded", "false");
+        searchInput.removeAttribute("aria-activedescendant");
+      }
       announceSearch("Search results closed");
     }
   }
@@ -188,10 +203,17 @@
       return;
     }
 
+    searchInput.setAttribute("role", "combobox");
+    searchInput.setAttribute("aria-expanded", "false");
+    searchInput.setAttribute("aria-autocomplete", "list");
+    searchInput.setAttribute("aria-controls", "search-results-listbox");
+
     // Create results container if it doesn't exist
     searchResults = document.querySelector(".search-results");
     if (!searchResults) {
       searchResults = document.createElement("div");
+      searchResults.id = "search-results-listbox";
+      searchResults.setAttribute("role", "listbox");
       searchResults.className = "search-results";
       searchResults.style.cssText = `
         position: absolute;
@@ -324,8 +346,13 @@
       }
 
       // Update active item
-      items.forEach((item) => item.classList.remove("active"));
+      items.forEach((item) => {
+        item.classList.remove("active");
+        item.setAttribute("aria-selected", "false");
+      });
       items[currentIndex].classList.add("active");
+      items[currentIndex].setAttribute("aria-selected", "true");
+      searchInput.setAttribute("aria-activedescendant", items[currentIndex].id);
       items[currentIndex].scrollIntoView({ block: "nearest" });
 
       const activeTitle = items[currentIndex].querySelector(


### PR DESCRIPTION
💡 **What:** Added the standard ARIA combobox pattern to the search component (`docs/assets/js/search.js`).
🎯 **Why:** To improve accessibility for screen reader users and keyboard-only navigators. This makes the relationship between the search input and its dynamic result list explicit, and allows assistive technologies to announce the active result as the user navigates with arrow keys.
📸 **Before/After:** No visual changes. Purely semantic HTML attributes (`role`, `aria-expanded`, `aria-activedescendant`, `aria-selected`) added via JavaScript.
♿ **Accessibility:** Solves an issue where dynamic search dropdowns are read as plain, disconnected text elements by explicitly defining a combobox, listbox, and options.

---
*PR created automatically by Jules for task [6783813995787232193](https://jules.google.com/task/6783813995787232193) started by @CodeHalwell*