### PR TITLE
🎨 Palette: [UX improvement] Improve navigation accessibility and semantic links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -69,3 +69,6 @@
 ## 2026-05-19 - [ARIA Combobox for Search Inputs]
 **Learning:** For accessibility in custom search dropdowns (input + results list), implement the ARIA combobox pattern. Screen readers need these explicit roles and attributes to understand the relationship between the input field and the dynamic list of results, and to announce the currently active item during keyboard navigation.
 **Action:** Add `role="combobox"`, `aria-expanded`, `aria-autocomplete`, and `aria-controls` to the input, `role="listbox"` to the dropdown container, and use `aria-activedescendant` on the input combined with `role="option"` and `aria-selected` on the results to announce active items.
+## 2025-05-18 - Semantic Anchor IDs vs TOC Execution Order
+**Learning:** Generating TOC elements with fallback IDs (`heading-0`) *before* semantic IDs are calculated breaks anchor functionality and produces inaccessible URLs. When multiple features depend on element IDs (like TOC generation and hover anchors), ID generation must be centralized and executed first.
+**Action:** Always centralize DOM node ID generation in a dedicated initialization function that runs before any features that depend on those IDs. Track seen IDs to prevent duplicates and append counters if necessary.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -123,6 +123,39 @@
     });
   }
 
+  // ==================== Ensure Semantic Heading IDs ====================
+
+  function ensureHeadingIds() {
+    const headings = document.querySelectorAll(
+      ".content-wrapper h2, .content-wrapper h3, .content-wrapper h4"
+    );
+
+    const seenIds = new Set();
+
+    headings.forEach((heading) => {
+      if (!heading.id) {
+        let baseId = heading.textContent
+          .toLowerCase()
+          .replace(/[^\w\s-]/g, "")
+          .replace(/\s+/g, "-");
+
+        if (!baseId) {
+          baseId = "section";
+        }
+
+        let finalId = baseId;
+        let counter = 1;
+        while (seenIds.has(finalId)) {
+          finalId = `${baseId}-${counter}`;
+          counter++;
+        }
+
+        heading.id = finalId;
+      }
+      seenIds.add(heading.id);
+    });
+  }
+
   // ==================== Table of Contents Generator ====================
 
   function generateTableOfContents() {
@@ -131,6 +164,9 @@
 
     if (!content || !tocContainer) return;
 
+    tocContainer.setAttribute("role", "navigation");
+    tocContainer.setAttribute("aria-label", "Table of contents");
+
     const headings = content.querySelectorAll("h2, h3, h4");
     if (headings.length === 0) return;
 
@@ -138,11 +174,6 @@
     tocList.className = "toc-list";
 
     headings.forEach((heading, index) => {
-      // Add ID if not present
-      if (!heading.id) {
-        heading.id = "heading-" + index;
-      }
-
       const level = parseInt(heading.tagName.substring(1));
       const listItem = document.createElement("li");
       listItem.className = "toc-item toc-level-" + level;
@@ -377,13 +408,6 @@
     );
 
     headings.forEach((heading) => {
-      if (!heading.id) {
-        heading.id = heading.textContent
-          .toLowerCase()
-          .replace(/[^\w\s-]/g, "")
-          .replace(/\s+/g, "-");
-      }
-
       const anchor = document.createElement("a");
       anchor.className = "heading-anchor";
       anchor.href = "#" + heading.id;
@@ -459,6 +483,7 @@
     initMobileMenu();
     highlightActiveNav();
     initSmoothScroll();
+    ensureHeadingIds();
     generateTableOfContents();
     initCodeCopyButtons();
     initScrollProgress();


### PR DESCRIPTION
This pull request addresses an accessibility and UX issue in the documentation's client-side navigation script (`docs/assets/js/navigation.js`). Previously, the Table of Contents generation ran before semantic anchors were calculated, leading to inaccessible fallback IDs (e.g., `heading-0`) being assigned. These fallback IDs broke the ability to deep-link to specific sections of the documentation using shareable URLs.

This change extracts the semantic ID generation into a centralized `ensureHeadingIds()` function, which is called first during initialization. It also removes duplicate ID generation logic and adds appropriate ARIA attributes (`role="navigation"`, `aria-label="Table of contents"`) to the TOC container.

---
*PR created automatically by Jules for task [6326672325107089061](https://jules.google.com/task/6326672325107089061) started by @CodeHalwell*