### PR TITLE
Add AF 1.6.0 ContextVar instrumentation workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`disable_af_instrumentation()` helper** — new top-level function
+  (`from agent_gantry import disable_af_instrumentation`) that calls
+  `agent_framework.telemetry.disable_instrumentation()` when AF >=1.6.0 is
+  installed. Required for concurrent `asyncio.gather()` / `TaskGroup` workflows
+  on AF 1.6.0 (which defaults to ContextVar-based instrumentation that crashes
+  when tokens are reset across child asyncio contexts). No-op on AF <1.6.0 or
+  when AF is not installed. Returns `True` if instrumentation was disabled,
+  `False` if it was not applicable.
+  *Risk: safe additive — existing callers unaffected.*
+  Source: https://pypi.org/pypi/agent-framework/json (1.6.0 release notes)
+
+- **`GantryToolBridge(disable_af_instrumentation=True)`** — new optional
+  constructor parameter that applies the shim automatically at bridge
+  construction time. Useful when the bridge is constructed near the point where
+  concurrent agents are built. Defaults to `False`.
+  *Risk: safe additive — new keyword arg with a `False` default.*
+
 ### Fixed
+
+- **`AnthropicClient.create_message()` no longer sends `tools=[]`** when no
+  tools are retrieved. Previously an empty list was always passed, which causes
+  the Anthropic API to inject the tool-use system prompt even with no tools
+  (adding ≈346 extra input tokens for Claude 4 models). The `tools` key is now
+  omitted entirely when the retrieved list is empty, preserving existing
+  behaviour for non-empty lists.
+  *Risk: safe fix — only changes the API payload when `tools` would have been
+  `[]`; all callers that rely on non-empty tool lists are unaffected.*
+  Source: https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview
+          (pricing table — tool-use system-prompt token overhead)
+
+### Fixed (prior)
 
 - **`AnthropicAdapter.to_provider_schema(strict=True)` now auto-injects
   `additionalProperties: false`** into the emitted `input_schema`. Anthropic's
@@ -23,26 +55,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`agent-framework` floor held at `>=1.5.0,<2.0.0`** — reverted the 1.6.0 bump
-  attempted in this audit cycle. AF 1.6.0 (released 2026-05-22) introduces
-  instrumentation enabled by default using `asyncio.ContextVar` tokens, which
-  triggers a hard `ValueError` when two `Agent.run()` calls are awaited
-  concurrently via `asyncio.gather()` or `TaskGroup`:
+- **`agent-framework` range updated to `>=1.5.0,<2.0.0`** — upper bound relaxed
+  from `<1.6.0`. AF 1.6.0 (released 2026-05-22) introduces instrumentation
+  enabled by default using `asyncio.ContextVar` tokens, which triggers a hard
+  `ValueError` when two `Agent.run()` calls are awaited concurrently via
+  `asyncio.gather()` or `TaskGroup`. Sequential workflows (``WorkflowAgent``,
+  `SequentialBuilder`, `HandoffBuilder`) are **not** affected. A Gantry
+  compatibility shim is now provided:
+  ```python
+  from agent_gantry import disable_af_instrumentation
+  disable_af_instrumentation()   # call once at startup for concurrent workflows
   ```
-  ValueError: <Token var=<ContextVar name='inner_response_telemetry_captured_fields'>
-  ...> was created in a different Context
-  ```
-  The root cause is that `asyncio.gather()` creates a child asyncio context for
-  each coroutine; AF's `ContextVar.reset(token)` is then called from the parent
-  context (not the child context in which the token was issued), violating the
-  CPython invariant *"A token object cannot be used to reset the variable in a
-  context other than the one where it was created."*
-  This is an upstream bug in AF 1.6.0 that affects any concurrent agent usage
-  (not a Gantry issue). The floor will be bumped once AF releases a patch.
-  AF 1.5.0 features continue to benefit Gantry: intermediate output handling,
-  `ContextProvider.before_run` tools-in-session fix, Azure OpenAI recording.
-  *Risk: safe internal — revert-only; no Gantry code changes required.*
+  Or pass ``GantryToolBridge(gantry, disable_af_instrumentation=True)`` to
+  apply it automatically. See the ``disable_af_instrumentation`` entry in
+  the Added section above.
+  *Risk: safe — upper bound relaxed; the shim is opt-in and a no-op on AF <1.6.0.*
   Source: https://pypi.org/pypi/agent-framework/json
+          https://github.com/microsoft/agent-framework/releases (1.6.0 notes)
 
 - **`openai` floor bumped to `>=2.38.0`** (was `>=2.37.0`). Released 2026-05-21;
   adds `service_tier` parameter to `responses compact`, eager pydantic iterator

--- a/agent_gantry/__init__.py
+++ b/agent_gantry/__init__.py
@@ -10,7 +10,6 @@ from agent_gantry.core.gantry import AgentGantry, create_default_gantry
 from agent_gantry.integrations.agent_framework_bridge import (
     RetrievalCandidate,
     RetrievalDecision,
-    disable_af_instrumentation,
 )
 from agent_gantry.integrations.agent_framework_provider import (
     GantryContextProvider,
@@ -29,6 +28,29 @@ from agent_gantry.schema.tool import (
     ToolHealth,
     ToolSource,
 )
+
+
+def disable_af_instrumentation() -> bool:
+    """Disable Agent Framework ≥1.6.0 default ContextVar instrumentation.
+
+    Call once at process startup before constructing any agents when running
+    concurrent workflows (``asyncio.gather()`` / ``TaskGroup``) on AF 1.6.0.
+    Sequential workflows (WorkflowAgent, SequentialBuilder, HandoffBuilder)
+    are **not** affected and do not require this call.
+
+    The import is deferred so that the ``agent-framework`` package is only
+    required when the function is actually called, keeping ``agent_gantry``
+    importable in environments where AF is not installed.
+
+    Returns ``True`` if instrumentation was disabled, ``False`` otherwise
+    (AF not installed, AF version is older than 1.6.0, or the telemetry
+    module does not expose ``disable_instrumentation``).
+    """
+    from agent_gantry.integrations.agent_framework_bridge import (
+        disable_af_instrumentation as _impl,
+    )
+    return _impl()
+
 
 __version__ = "0.4.0"
 __all__ = [

--- a/agent_gantry/__init__.py
+++ b/agent_gantry/__init__.py
@@ -10,6 +10,7 @@ from agent_gantry.core.gantry import AgentGantry, create_default_gantry
 from agent_gantry.integrations.agent_framework_bridge import (
     RetrievalCandidate,
     RetrievalDecision,
+    disable_af_instrumentation,
 )
 from agent_gantry.integrations.agent_framework_provider import (
     GantryContextProvider,
@@ -37,6 +38,7 @@ __all__ = [
     "RetrievalCandidate",
     "RetrievalDecision",
     "create_default_gantry",
+    "disable_af_instrumentation",
     "with_semantic_tools",
     "set_default_gantry",
     "ToolCall",

--- a/agent_gantry/integrations/agent_framework_bridge.py
+++ b/agent_gantry/integrations/agent_framework_bridge.py
@@ -206,6 +206,95 @@ _APPROVAL_REQUIRED_CAPS: frozenset[ToolCapability] = frozenset(
 )
 
 
+def _get_af_version() -> tuple[int, int, int] | None:
+    """Return the installed agent-framework version as (major, minor, patch), or ``None``."""
+    try:
+        import importlib.metadata as _im
+        raw = _im.version("agent-framework")
+        parts = raw.split(".")
+        return (int(parts[0]), int(parts[1]), int(parts[2]) if len(parts) > 2 else 0)
+    except Exception:
+        return None
+
+
+def disable_af_instrumentation() -> bool:
+    """Disable Microsoft Agent Framework's default instrumentation (AF >=1.6.0).
+
+    AF 1.6.0 enables ``asyncio.ContextVar``-based telemetry by default.  When
+    two ``Agent.run()`` coroutines run concurrently (e.g. via
+    ``asyncio.gather()`` or ``TaskGroup``), CPython raises::
+
+        ValueError: <Token …> was created in a different Context
+
+    because each ``gather`` coroutine runs in an isolated child asyncio context
+    and AF tries to reset the token from the parent context.
+
+    Calling this helper once — before building any agent — disables AF's
+    built-in instrumentation for the lifetime of the process, avoiding the
+    crash.  It is a no-op when AF is not installed or when the version is
+    earlier than 1.6.0 (which has no default instrumentation to disable).
+
+    To retain per-invocation observability after calling this function, attach
+    :class:`~agent_gantry.integrations.agent_framework_middleware.GantryObservabilityMiddleware`
+    to your agents; it records timing and success signals without the
+    ContextVar clash.
+
+    Returns:
+        ``True`` if instrumentation was successfully disabled, ``False`` if it
+        was already disabled, not applicable, or the AF version predates 1.6.0.
+
+    Example::
+
+        # Sequential workflows are unaffected — only needed for concurrent
+        # asyncio.gather() / TaskGroup usage with AF >=1.6.0.
+        from agent_gantry import disable_af_instrumentation
+        disable_af_instrumentation()
+
+        bridge = GantryToolBridge(gantry)
+        agents = await asyncio.gather(
+            bridge.as_agent(client, "query-a", name="A", instructions="…"),
+            bridge.as_agent(client, "query-b", name="B", instructions="…"),
+        )
+
+    Source: https://pypi.org/pypi/agent-framework/json (1.6.0 release notes —
+    "Enable instrumentation by default")
+    """
+    ver = _get_af_version()
+    if ver is None or ver < (1, 6, 0):
+        return False
+    try:
+        from agent_framework import telemetry as _af_telemetry  # type: ignore[import-not-found]
+
+        _disable = getattr(_af_telemetry, "disable_instrumentation", None)
+        if callable(_disable):
+            _disable()
+            logger.debug(
+                "disable_af_instrumentation: called agent_framework.telemetry"
+                ".disable_instrumentation() (AF %d.%d.%d)",
+                *ver,
+            )
+            return True
+        logger.warning(
+            "disable_af_instrumentation: agent_framework.telemetry has no "
+            "'disable_instrumentation' callable (AF %d.%d.%d). "
+            "The ContextVar concurrency workaround could not be applied.",
+            *ver,
+        )
+        return False
+    except Exception:
+        logger.debug(
+            "disable_af_instrumentation: failed to import or call "
+            "agent_framework.telemetry.disable_instrumentation",
+            exc_info=True,
+        )
+        return False
+
+
+# Private alias so GantryToolBridge.__init__ can call the module-level helper
+# without the local parameter `disable_af_instrumentation` shadowing it.
+_disable_af_instrumentation = disable_af_instrumentation
+
+
 def _require_af_installed(caller: str) -> None:
     """Raise a descriptive ImportError when agent-framework is not installed."""
     try:
@@ -457,8 +546,9 @@ class GantryToolBridge:
         *,
         score_threshold: float | str | None = 0.0,
         as_function_tool: bool | None = None,
+        disable_af_instrumentation: bool = False,
     ) -> None:
-        """Initialize the bridge.
+        """Initialise the bridge.
 
         Args:
             gantry: The AgentGantry instance providing tool retrieval and execution.
@@ -470,6 +560,17 @@ class GantryToolBridge:
                 ``True`` = force wrapping (raise if AF is missing);
                 ``False`` = always return bare callables. Defaults produce the
                 most idiomatic AF behaviour without introducing a hard dep.
+            disable_af_instrumentation: When ``True``, call
+                :func:`disable_af_instrumentation` at construction time to
+                suppress AF >=1.6.0's default ContextVar-based telemetry.
+                Required for concurrent workflows (``asyncio.gather()`` /
+                ``TaskGroup``) on AF 1.6.0 to prevent::
+
+                    ValueError: <Token …> was created in a different Context
+
+                Safe to pass when AF <1.6.0 is installed (becomes a no-op).
+                Sequential single-agent flows are unaffected and do NOT need
+                this flag. Defaults to ``False``.
         """
         # Validate the threshold eagerly so misconfiguration surfaces at
         # construction time rather than on the first retrieval round.
@@ -478,6 +579,8 @@ class GantryToolBridge:
         self._score_threshold = score_threshold
         self._as_function_tool = as_function_tool
         self._tool_cache: dict[str, Any] = {}
+        if disable_af_instrumentation:
+            _disable_af_instrumentation()
 
     async def _retrieve(
         self,

--- a/agent_gantry/integrations/agent_framework_bridge.py
+++ b/agent_gantry/integrations/agent_framework_bridge.py
@@ -207,12 +207,23 @@ _APPROVAL_REQUIRED_CAPS: frozenset[ToolCapability] = frozenset(
 
 
 def _get_af_version() -> tuple[int, int, int] | None:
-    """Return the installed agent-framework version as (major, minor, patch), or ``None``."""
+    """Return the installed agent-framework version as (major, minor, patch), or ``None``.
+
+    Uses ``re.findall`` to extract only the numeric components so pre-release
+    strings like ``"1.6.0rc1"`` or ``"1.6.0b2"`` are parsed correctly rather
+    than triggering a ``ValueError`` in ``int()``.
+    """
     try:
         import importlib.metadata as _im
+        import re
+
         raw = _im.version("agent-framework")
-        parts = raw.split(".")
-        return (int(parts[0]), int(parts[1]), int(parts[2]) if len(parts) > 2 else 0)
+        nums = [int(n) for n in re.findall(r"[0-9]+", raw)]
+        return (
+            nums[0] if len(nums) > 0 else 0,
+            nums[1] if len(nums) > 1 else 0,
+            nums[2] if len(nums) > 2 else 0,
+        )
     except Exception:
         return None
 

--- a/agent_gantry/integrations/agent_framework_middleware.py
+++ b/agent_gantry/integrations/agent_framework_middleware.py
@@ -225,16 +225,21 @@ class GantryObservabilityMiddleware:
     This is intentional: the two spans are complementary rather than
     duplicates.  If you want only one source of truth, either omit this
     middleware (rely on AF's built-in instrumentation) or suppress AF's
-    instrumentation by calling
-    ``agent_framework.telemetry.disable_instrumentation()`` before building
-    the agent.
+    instrumentation via Gantry's helper::
+
+        from agent_gantry import disable_af_instrumentation
+        disable_af_instrumentation()   # call once before agent construction
 
     .. note::
-        AF 1.6.0 has a known upstream bug: concurrent ``Agent.run()`` calls
-        via ``asyncio.gather()`` raise ``ValueError`` due to a ``ContextVar``
-        token being reset in a different asyncio context than it was created.
-        The Gantry package floor remains at ``>=1.5.0`` until a patch is
-        released.  This note will be removed when the floor is bumped.
+        AF 1.6.0 has a known upstream bug affecting *concurrent* ``Agent.run()``
+        calls via ``asyncio.gather()`` / ``TaskGroup``: a ``ContextVar`` token
+        is reset in a different asyncio context than it was created, raising
+        ``ValueError``.  Sequential workflows (``WorkflowAgent``,
+        ``SequentialBuilder``, ``HandoffBuilder``) are **not** affected.
+        For concurrent patterns on AF 1.6.0 call
+        :func:`~agent_gantry.disable_af_instrumentation` (or pass
+        ``disable_af_instrumentation=True`` to ``GantryToolBridge``) once
+        at startup to disable AF's instrumentation.
 
     See :class:`GantryApprovalMiddleware` for the factory-pattern rationale.
     """

--- a/agent_gantry/integrations/anthropic_features.py
+++ b/agent_gantry/integrations/anthropic_features.py
@@ -184,14 +184,24 @@ class AnthropicClient:
                 }
             }
 
-        # Create message
-        response = await self._client.messages.create(
-            model=model,
-            messages=messages,
-            max_tokens=max_tokens,
-            tools=tools if tools else [],
+        # Build the create() kwargs.  Only include `tools` when the list is
+        # non-empty: passing an empty list is treated by the Anthropic API the
+        # same as specifying tool_choice="none" — it still appends the tool-use
+        # system prompt and consumes tokens (346 extra input tokens for most
+        # Claude 4 models per the pricing table).  Omitting the key entirely
+        # avoids that overhead when no tools were retrieved.
+        # Source: https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview
+        create_kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_tokens,
             **kwargs,
-        )
+        }
+        if tools:
+            create_kwargs["tools"] = tools
+
+        # Create message
+        response = await self._client.messages.create(**create_kwargs)
 
         return response
 

--- a/examples/agent_frameworks/agent_framework_example.py
+++ b/examples/agent_frameworks/agent_framework_example.py
@@ -1,16 +1,22 @@
 """
-Microsoft Agent Framework (1.5.0) integration example.
+Microsoft Agent Framework (1.5.0+) integration example.
 
 Demonstrates how Agent-Gantry's semantic routing reduces token usage in
 multi-agent systems by surfacing only the relevant tools per query.
 
-The ``agent-framework`` floor in ``pyproject.toml`` is ``>=1.5.0,<2.0.0``.
-``GantryToolBridge`` works against any AF release in that range; the bridge
-itself is API-stable across 1.4.x → 1.5.x and is unaffected by the 1.5.0
-changes (intermediate output handling improvements for workflows, the
-ContextProvider.before_run tools-in-session-creation fix, Azure OpenAI
-served-model recording, and YAML block scalar parsing in SKILL.md — all
-upstream improvements or infrastructure that Gantry does not consume).
+The ``agent-framework`` range in ``pyproject.toml`` is ``>=1.5.0,<2.0.0``.
+``GantryToolBridge`` works against any AF release in that range.
+
+**AF 1.6.0 concurrent workflow note:**
+AF 1.6.0 enables ContextVar-based instrumentation by default.  Sequential
+workflows (WorkflowAgent, SequentialBuilder, HandoffBuilder — all used here)
+are **not** affected.  If you run concurrent workflows via ``asyncio.gather()``
+or ``TaskGroup`` on AF 1.6.0, add one call at startup::
+
+    from agent_gantry import disable_af_instrumentation
+    disable_af_instrumentation()
+
+Or construct the bridge with ``GantryToolBridge(gantry, disable_af_instrumentation=True)``.
 
 Covers three construction patterns:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,14 +50,25 @@ dev = [
     "python-dotenv>=1.0.0",
 ]
 agent-frameworks = [
-    # Range: >=1.5.0,<1.6.0.  AF 1.6.0 (released 2026-05-22) is intentionally
-    # excluded: its default-enabled instrumentation uses asyncio.ContextVar
-    # tokens that cannot be reset across asyncio child contexts, causing:
+    # Range: >=1.5.0,<2.0.0.
+    # AF 1.6.0 (released 2026-05-22) introduced instrumentation enabled by
+    # default.  Its ContextVar tokens cannot be reset across asyncio child
+    # contexts, so calling two Agent.run() coroutines concurrently via
+    # asyncio.gather() / TaskGroup raises:
     #   ValueError: <Token ...> was created in a different Context
-    # in agent_framework/observability.py when two Agent.run() calls run
-    # concurrently via asyncio.gather() or TaskGroup.  This is an upstream
-    # bug in AF 1.6.0, not a Gantry issue.  The upper bound will be relaxed
-    # to <2.0.0 once AF releases a patch.
+    # in agent_framework/observability.py.  This is an upstream bug in AF 1.6.0;
+    # it does NOT affect sequential workflows (WorkflowAgent, SequentialBuilder,
+    # HandoffBuilder all dispatch one Agent at a time).
+    #
+    # Workaround for concurrent workflows on AF >=1.6.0:
+    #   from agent_gantry import disable_af_instrumentation
+    #   disable_af_instrumentation()   # call once before agent construction
+    # This shim calls agent_framework.telemetry.disable_instrumentation() when
+    # AF >=1.6.0 is detected.  Use GantryObservabilityMiddleware to retain
+    # per-invocation tracing without the ContextVar clash.
+    # GantryToolBridge also accepts disable_af_instrumentation=True to apply
+    # the shim automatically at bridge construction time.
+    #
     # AF 1.5.0 features retained: intermediate output handling,
     # ContextProvider.before_run tools-in-session fix (directly benefits
     # GantryContextProvider), Azure OpenAI recording, YAML block scalar parsing.
@@ -70,7 +81,7 @@ agent-frameworks = [
     # AgentResponse — use str() or .content to extract text.
     # Source: https://pypi.org/pypi/agent-framework/json
     #         https://github.com/microsoft/agent-framework/releases
-    "agent-framework>=1.5.0,<1.6.0",
+    "agent-framework>=1.5.0,<2.0.0",
     "autogen-agentchat>=0.7.5",
     "autogen-ext[openai]>=0.7.5",
     # crewai 1.14.5 (latest stable) pins opentelemetry-api~=1.34.0 (<1.35), which

--- a/tests/test_performance_benchmarks.py
+++ b/tests/test_performance_benchmarks.py
@@ -102,16 +102,16 @@ async def test_concurrent_retrieval_throughput(gantry_with_tools):
     num_requests = 20
 
     # Test 1: Sequential retrievals (baseline)
-    start = time.time()
+    start = time.perf_counter()
     for i in range(num_requests):
         await gantry.retrieve_tools(f"query {i}", limit=5)
-    sequential_duration = time.time() - start
+    sequential_duration = time.perf_counter() - start
 
     # Test 2: Concurrent retrievals (should be much faster if non-blocking)
-    start = time.time()
+    start = time.perf_counter()
     tasks = [gantry.retrieve_tools(f"query {i}", limit=5) for i in range(num_requests)]
     await asyncio.gather(*tasks)
-    concurrent_duration = time.time() - start
+    concurrent_duration = time.perf_counter() - start
 
     # Calculate speedup
     speedup = sequential_duration / concurrent_duration
@@ -168,13 +168,13 @@ async def test_mmr_embedding_caching():
     initial_embed_count = embedder.embed_count
 
     # Retrieve with MMR diversity
-    start = time.time()
+    start = time.perf_counter()
     await gantry.retrieve_tools(
         "task query",
         limit=5,
         diversity_factor=0.5,  # Enable MMR
     )
-    duration = time.time() - start
+    duration = time.perf_counter() - start
     embed_count_after = embedder.embed_count
 
     # Calculate how many embeddings were generated during retrieval
@@ -206,15 +206,15 @@ async def test_embedding_latency():
     embedder = MockEmbedder(latency_ms=100, dimension=768)
 
     # Test single embedding
-    start = time.time()
+    start = time.perf_counter()
     await embedder.embed_text("test query")
-    single_duration = time.time() - start
+    single_duration = time.perf_counter() - start
 
     # Test batch embedding
     texts = [f"query {i}" for i in range(10)]
-    start = time.time()
+    start = time.perf_counter()
     await embedder.embed_batch(texts)
-    batch_duration = time.time() - start
+    batch_duration = time.perf_counter() - start
 
     print(f"\n{'=' * 60}")
     print("Embedding Latency Benchmark")
@@ -244,22 +244,24 @@ async def test_vector_search_performance(gantry_with_tools):
 
     # Benchmark search performance
     iterations = 100
-    start = time.time()
+    start = time.perf_counter()
     for _ in range(iterations):
         await gantry._vector_store.search(
             query_vector=query_embedding,
             limit=10,
         )
-    duration = time.time() - start
+    duration = time.perf_counter() - start
     avg_latency = (duration / iterations) * 1000
+
+    throughput = float("inf") if duration <= 0 else iterations / duration
 
     print(f"\n{'=' * 60}")
     print("Vector Search Performance Benchmark")
     print(f"{'=' * 60}")
     print(f"Total searches: {iterations}")
-    print(f"Total duration: {duration:.2f}s")
+    print(f"Total duration: {duration:.6f}s")
     print(f"Average latency: {avg_latency:.2f}ms")
-    print(f"Throughput: {iterations / duration:.0f} searches/sec")
+    print(f"Throughput: {throughput:.0f} searches/sec")
     print(f"{'=' * 60}\n")
 
     # In-memory search should be fast. Use 200ms as an upper bound — macOS kqueue
@@ -289,9 +291,9 @@ async def test_end_to_end_retrieval_latency(gantry_with_tools):
     latencies = []
 
     for i in range(iterations):
-        start = time.time()
+        start = time.perf_counter()
         tools = await gantry.retrieve_tools(f"query {i}", limit=5)
-        latency = (time.time() - start) * 1000
+        latency = (time.perf_counter() - start) * 1000
         latencies.append(latency)
         assert len(tools) <= 5, "Limit not respected"
 
@@ -347,10 +349,10 @@ async def test_concurrent_execution_scalability():
     results = {}
 
     for concurrency in concurrency_levels:
-        start = time.time()
+        start = time.perf_counter()
         tasks = [gantry.retrieve_tools(f"query {i}", limit=5) for i in range(concurrency)]
         await asyncio.gather(*tasks)
-        duration = time.time() - start
+        duration = time.perf_counter() - start
         throughput = concurrency / duration
 
         results[concurrency] = {

--- a/tests/test_performance_benchmarks.py
+++ b/tests/test_performance_benchmarks.py
@@ -102,28 +102,34 @@ async def test_concurrent_retrieval_throughput(gantry_with_tools):
     num_requests = 20
 
     # Test 1: Sequential retrievals (baseline)
-    start = time.time()
+    start = time.perf_counter()
     for i in range(num_requests):
         await gantry.retrieve_tools(f"query {i}", limit=5)
-    sequential_duration = time.time() - start
+    sequential_duration = time.perf_counter() - start
 
     # Test 2: Concurrent retrievals (should be much faster if non-blocking)
-    start = time.time()
+    start = time.perf_counter()
     tasks = [gantry.retrieve_tools(f"query {i}", limit=5) for i in range(num_requests)]
     await asyncio.gather(*tasks)
-    concurrent_duration = time.time() - start
+    concurrent_duration = time.perf_counter() - start
 
-    # Calculate speedup
-    speedup = sequential_duration / concurrent_duration
+    # Calculate speedup — guard against zero concurrent_duration on very fast runners.
+    speedup = (
+        sequential_duration / concurrent_duration
+        if concurrent_duration > 0
+        else float("inf")
+    )
 
     print(f"\n{'=' * 60}")
     print("Concurrent Retrieval Throughput Benchmark")
     print(f"{'=' * 60}")
+    seq_rps = num_requests / sequential_duration if sequential_duration > 0 else float("inf")
+    con_rps = num_requests / concurrent_duration if concurrent_duration > 0 else float("inf")
     print(
-        f"Sequential: {sequential_duration:.2f}s ({num_requests / sequential_duration:.1f} req/s)"
+        f"Sequential: {sequential_duration:.2f}s ({seq_rps:.1f} req/s)"
     )
     print(
-        f"Concurrent: {concurrent_duration:.2f}s ({num_requests / concurrent_duration:.1f} req/s)"
+        f"Concurrent: {concurrent_duration:.2f}s ({con_rps:.1f} req/s)"
     )
     print(f"Speedup: {speedup:.1f}x")
     print(f"{'=' * 60}\n")
@@ -206,15 +212,15 @@ async def test_embedding_latency():
     embedder = MockEmbedder(latency_ms=100, dimension=768)
 
     # Test single embedding
-    start = time.time()
+    start = time.perf_counter()
     await embedder.embed_text("test query")
-    single_duration = time.time() - start
+    single_duration = time.perf_counter() - start
 
     # Test batch embedding
     texts = [f"query {i}" for i in range(10)]
-    start = time.time()
+    start = time.perf_counter()
     await embedder.embed_batch(texts)
-    batch_duration = time.time() - start
+    batch_duration = time.perf_counter() - start
 
     print(f"\n{'=' * 60}")
     print("Embedding Latency Benchmark")
@@ -223,7 +229,8 @@ async def test_embedding_latency():
     print(
         f"Batch (10 texts): {batch_duration * 1000:.1f}ms ({batch_duration * 100:.1f}ms per text)"
     )
-    print(f"Batch efficiency: {single_duration * 10 / batch_duration:.1f}x faster than individual")
+    batch_efficiency = (single_duration * 10 / batch_duration) if batch_duration > 0 else float("inf")
+    print(f"Batch efficiency: {batch_efficiency:.1f}x faster than individual")
     print(f"{'=' * 60}\n")
 
     # Batch should be more efficient than individual embeddings
@@ -242,24 +249,30 @@ async def test_vector_search_performance(gantry_with_tools):
     # Generate a test query embedding
     query_embedding = await gantry._embedder.embed_text("test query")
 
-    # Benchmark search performance
+    # Benchmark search performance.
+    # Use time.perf_counter() — time.time() on Windows has ~15ms resolution and
+    # can return 0.0 for fast in-memory operations, causing ZeroDivisionError.
     iterations = 100
-    start = time.time()
+    start = time.perf_counter()
     for _ in range(iterations):
         await gantry._vector_store.search(
             query_vector=query_embedding,
             limit=10,
         )
-    duration = time.time() - start
+    duration = time.perf_counter() - start
     avg_latency = (duration / iterations) * 1000
+
+    # Guard against zero duration on very fast runners (Windows perf_counter
+    # is nanosecond-resolution, so 0.0 shouldn't occur, but be defensive).
+    throughput = float("inf") if duration <= 0 else iterations / duration
 
     print(f"\n{'=' * 60}")
     print("Vector Search Performance Benchmark")
     print(f"{'=' * 60}")
     print(f"Total searches: {iterations}")
-    print(f"Total duration: {duration:.2f}s")
+    print(f"Total duration: {duration:.6f}s")
     print(f"Average latency: {avg_latency:.2f}ms")
-    print(f"Throughput: {iterations / duration:.0f} searches/sec")
+    print(f"Throughput: {throughput:.0f} searches/sec")
     print(f"{'=' * 60}\n")
 
     # In-memory search should be fast. Use 200ms as an upper bound — macOS kqueue
@@ -289,9 +302,9 @@ async def test_end_to_end_retrieval_latency(gantry_with_tools):
     latencies = []
 
     for i in range(iterations):
-        start = time.time()
+        start = time.perf_counter()
         tools = await gantry.retrieve_tools(f"query {i}", limit=5)
-        latency = (time.time() - start) * 1000
+        latency = (time.perf_counter() - start) * 1000
         latencies.append(latency)
         assert len(tools) <= 5, "Limit not respected"
 
@@ -347,11 +360,11 @@ async def test_concurrent_execution_scalability():
     results = {}
 
     for concurrency in concurrency_levels:
-        start = time.time()
+        start = time.perf_counter()
         tasks = [gantry.retrieve_tools(f"query {i}", limit=5) for i in range(concurrency)]
         await asyncio.gather(*tasks)
-        duration = time.time() - start
-        throughput = concurrency / duration
+        duration = time.perf_counter() - start
+        throughput = concurrency / duration if duration > 0 else float("inf")
 
         results[concurrency] = {
             "duration": duration,

--- a/uv.lock
+++ b/uv.lock
@@ -658,7 +658,7 @@ vector-stores = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.5.0,<1.6.0" },
+    { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.5.0,<2.0.0" },
     { name = "agent-gantry", extras = ["dev", "embeddings", "openai", "cohere", "vector-stores", "lancedb", "nomic", "mcp", "a2a", "llm-providers", "agent-frameworks", "example-tools"], marker = "extra == 'all'" },
     { name = "agent-gantry", extras = ["openai", "anthropic", "google-genai", "google-vertexai", "mistral", "groq"], marker = "extra == 'llm-providers'" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.104.1" },


### PR DESCRIPTION
## Summary

Adds a compatibility shim for Microsoft Agent Framework 1.6.0's default ContextVar-based instrumentation, which crashes when concurrent `Agent.run()` calls are awaited via `asyncio.gather()` or `TaskGroup`. The upper bound on the `agent-framework` dependency is relaxed from `<1.6.0` to `<2.0.0`, with the workaround provided as an opt-in helper function and constructor parameter.

## Key Changes

- **New `disable_af_instrumentation()` helper function** — Top-level export that detects AF >=1.6.0 and calls `agent_framework.telemetry.disable_instrumentation()` to suppress the default ContextVar-based telemetry. Returns `True` if disabled, `False` if not applicable or already disabled. No-op on AF <1.6.0 or when AF is not installed.

- **`GantryToolBridge(disable_af_instrumentation=True)` parameter** — New optional constructor parameter that applies the shim automatically at bridge construction time. Defaults to `False` for backward compatibility.

- **`AnthropicClient.create_message()` optimization** — Now omits the `tools` key entirely when the retrieved tool list is empty, instead of passing `tools=[]`. This avoids the Anthropic API injecting the tool-use system prompt (≈346 extra input tokens) when no tools are available.

- **Updated dependency range** — `agent-framework>=1.5.0,<2.0.0` (was `<1.6.0`). Sequential workflows (WorkflowAgent, SequentialBuilder, HandoffBuilder) are unaffected by the AF 1.6.0 ContextVar issue; only concurrent patterns require the workaround.

- **Documentation updates** — Added notes to `GantryObservabilityMiddleware`, example code, and `pyproject.toml` explaining the AF 1.6.0 issue, when it occurs (concurrent workflows only), and how to apply the workaround.

## Implementation Details

- Version detection via `importlib.metadata.version()` with graceful fallback to `None` if AF is not installed.
- The shim is called via a private module-level alias (`_disable_af_instrumentation`) in `GantryToolBridge.__init__` to avoid shadowing the parameter name.
- Comprehensive logging at debug and warning levels for troubleshooting.
- All changes are additive and backward-compatible; existing code is unaffected.

https://claude.ai/code/session_01XaMbYASVhTv3jTCxDXvJKg