### PR TITLE
🎨 Palette: Improve keyboard accessibility for combobox search options

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -72,3 +72,7 @@
 ## 2025-05-18 - Semantic Anchor IDs vs TOC Execution Order
 **Learning:** Generating TOC elements with fallback IDs (`heading-0`) *before* semantic IDs are calculated breaks anchor functionality and produces inaccessible URLs. When multiple features depend on element IDs (like TOC generation and hover anchors), ID generation must be centralized and executed first.
 **Action:** Always centralize DOM node ID generation in a dedicated initialization function that runs before any features that depend on those IDs. Track seen IDs to prevent duplicates and append counters if necessary.
+
+## 2026-05-22 - [Keyboard Accessibility for Combobox Options]
+**Learning:** In an ARIA combobox where `aria-activedescendant` is used to manage focus via arrow keys, leaving interactive elements (like `<a>` with `href`) in the dropdown list in the normal document tab order forces keyboard users to awkwardly tab through every single search result to reach the rest of the page.
+**Action:** When implementing an ARIA combobox pattern, always ensure the child options (like search results) have `tabindex="-1"` applied, removing them from the tab sequence so users can efficiently bypass the dropdown while still navigating via arrow keys.

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -156,6 +156,7 @@
       resultItem.id = `search-result-item-${index}`;
       resultItem.setAttribute("role", "option");
       resultItem.setAttribute("aria-selected", "false");
+      resultItem.setAttribute("tabindex", "-1");
 
       const resultTitle = document.createElement("div");
       resultTitle.className = "search-result-title";


### PR DESCRIPTION
💡 What: Added `tabindex="-1"` to dynamically generated search results in the ARIA combobox pattern.
🎯 Why: In an ARIA combobox that uses `aria-activedescendant` for arrow-key navigation, child options should be removed from the tab sequence. Otherwise, keyboard users who want to skip the dropdown must press `Tab` repeatedly to cycle through every search result before reaching the next interactive element on the page.
♿ Accessibility: Ensures that keyboard users can easily bypass the search results container with a single `Tab` key press, perfectly matching the standard WAI-ARIA combobox interaction model. Also recorded this learning in the Palette journal.

---
*PR created automatically by Jules for task [12550353418722409574](https://jules.google.com/task/12550353418722409574) started by @CodeHalwell*