### PR TITLE
🎨 Palette: Improve search combobox accessibility on Escape

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -76,3 +76,7 @@
 ## 2026-05-22 - [Keyboard Accessibility for Combobox Options]
 **Learning:** In an ARIA combobox where `aria-activedescendant` is used to manage focus via arrow keys, leaving interactive elements (like `<a>` with `href`) in the dropdown list in the normal document tab order forces keyboard users to awkwardly tab through every single search result to reach the rest of the page.
 **Action:** When implementing an ARIA combobox pattern, always ensure the child options (like search results) have `tabindex="-1"` applied, removing them from the tab sequence so users can efficiently bypass the dropdown while still navigating via arrow keys.
+
+## 2024-05-23 - [Keyboard Focus Management on Combobox Escape]
+**Learning:** When users dismiss a combobox dropdown (like search results) using the `Escape` key, automatically blurring the input causes them to lose their position in the tab order, forcing them to start navigating from the top of the document again.
+**Action:** When handling the `Escape` key in a combobox, always call `e.preventDefault()` to stop the event from bubbling, and leave focus on the input field so users can seamlessly continue keyboard navigation.

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -339,8 +339,8 @@
         }
         return;
       } else if (e.key === "Escape") {
+        e.preventDefault();
         hideResults();
-        searchInput.blur();
         return;
       } else {
         return;


### PR DESCRIPTION
This PR improves the keyboard accessibility of the documentation search combobox.

Previously, when a keyboard user pressed `Escape` to close the search results dropdown, the JavaScript called `searchInput.blur()`. This dropped focus entirely, forcing screen reader and keyboard-only users to restart their tab sequence from the top of the page.

By replacing the `blur()` call with `e.preventDefault()`, the dropdown correctly closes while maintaining focus on the search input, allowing users to seamlessly continue their navigation or type a new query.

---
*PR created automatically by Jules for task [12754482852429501032](https://jules.google.com/task/12754482852429501032) started by @CodeHalwell*