### PR TITLE
🎨 Palette: [UX improvement] Respect prefers-reduced-motion in docs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -80,3 +80,7 @@
 ## 2024-05-23 - [Keyboard Focus Management on Combobox Escape]
 **Learning:** When users dismiss a combobox dropdown (like search results) using the `Escape` key, automatically blurring the input causes them to lose their position in the tab order, forcing them to start navigating from the top of the document again.
 **Action:** When handling the `Escape` key in a combobox, always call `e.preventDefault()` to stop the event from bubbling, and leave focus on the input field so users can seamlessly continue keyboard navigation.
+
+## 2026-05-28 - [Respecting prefers-reduced-motion for Accessibility]
+**Learning:** Animations, transitions, and smooth scrolling can cause discomfort or nausea for users with vestibular disorders. If these features are added without respecting the user's OS-level motion preferences, it creates a severe accessibility barrier.
+**Action:** Always include a `@media (prefers-reduced-motion: reduce)` block in the global CSS to forcefully disable animations, transitions, and smooth scrolling site-wide when the user has requested reduced motion.

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -751,3 +751,15 @@ img {
 html {
   scroll-padding-top: calc(var(--header-height) + var(--spacing-lg));
 }
+
+/* ==================== Accessibility: Reduced Motion ==================== */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
💡 **What:** Added a `@media (prefers-reduced-motion: reduce)` block to the docs CSS to disable all animations, transitions, and smooth scrolling.
🎯 **Why:** Animations and transitions can cause discomfort or nausea for users with vestibular disorders. Respecting the OS-level `prefers-reduced-motion` setting is a crucial accessibility requirement.
📸 **Before/After:** Visual animations (like fading in, collapsible expanding, smooth scrolling) are effectively disabled when the OS preference is set.
♿ **Accessibility:** Directly addresses a known accessibility issue for vestibular disorders by honoring user motion preferences, using `0.01ms` durations so JS event listeners still trigger safely.

---
*PR created automatically by Jules for task [13016683112863688001](https://jules.google.com/task/13016683112863688001) started by @CodeHalwell*