### PR TITLE
🎨 Palette: Apply smooth scrolling to dynamic anchor links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -84,3 +84,7 @@
 ## 2026-05-28 - [Respecting prefers-reduced-motion for Accessibility]
 **Learning:** Animations, transitions, and smooth scrolling can cause discomfort or nausea for users with vestibular disorders. If these features are added without respecting the user's OS-level motion preferences, it creates a severe accessibility barrier.
 **Action:** Always include a `@media (prefers-reduced-motion: reduce)` block in the global CSS to forcefully disable animations, transitions, and smooth scrolling site-wide when the user has requested reduced motion.
+
+## 2026-05-29 - [Event Binding Order for Dynamic Content]
+**Learning:** Attaching event listeners (like smooth scrolling behavior) to DOM elements using a generic selector early in the initialization sequence misses elements that are generated later dynamically (like Table of Contents or Heading anchors).
+**Action:** Always ensure that behavioral initialization functions (like `initSmoothScroll`) run *after* all functions that dynamically generate the targeted DOM nodes.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -127,7 +127,7 @@
 
   function ensureHeadingIds() {
     const headings = document.querySelectorAll(
-      ".content-wrapper h2, .content-wrapper h3, .content-wrapper h4"
+      ".content-wrapper h2, .content-wrapper h3, .content-wrapper h4",
     );
 
     const seenIds = new Set();
@@ -482,7 +482,6 @@
 
     initMobileMenu();
     highlightActiveNav();
-    initSmoothScroll();
     ensureHeadingIds();
     generateTableOfContents();
     initCodeCopyButtons();
@@ -492,6 +491,7 @@
     initCollapsibleSections();
     addHeadingAnchors();
     initResponsiveTables();
+    initSmoothScroll();
 
     console.log("Agent-Gantry Documentation - Navigation initialized");
   }


### PR DESCRIPTION
💡 What: Moved `initSmoothScroll()` to run after dynamically generated navigation links like Table of Contents and heading anchors.
🎯 Why: Smooth scrolling wasn't being applied to TOC or heading links because they were generated after the event listeners were bound, creating a jarring jump for users.
♿ Accessibility: Preserves keyboard focus and programmatic scrolling behavior for screen reader and keyboard users on dynamically generated links.

---
*PR created automatically by Jules for task [18314017541416917140](https://jules.google.com/task/18314017541416917140) started by @CodeHalwell*