### PR TITLE
chore(audit): modernisation audit v0.4.0 — AF 1.7.0, anthropic 0.105.0, claude-opus-4-8

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,14 +1,15 @@
 # Agent-Gantry Modernisation Audit
 
-**Date:** 2026-05-27  
-**Repository:** `CodeHalwell/Agent-Gantry` · version `0.4.0`  
-**Branch:** `claude/cool-hopper-Y9M5N` (based on `sentinel/fix-ssrf-port-bypass-15808601177667804830`)  
-**Auditor:** Claude (claude-sonnet-4-6)
+**Date:** 2026-05-29 (supersedes 2026-05-27 run)
+**Repository:** `CodeHalwell/Agent-Gantry` · version `0.4.0`
+**Branch:** `claude/cool-hopper-34gYr` (based on `main`)
+**Auditor:** Claude (Sonnet 4.6)
 
-> **Note on PR history.** This audit incorporates security fix PR #207 (SSRF bypass via
-> malformed URL ports, merged via `sentinel/fix-ssrf-port-bypass-15808601177667804830`) and
-> accessibility fix PR #208 (search combobox `Escape` focus retention). The audit branch
-> starts from the sentinel security branch so all current fixes are in scope.
+> **PR history incorporated.** This audit builds on the 2026-05-27 run which
+> already incorporated security fix PR #207 (SSRF bypass), accessibility fix PR #208
+> (search combobox Escape focus), audit+lock-bump commit #209 (langchain/langgraph),
+> and docs CSS commit #210 (prefers-reduced-motion). The 2026-05-29 run adds
+> agent-framework 1.7.0, anthropic 0.105.0, and claude-opus-4-8 model awareness.
 
 ---
 
@@ -16,34 +17,44 @@
 
 | Severity | Count | Areas |
 |----------|-------|-------|
-| **Must-change now** | 3 | Dependency floor bumps (langchain, langchain-openai, langgraph) |
-| **Good next-step** | 5 | Comment refresh (crewai, google-adk, google-genai, agent-framework 1.6.0 notes), AutoGen→MAF migration page |
+| **Must-change now** | 3 | AF floor bump (1.5.0→1.7.0), anthropic floor bump (0.104.1→0.105.0), claude-opus-4-8 model awareness in anthropic_features.py |
+| **Good next-step** | 4 | google-genai comment refresh (2.7.0), HarnessAgent exploration, google-adk 2.x standalone docs, MAF migration guide |
 
-The repository is in excellent overall health for `v0.4.0`. All three provider API surfaces are
-current:
+The repository remains in excellent overall health for `v0.4.0`. All three provider API
+surfaces are current and no Assistants API or deprecated model IDs were found.
 
-- **OpenAI**: Responses API (`client.responses.create`) is the primary path. No Assistants API
-  code is present. Chat Completions is retained as a supported secondary path.
-- **Anthropic**: Messages API with correct `input_schema`, `is_error`, and all three thinking
-  modes (interleaved, extended, adaptive).
-- **Google Gemini**: `google.genai` SDK with `functionDeclarations` and correct
-  `functionResponse` correlation.
+**New findings this run (2026-05-29):**
 
-The Microsoft Agent Framework integration is comprehensive and aligned with AF 1.5.0/1.6.0:
-`Agent`, `AgentExecutor`, `WorkflowBuilder`, `SequentialBuilder`, `HandoffBuilder`,
-`ContextProvider`, `FunctionMiddleware`, and `chat_middleware` are all used correctly. A
-documented workaround exists for the AF 1.6.0 ContextVar concurrency bug.
+1. **`agent-framework` 1.7.0** (released 2026-05-28) — lock was pinned to 1.5.0. The
+   1.7.0 breaking change (removed Python-only declarative actions in
+   `agent-framework-declarative`) does **not** affect Gantry, which uses only core
+   primitives. Floor bumped to `>=1.7.0,<2.0.0`; lock updated.
 
-Security: the SSRF bypass via malformed URL ports (`http://@:evil.com/…`) has been fixed in
-`core/security.py` and is covered by `test_ssrf_port_bypass`. The fix correctly blocks URLs
-that lack a valid hostname after port-parsing raises `ValueError`.
+2. **`anthropic` 0.105.0/0.105.2** (released 2026-05-28/29) — adds `claude-opus-4-8`
+   model support, mid-conversation system blocks, and `usage.output_tokens_details`.
+   Floor bumped to `>=0.105.0`; lock updated.
+
+3. **`claude-opus-4-8`** is now Anthropic's primary/latest Opus model. Adaptive thinking
+   only (no extended thinking). `anthropic_features.py` updated to include it.
+
+4. **Model retirement warning** — `claude-sonnet-4-20250514` and
+   `claude-opus-4-20250514` retire on **June 15, 2026** (17 days from today). A grep
+   confirms neither deprecated ID appears anywhere in the codebase. ✅
+
+5. **`google-genai` 2.7.0** — no breaking changes to function calling. Comment updated;
+   floor unchanged at `>=1.75.0` (google-adk conflict in combined extra).
 
 **Actionable items completed in this audit run:**
-1. Bump `langchain` floor `1.3.1 → 1.3.2` (latest stable).
-2. Bump `langchain-openai` floor `1.2.1 → 1.2.2` (latest stable).
-3. Bump `langgraph` floor `1.2.1 → 1.2.2` (latest stable).
-4. Update `pyproject.toml` comments for `crewai`, `google-adk`, `google-genai`.
-5. Regenerate `uv.lock` (three packages updated, no solver conflicts).
+1. Bump `agent-framework` floor `>=1.5.0,<2.0.0 → >=1.7.0,<2.0.0`.
+2. Bump `anthropic` floor `>=0.104.1 → >=0.105.0`.
+3. Update `pyproject.toml` comments for `agent-framework` 1.7.0, `google-genai` 2.7.0.
+4. Update `anthropic_features.py` to add `claude-opus-4-8` to model support tables.
+5. Regenerate `uv.lock` (agent-framework 1.5.0→1.7.0, anthropic 0.104.1→0.105.2).
+
+**Items completed in the 2026-05-27 run (preserved):**
+6. Bump `langchain>=1.3.2`, `langchain-openai>=1.2.2`, `langgraph>=1.2.2`.
+7. Regenerated `uv.lock` for those three packages.
+8. Fixed SSRF bypass (PR #207), accessibility (PR #208).
 
 ---
 
@@ -53,81 +64,79 @@ that lack a valid hostname after port-parsing raises `ValueError`.
 
 Sources verified against PyPI JSON API (cited URLs below).
 
-| Package | Current floor | Latest stable | Action | Risk |
-|---------|--------------|---------------|--------|------|
-| `agent-framework` | `>=1.5.0,<2.0.0` | `1.6.0` | Within range ✅ — update comment | Safe internal |
-| `anthropic` | `>=0.104.1` | `0.104.1` | ✅ at latest | — |
-| `autogen-agentchat` | `>=0.7.5` | `0.7.5` | ✅ at latest | — |
-| `autogen-ext[openai]` | `>=0.7.5` | `0.7.5` | ✅ at latest | — |
-| `cohere` | `>=6.0.0` | (unchecked) | No action | — |
-| `crewai` | `>=1.6.1` | `1.14.5` | Comment updated (latest is 1.14.5) | Note only |
-| `google-adk` | `>=1.14.1` | `2.1.0` | Comment updated; floor stays at 1.14.1 (langgraph conflict) | Blocked — see §2.4 |
-| `google-genai` | `>=1.75.0` | `2.6.0` | Comment updated (latest is 2.6.0); floor stays 1.75.0 | Note only |
-| `groq` | `>=1.2.0` | `1.2.0` | ✅ at latest | — |
-| `langchain` | `>=1.3.1` | `1.3.2` | **Bumped to >=1.3.2** ✅ | Safe internal |
-| `langchain-openai` | `>=1.2.1` | `1.2.2` | **Bumped to >=1.2.2** ✅ | Safe internal |
-| `langgraph` | `>=1.2.1` | `1.2.2` | **Bumped to >=1.2.2** ✅ | Safe internal |
-| `llama-index-core` | `>=0.14.22` | `0.14.22` | ✅ at latest | — |
-| `llama-index-llms-openai` | `>=0.7.7` | (unchecked) | No action | — |
-| `mcp` | `>=1.27.1` | `1.27.1` | ✅ at latest | — |
-| `openai` | `>=2.38.0` | `2.38.0` | ✅ at latest | — |
-| `semantic-kernel` | `>=1.36.0` | `1.42.0` | Comment only — OTel conflict with AF; see §2.3 | Blocked |
+| Package | Previous floor | Current floor | Latest stable | Action | Risk |
+|---------|---------------|---------------|---------------|--------|------|
+| `agent-framework` | `>=1.5.0,<2.0.0` | `>=1.7.0,<2.0.0` | `1.7.0` | **Bumped ✅** | Safe internal — breaking change in `declarative` sub-package, not used by Gantry |
+| `anthropic` | `>=0.104.1` | `>=0.105.0` | `0.105.2` | **Bumped ✅** | Safe internal |
+| `google-genai` | `>=1.75.0` | `>=1.75.0` | `2.7.0` | Comment updated ✅ | Floor unchanged (google-adk conflict) |
+| `openai` | `>=2.38.0` | `>=2.38.0` | `2.38.0` | ✅ at latest | — |
+| `langchain` | `>=1.3.2` | `>=1.3.2` | `1.3.2` | ✅ at latest | — |
+| `langchain-openai` | `>=1.2.2` | `>=1.2.2` | `1.2.2` | ✅ at latest | — |
+| `langgraph` | `>=1.2.2` | `>=1.2.2` | `1.2.2` | ✅ at latest | — |
+| `autogen-agentchat` | `>=0.7.5` | `>=0.7.5` | `0.7.5` | ✅ at latest | — |
+| `autogen-ext[openai]` | `>=0.7.5` | `>=0.7.5` | `0.7.5` | ✅ at latest | — |
+| `crewai` | `>=1.6.1` | `>=1.6.1` | `1.14.5` | Note only — OTel conflict | Blocked |
+| `google-adk` | `>=1.14.1` | `>=1.14.1` | `2.1.0` | Note only — langgraph conflict | Blocked |
+| `mcp` | `>=1.27.1` | `>=1.27.1` | `1.27.1` | ✅ at latest | — |
+| `groq` | `>=1.2.0` | `>=1.2.0` | `1.2.0` | ✅ at latest | — |
+| `semantic-kernel` | `>=1.36.0` | `>=1.36.0` | `1.42.0` | Note only — OTel conflict | Blocked |
+| `llama-index-core` | `>=0.14.22` | `>=0.14.22` | `0.14.22` | ✅ at latest | — |
 
-**Citation sources (all verified 2026-05-27):**
-- `langchain 1.3.2`: https://pypi.org/pypi/langchain/json
-- `langchain-openai 1.2.2`: https://pypi.org/pypi/langchain-openai/json
-- `langgraph 1.2.2`: https://pypi.org/pypi/langgraph/json
-- `crewai 1.14.5`: https://pypi.org/pypi/crewai/json
-- `google-adk 2.1.0`: https://pypi.org/pypi/google-adk/json
-- `google-genai 2.6.0`: https://pypi.org/pypi/google-genai/json
-- `agent-framework 1.6.0`: https://pypi.org/pypi/agent-framework/json
-- `anthropic 0.104.1`: https://pypi.org/pypi/anthropic/json
+**Citation sources (verified 2026-05-29):**
+- `agent-framework 1.7.0`: https://pypi.org/pypi/agent-framework/json · https://github.com/microsoft/agent-framework/releases
+- `anthropic 0.105.2`: https://pypi.org/pypi/anthropic/json · https://github.com/anthropics/anthropic-sdk-python/releases
+- `google-genai 2.7.0`: https://pypi.org/pypi/google-genai/json · https://github.com/googleapis/python-genai/releases
 - `openai 2.38.0`: https://pypi.org/pypi/openai/json
+- `langchain 1.3.2`: https://pypi.org/pypi/langchain/json
+- `langgraph 1.2.2`: https://pypi.org/pypi/langgraph/json
 - `mcp 1.27.1`: https://pypi.org/pypi/mcp/json
-- `llama-index-core 0.14.22`: https://pypi.org/pypi/llama-index-core/json
-- `groq 1.2.0`: https://pypi.org/pypi/groq/json
 
 ### 2.2 Commands applied in this run
 
 ```bash
 # Bumped floors in pyproject.toml, then regenerated the lock:
-uv lock --upgrade-package langchain \
-        --upgrade-package langchain-openai \
-        --upgrade-package langgraph
+uv lock --upgrade-package agent-framework --upgrade-package anthropic
 
 # Output:
-# Updated langchain v1.3.1 -> v1.3.2
-# Updated langchain-openai v1.2.1 -> v1.2.2
-# Updated langgraph v1.2.1 -> v1.2.2
+# Updated agent-framework v1.5.0 -> v1.7.0
+# Updated agent-framework-core v1.5.0 -> v1.7.0
+# Updated anthropic v0.104.1 -> v0.105.2
 ```
 
-No solver conflicts were raised. The three packages updated cleanly within the existing
+No solver conflicts were raised. The two packages updated cleanly within the existing
 constraint set.
 
-### 2.3 Blocked upgrade: `semantic-kernel ≥ 1.42.0`
+### 2.3 agent-framework 1.7.0 — breaking change analysis
 
-`semantic-kernel 1.42.0` (latest stable) is blocked in the `agent-frameworks` combined extra
-because `agent-framework>=1.2.1` requires `opentelemetry-api>=1.39.0`, while older
-`semantic-kernel` versions pin a narrower range. The floor stays at `>=1.36.0`.
+**Breaking change:** Python-only declarative actions removed; alias kinds renamed
+in `agent-framework-declarative`.
 
-**Resolution path:** install `semantic-kernel` in a dedicated virtual environment without
-`agent-framework`, or wait for a `semantic-kernel` release that widens its `opentelemetry-api`
-range to include `>=1.39.0`.
+**Impact on Gantry:** None. Gantry's AF integration (`agent_framework_bridge.py`,
+`agent_framework_provider.py`, `agent_framework_middleware.py`) uses:
+- `agent_framework.Agent`
+- `agent_framework.AgentExecutor`, `WorkflowAgent`, `WorkflowBuilder`
+- `agent_framework.orchestrations.SequentialBuilder`, `HandoffBuilder`
+- `agent_framework.ContextProvider`, `chat_middleware`, `FunctionMiddleware`
+- `agent_framework.telemetry.disable_instrumentation`
+
+None of these symbols reside in `agent-framework-declarative`. Classification: **safe internal**.
+
+**New features in 1.7.0 (not yet used by Gantry — good next-step):**
+- `HarnessAgent` / background-agents harness provider
+- `A2AAgentSession` with referenced task IDs and input-required support
+
+Source: https://github.com/microsoft/agent-framework/releases (verified 2026-05-29)
 
 ### 2.4 Blocked upgrade: `google-adk ≥ 2.x`
 
-`google-adk 2.1.0` is the latest stable release (Workflow Runtime + Task API, major version
-bump). It is blocked in the combined `agent-frameworks` extra because:
+`google-adk 2.1.0` (latest stable) requires `langgraph<0.4.8`, incompatible with
+`langgraph>=1.2.2`. Floor stays at `>=1.14.1`. Standalone install works:
+`pip install "agent-gantry[google-genai]" "google-adk>=2.1.0"`.
 
-1. `google-adk 2.x` (and `1.34.x` before it) requires `langgraph<0.4.8` via its extensions
-   extra, which is incompatible with `langgraph>=1.2.2` now required by this project.
-2. Potential transitive `pydantic` / `opentelemetry-api` conflicts in the 2.x internals
-   require validation in an isolated environment first.
+### 2.5 Blocked upgrade: `semantic-kernel ≥ 1.42.0`
 
-**Standalone usage:** `pip install "agent-gantry[google-genai]" "google-adk>=2.1.0"` works in
-an environment without LangChain/LangGraph.
-
-Source: https://pypi.org/pypi/google-adk/json (verified 2026-05-27).
+`opentelemetry-api` range conflict with `agent-framework>=1.2.1`. Floor stays at
+`>=1.36.0`. Install in a separate environment without `agent-framework` to use 1.42.0.
 
 ---
 
@@ -135,36 +144,15 @@ Source: https://pypi.org/pypi/google-adk/json (verified 2026-05-27).
 
 ### 3.1 OpenAI
 
-**Finding:** No Assistants API usage found in the codebase. The Responses API
-(`client.responses.create`) is already the primary pattern. ✅
+**Finding:** No Assistants API usage. Responses API (`client.responses.create`) is
+the primary path. Chat Completions retained as a supported secondary path. ✅
 
-**Responses API usage** (`examples/llm_integration/openai_demo.py`): Correct.
-- `input=` (flat message array), `tools=` (flat schema), `previous_response_id`,
-  and `function_call_output` items are all used correctly.
-- Uses `gpt-4.1` (current model family).
+**Tool schema** (`OpenAIResponsesAdapter`): flat `{type: "function", name: ...}` shape —
+correct per the Responses API specification. ✅
 
-**Tool schema** (`agent_gantry/adapters/tool_spec/providers.py`, `OpenAIResponsesAdapter`):
-produces the correct flat shape:
+**Assistants API sunset:** August 26, 2026. No code touches the Assistants API. ✅
 
-```python
-{"type": "function", "name": "...", "description": "...", "parameters": {...}}
-```
-
-per the Responses API specification. ✅
-
-Source: https://platform.openai.com/docs/api-reference/responses (verified 2026-05-27).
-
-**Tool result format** (`OpenAIResponsesAdapter.format_tool_result`): correctly produces:
-
-```python
-{"type": "function_call_output", "call_id": "...", "output": "..."}
-```
-✅
-
-**Chat Completions** (`OpenAIAdapter`): still supported for the `dialect="openai"` path.
-Correct format. ✅
-
-**Assistants API sunset:** August 26 2026. No code touches the Assistants API. ✅
+Source: https://platform.openai.com/docs/api-reference/responses (verified 2026-05-27)
 
 **Risk level:** Safe internal — no changes required.
 
@@ -172,193 +160,140 @@ Correct format. ✅
 
 **Finding:** Messages API is used throughout with correct shapes. ✅
 
-**Tool schema** (`AnthropicAdapter.to_provider_schema`): produces correct `input_schema` field
-with optional `additionalProperties: false` injection for `strict=True` mode (documented in the
-code with a citation to `platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use`).
+**New model in 0.105.0: `claude-opus-4-8`**
 
-**Tool result** (`AnthropicAdapter.format_tool_result`): correctly emits `tool_use_id` and
-`is_error=True` when the tool failed. ✅
+`claude-opus-4-8` is now Anthropic's primary/latest Opus model (added in anthropic
+SDK 0.105.0, released 2026-05-28). Capabilities confirmed against the official model
+table (https://platform.claude.com/docs/en/docs/about-claude/models/overview,
+verified 2026-05-29):
 
-Source: https://docs.anthropic.com/en/api/messages (verified 2026-05-27).
+| Feature | claude-opus-4-8 | claude-opus-4-7 | claude-sonnet-4-6 | claude-haiku-4-5 |
+|---------|-----------------|-----------------|-------------------|-----------------|
+| Extended thinking | ❌ No | ❌ No | ✅ Yes | ✅ Yes |
+| Adaptive thinking | ✅ Yes | ✅ Yes | ✅ Yes | ❌ No |
+| Context window | 1M tokens | 1M tokens | 1M tokens | 200k tokens |
+| Max output | 128k tokens | 128k tokens | 64k tokens | 64k tokens |
 
-**Thinking modes** (`agent_gantry/integrations/anthropic_features.py`): three modes implemented:
+**Changes applied to `agent_gantry/integrations/anthropic_features.py`:**
+- `AnthropicFeatures` dataclass comment: added `claude-opus-4-8` to models that
+  do not support extended thinking.
+- `AnthropicFeatures` adaptive thinking comment: added `claude-opus-4-8` to the
+  list of supported models.
+- `AnthropicClient` docstring: updated extended/adaptive thinking model lists.
+- `create_anthropic_client` docstring: updated all model references.
 
-| Mode | Implementation | Status |
-|------|----------------|--------|
-| `interleaved` | `anthropic-beta: interleaved-thinking-2025-05-14` header | ✅ |
-| `extended` | `thinking: {type: "enabled", budget_tokens: N}` | ✅ |
-| `adaptive` | `thinking: {type: "adaptive", effort: "low|medium|high"}` | ✅ |
+**New field: `usage.output_tokens_details`** — returned automatically by the API
+when using 0.105.0+. No code change needed; users can access it via
+`response.usage.output_tokens_details` from the SDK object. Noted here for
+observability integrators.
 
-`claude-opus-4-7` correctly excludes `extended` thinking (not supported on that model).
-`adaptive` is correctly marked as not available on `claude-haiku-4-5`.
+**⚠️ Model retirement — June 15, 2026 (17 days from today):**
+`claude-sonnet-4-20250514` (alias `claude-sonnet-4-0`) and
+`claude-opus-4-20250514` (alias `claude-opus-4-0`) are **deprecated and retire on
+June 15, 2026**. A full grep of the codebase confirms neither deprecated model ID
+appears in any source file or example. ✅ No action required.
 
-Source: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking (verified 2026-05-27).
+Source: https://platform.claude.com/docs/en/docs/about-claude/models/overview (verified 2026-05-29)
 
-**Model names:** `claude-sonnet-4-6` and `claude-opus-4-7` are current production aliases. ✅
-
-**Risk level:** Safe internal — no changes required.
+**Risk level:** Safe internal — no breaking changes.
 
 ### 3.3 Google Gemini / Gen AI
 
 **Finding:** Correct `functionDeclarations` / `functionResponse` shapes used throughout. ✅
 
-**Tool schema** (`GeminiAdapter.to_provider_schema`): produces:
-```python
-{"name": "...", "description": "...", "parameters": {...}}
-```
-which maps directly to Gemini `FunctionDeclaration`. ✅
+**google-genai 2.7.0** — no breaking changes to `generateContent` or function calling.
+New features (computer_use field for Vertex, Reinforcement Tuning) are not used by
+Gantry and require no code changes. ✅
 
-**Tool result** (`GeminiAdapter.format_tool_result`): places `id` inside `functionResponse`
-(correct — `id` is a field on the `FunctionResponse` proto, not on `Part`):
-```python
-{"functionResponse": {"name": "...", "response": {...}, "id": "..."}}
-```
-✅
+`gemini-2.5-flash` is the current stable model used in examples. ✅
 
-Source: https://ai.google.dev/gemini-api/docs/function-calling (verified 2026-05-27).
-
-**Model names** (`google_genai_demo.py`): `gemini-2.5-flash` is current stable. ✅
-
-**Async interface** (`client.aio.models.generate_content`): correct for google-genai ≥1.x.
-The SDK's 2.x breaking changes were limited to the Interactions API surface (SSE event renames,
-`response_format` restructuring); `generate_content` and function calling are unaffected. ✅
+Source: https://github.com/googleapis/python-genai/releases (verified 2026-05-29)
 
 **Risk level:** Safe internal — no changes required.
 
 ### 3.4 Mistral
 
-**Finding:** `mistralai` was quarantined on PyPI on 2026-05-12. The repo correctly migrates to
-`AsyncOpenAI(base_url="https://api.mistral.ai/v1")` and `MistralAdapter` inherits
-`OpenAIAdapter` for schema and result formats. ✅
-
-**Risk level:** Safe internal — no changes required.
+`mistralai` quarantined on PyPI (2026-05-12). Correctly migrated to
+`AsyncOpenAI(base_url="https://api.mistral.ai/v1")`. ✅
 
 ### 3.5 Groq
 
-**Finding:** `AsyncGroq` with `chat.completions.create()`. `GroqAdapter` inherits
-`OpenAIAdapter`. All shapes are correct. ✅
-
-**Risk level:** Safe internal — no changes required.
+`AsyncGroq` with `chat.completions.create()`. `GroqAdapter` inherits `OpenAIAdapter`.
+All shapes correct. ✅
 
 ---
 
 ## 4 · Framework Integration Refactors
 
-### 4.1 Microsoft Agent Framework (AF 1.5.0 / 1.6.0) — Priority review
+### 4.1 Microsoft Agent Framework (AF 1.7.0) — Priority review
 
-All AF integration modules align with the `agent-framework>=1.5.0,<2.0.0` GA surface.
+Gantry's AF integration aligns with `agent-framework>=1.7.0,<2.0.0`.
 
 #### 4.1.1 Agent construction and configuration
 
-`GantryToolBridge.build_agent` and `as_agent`
-(`agent_gantry/integrations/agent_framework_bridge.py`) construct agents via:
+`GantryToolBridge.build_agent` and `as_agent` use:
 
 ```python
 Agent(client, instructions, name=name, tools=tools, middleware=middleware)
 ```
 
-This is the idiomatic AF 1.x constructor signature. ✅
-
-`_build_callable_for_tool` uses `@agent_framework.tool(wrapper, name=..., description=...,
-approval_mode=...)` when AF is installed, producing a real `FunctionTool` with GA metadata. ✅
+Idiomatic AF 1.x constructor signature. ✅
 
 #### 4.1.2 Workflow subsystem
 
 | Builder | Status |
 |---------|--------|
 | `SequentialBuilder` | ✅ `build_sequential_workflow` |
-| `HandoffBuilder` | ✅ `build_handoff_workflow` — `.participants()`, `.with_start_agent()`, `.add_handoff()` |
+| `HandoffBuilder` | ✅ `build_handoff_workflow` |
 | `WorkflowBuilder` + `AgentExecutor` | ✅ `build_workflow` |
 
-All three builders are imported from `agent_framework.orchestrations` ✅
+All imported from `agent_framework.orchestrations`. ✅
 
-#### 4.1.3 Hosting / AF 1.6.0 ContextVar bug
+#### 4.1.3 AF 1.7.0 — new features (not yet integrated)
 
-AF 1.6.0 (released 2026-05-22) enables `asyncio.ContextVar`-based instrumentation by
-default. Concurrent `Agent.run()` coroutines via `asyncio.gather()` / `TaskGroup` raise:
+- **`HarnessAgent`**: New agent class for background/harness execution patterns.
+  Potential use: long-running Gantry tool pipelines that should run in a background
+  harness with progress reporting. Flagged as "good next-step" below.
+- **`A2AAgentSession`**: Referenced task IDs and input-required support for A2A
+  agent-to-agent communication. Could complement Gantry's A2A integration
+  (`agent_gantry/integrations/a2a_bridge.py`).
 
-```
-ValueError: <Token …> was created in a different Context
-```
+#### 4.1.4 AF 1.6.0 ContextVar concurrency bug — workaround in place
 
-The repo already has a complete workaround:
+The workaround introduced in the 2026-05-27 run remains correct for AF 1.7.0:
+`disable_af_instrumentation()` calls
+`agent_framework.telemetry.disable_instrumentation()` when AF ≥ 1.6.0 is detected.
+Sequential workflows are unaffected.
 
-1. `disable_af_instrumentation()` in `agent_gantry/__init__.py` and
-   `agent_framework_bridge.py` — calls `agent_framework.telemetry.disable_instrumentation()`
-   when AF ≥ 1.6.0 is detected.
-2. `GantryToolBridge(disable_af_instrumentation=True)` — convenience flag to apply the
-   shim at bridge construction time.
-3. Documentation in `GantryObservabilityMiddleware` docstring.
+Source: https://pypi.org/pypi/agent-framework/json (verified 2026-05-29)
 
-Sequential workflows (`WorkflowAgent`, `SequentialBuilder`, `HandoffBuilder`) are **not**
-affected.
+#### 4.1.5 Middleware pipeline
 
-Source: https://pypi.org/pypi/agent-framework/json (1.6.0 release notes, verified 2026-05-27).
+`GantryApprovalMiddleware`, `GantryObservabilityMiddleware`,
+`GantryToolChoiceMiddleware` — all correct. Lazy AF import preserved. ✅
 
-#### 4.1.4 Middleware pipeline
+#### 4.1.6 Context provider
 
-`GantryApprovalMiddleware`, `GantryObservabilityMiddleware`, `GantryToolChoiceMiddleware` all
-reside in `agent_gantry/integrations/agent_framework_middleware.py`. They:
+`GantryContextProvider` subclasses `ContextProvider` dynamically. Per-run and
+per-call strategies implemented. `source_id` keying co-operates with
+`SkillsProvider`. ✅
 
-- Use `FunctionMiddleware` (preferred) with `ChatMiddlewareLayer` as a fallback for older
-  1.x point releases. ✅
-- Import AF lazily so the module remains usable without AF installed. ✅
-- `MiddlewareTermination` raised correctly for approval-required tools. ✅
-
-#### 4.1.5 Tools / skills / providers — `GantryContextProvider`
-
-`GantryContextProvider`
-(`agent_gantry/integrations/agent_framework_provider.py`) subclasses `ContextProvider`
-dynamically (lazy import). Per-run and per-call retrieval strategies are both implemented,
-including the `as_chat_middleware()` factory for per-call refresh. ✅
-
-`source_id` keying ensures co-operation with `SkillsProvider` and other context providers. ✅
-
-`MissingRequiredToolError` is raised at construction time when `required=[...]` names are
-absent from the gantry registry. ✅
-
-#### 4.1.6 Human-in-the-loop
-
-`_APPROVAL_REQUIRED_CAPS` maps `WRITE_DATA`, `DELETE_DATA`, `EXECUTE_CODE`, `FINANCIAL`, and
-`PII_ACCESS` capabilities to AF's `approval_mode="always_require"`, causing AF to surface an
-approval event before invocation. ✅
-
-`GantryApprovalMiddleware` raises `MiddlewareTermination` for tools flagged
-`ConfirmationRequiredError` by `SecurityPolicy`. ✅
-
-**Risk level:** Safe internal — no changes required.
+**Risk level:** Safe internal — no changes required for 1.7.0.
 
 ### 4.2 LangGraph
 
-`examples/agent_frameworks/langgraph_example.py` uses `create_react_agent` from
-`langgraph.prebuilt` and `ChatOpenAI` from `langchain_openai`. Both are the canonical
-LangGraph 1.x patterns. ✅
-
-`fetch_framework_tools(gantry, query, framework="langgraph")` in `framework_adapters.py`
-returns OpenAI-style schemas (which LangGraph accepts natively). ✅
-
-**Risk level:** Safe internal — no changes required.
+`create_react_agent` from `langgraph.prebuilt` and `ChatOpenAI` from
+`langchain_openai`. Current LangGraph 1.x idioms. ✅
 
 ### 4.3 AutoGen (AG2 0.7.5)
 
-`examples/agent_frameworks/autogen_example.py` uses `autogen_agentchat.agents.AssistantAgent`
-and `autogen_ext.models.openai.OpenAIChatCompletionClient` — the current AG2 v0.4 API. ✅
+`autogen_agentchat.agents.AssistantAgent` and
+`autogen_ext.models.openai.OpenAIChatCompletionClient` — current AG2 v0.4 API.
+Migration note to MAF included. ✅
 
-The example includes a migration note flagging MAF as the successor direction and pointing to
-the MAF example for teams evaluating migration. ✅
+### 4.4 CrewAI / Semantic Kernel / LlamaIndex
 
-**Risk level:** Safe internal — no changes required.
-
-### 4.4 CrewAI
-
-`crewai>=1.6.1` is pinned because 1.6.1 is the highest version that co-installs with
-`agent-framework` (due to `opentelemetry-api` range conflicts in crewai ≥ 1.7.0). Standalone
-CrewAI environments can use 1.14.5 (latest stable). ✅ (comment updated in this run)
-
-### 4.5 LlamaIndex / Semantic Kernel
-
-Both are pinned at current floors (`llama-index-core>=0.14.22`, `semantic-kernel>=1.36.0`)
-and have no actionable changes at this time.
+Unchanged. See §2.5 for blocked upgrade paths.
 
 ---
 
@@ -366,105 +301,57 @@ and have no actionable changes at this time.
 
 ### 5.1 `ToolSpec` contract
 
-The provider-agnostic contract is implemented via:
+The provider-agnostic contract is implemented via
+`agent_gantry/adapters/tool_spec/base.py` (`ToolCallPayload`, `ToolSpecAdapter`
+Protocol) and `agent_gantry/adapters/tool_spec/providers.py`.
 
-**`agent_gantry/adapters/tool_spec/base.py`**
-- `ToolCallPayload` (Pydantic model): `tool_name`, `tool_call_id`, `arguments`, `raw_payload`.
-- `ToolSpecAdapter` (Protocol): `dialect_name`, `to_provider_schema`, `from_provider_payload`,
-  `to_tool_call`, `format_tool_result`.
-
-**`agent_gantry/adapters/tool_spec/providers.py`**
-
-| Adapter | Dialect | Notes |
-|---------|---------|-------|
-| `OpenAIAdapter` | `openai` | Chat Completions — `{type: "function", function: {...}}` |
-| `OpenAIResponsesAdapter` | `openai_responses` | Responses API — flat `{type: "function", name: ...}` |
-| `AnthropicAdapter` | `anthropic` | `{name, description, input_schema}` |
-| `GeminiAdapter` | `gemini` | `{name, description, parameters}` |
-| `MistralAdapter` | `mistral` | Inherits `OpenAIAdapter` |
-| `GroqAdapter` | `groq` | Inherits `OpenAIAdapter` |
-| `AgentFrameworkAdapter` | `agent_framework` | Inherits `OpenAIAdapter`, adds `metadata` opt |
+| Adapter | Dialect | Status |
+|---------|---------|--------|
+| `OpenAIAdapter` | `openai` | ✅ Chat Completions |
+| `OpenAIResponsesAdapter` | `openai_responses` | ✅ Responses API |
+| `AnthropicAdapter` | `anthropic` | ✅ Messages API |
+| `GeminiAdapter` | `gemini` | ✅ functionDeclarations |
+| `MistralAdapter` | `mistral` | ✅ Inherits OpenAIAdapter |
+| `GroqAdapter` | `groq` | ✅ Inherits OpenAIAdapter |
+| `AgentFrameworkAdapter` | `agent_framework` | ✅ OpenAI-compatible + metadata |
 
 ### 5.2 Tool name normalisation
 
-Tool names are validated at registration via `validate_tool_name` (lowercase alphanumeric +
-underscore, 1–128 chars). All provider adapters pass the name through verbatim — no
-normalisation needed at the adapter layer. ✅
+Validated at registration; passed verbatim through all adapters. ✅
 
 ### 5.3 Required vs optional arguments
 
-`AnthropicAdapter.to_provider_schema(strict=True)` injects `additionalProperties: false`
-into the schema copy (without mutating the shared `ToolDefinition`). ✅
-
+`AnthropicAdapter.to_provider_schema(strict=True)` injects `additionalProperties: false`. ✅
 `OpenAIResponsesAdapter.to_provider_schema(strict=True)` sets `schema["strict"] = True`. ✅
 
 ### 5.4 Tool call IDs
 
-| Adapter | ID field | Source |
-|---------|----------|--------|
-| `OpenAIAdapter` | `payload["id"]` | Chat Completions `tool_calls[].id` |
-| `OpenAIResponsesAdapter` | `payload["call_id"]` | Responses API `output[].call_id` |
-| `AnthropicAdapter` | `payload["id"]` | `tool_use` block `id` |
-| `GeminiAdapter` | `payload.get("id")` | Present on ≥1.x parallel calls |
-| `AgentFrameworkAdapter` | `payload.get("id") or payload.get("call_id")` | Dual-field lookup |
+| Adapter | ID field |
+|---------|----------|
+| `OpenAIAdapter` | `payload["id"]` |
+| `OpenAIResponsesAdapter` | `payload["call_id"]` |
+| `AnthropicAdapter` | `payload["id"]` |
+| `GeminiAdapter` | `payload.get("id")` |
+| `AgentFrameworkAdapter` | `payload.get("id") or payload.get("call_id")` |
 
-All IDs are echoed back in `format_tool_result` to support parallel tool calls. ✅
+All IDs echoed back in `format_tool_result` for parallel tool call correlation. ✅
 
 ### 5.5 Parallel tool calls
 
-`GeminiAdapter.format_tool_result` places `id` inside `functionResponse`:
-```python
-{"functionResponse": {"name": "...", "response": {...}, "id": "..."}}
-```
-This is correct per the `FunctionResponse` proto schema. ✅
-
-OpenAI (both adapters) and Anthropic echo back `tool_call_id` / `call_id` / `tool_use_id`
-to the provider, enabling parallel call correlation. ✅
-
-### 5.6 Tool-result round-tripping
-
-| Adapter | Result shape |
-|---------|-------------|
-| `OpenAIAdapter` | `{role: "tool", content: "...", name: "...", tool_call_id: "..."}` |
-| `OpenAIResponsesAdapter` | `{type: "function_call_output", call_id: "...", output: "..."}` |
-| `AnthropicAdapter` | `{type: "tool_result", content: "...", tool_use_id: "...", is_error: bool}` |
-| `GeminiAdapter` | `{functionResponse: {name: "...", response: {...}, id: "..."}}` |
-
-All shapes are verified against current provider documentation. ✅
+`GeminiAdapter.format_tool_result` correctly places `id` inside `functionResponse`
+(matches `FunctionResponse` proto schema). ✅
 
 ---
 
 ## 6 · Documentation and Example Updates
 
-### 6.1 `examples/fast_track_demo.py`
+All examples use current model families:
+- OpenAI: `gpt-4.1` (Responses API), `gpt-4o` (Chat Completions) ✅
+- Anthropic: `claude-sonnet-4-6` ✅ (not deprecated)
+- Gemini: `gemini-2.5-flash` ✅
 
-Uses `client.chat.completions.create()` (Chat Completions). This is intentional — the demo
-is a minimal "before/after" and Chat Completions remains fully supported. The Responses API
-demo is in `examples/llm_integration/openai_demo.py` (Scenario A). No change needed.
-
-### 6.2 `examples/llm_integration/openai_demo.py`
-
-Correctly shows Responses API as Scenario A with `gpt-4.1`. Chat Completions retained as
-Scenario B with `gpt-4o`. Both model names are current. ✅
-
-### 6.3 `examples/llm_integration/anthropic_demo.py`
-
-Uses `claude-sonnet-4-6` — current production model. ✅
-
-### 6.4 `examples/llm_integration/google_genai_demo.py`
-
-Uses `gemini-2.5-flash` — current stable model. ✅
-Uses `types.Part.from_function_response()` with `id` kwarg for parallel call correlation. ✅
-Uses `client.aio.models.generate_content()` async path. ✅
-
-### 6.5 `examples/agent_frameworks/autogen_example.py`
-
-Includes a migration note to MAF. The AG2 0.7.5 API usage is correct. ✅
-
-### 6.6 `examples/agent_frameworks/langgraph_example.py`
-
-Uses `create_react_agent` and `langchain_core.tools.tool` — both current LangGraph 1.x
-idioms. ✅
+No deprecated model IDs (`claude-sonnet-4-20250514`, `claude-opus-4-20250514`,
+`claude-sonnet-4-0`, `claude-opus-4-0`) appear anywhere in the codebase. ✅
 
 ---
 
@@ -472,35 +359,10 @@ idioms. ✅
 
 ### 7.1 SSRF bypass — malformed URL ports (PR #207)
 
-**Fixed.** `SecurityPolicy._extract_domains` in `agent_gantry/core/security.py` now
-correctly handles URLs where `urllib.parse.urlparse(...).port` raises `ValueError`:
-
-```python
-try:
-    _ = parsed.port
-except ValueError:
-    if not parsed.hostname:
-        domains.add("<invalid_domain>")
-        continue
-```
-
-When `parsed.port` raises `ValueError` **and** `parsed.hostname` is `None` / empty (e.g.,
-`http://@:evil.com/etc/passwd`), the URL is blocked by adding `<invalid_domain>` to the
-domain set, which is never in the allowed list.
-
-**Test coverage:** `tests/test_security.py::test_ssrf_port_bypass` — passes. ✅
-
-**Clarification on the general case:** For URLs with a valid hostname but an invalid port
-(e.g., `http://example.com:evil.com`), `parsed.hostname = "example.com"` and the code
-falls through to the normal hostname-extraction path, adding `"example.com"` to the
-domain set. This is correct behaviour: the true network target of such a URL is
-`example.com` (the malformed port prevents connection, so there is no SSRF risk), and
-`"example.com"` is correctly validated against the allowed list.
-
-### 7.2 Search combobox accessibility (PR #208)
-
-`Escape` on the search combobox now calls `e.preventDefault()` instead of
-`searchInput.blur()`, retaining focus on the input field. ✅
+Fixed. `SecurityPolicy._extract_domains` correctly handles `ValueError` from
+`urllib.parse.urlparse(...).port`. URLs that lack a valid hostname after port-parsing
+raises are blocked as `<invalid_domain>`. Test coverage in
+`tests/test_security.py::test_ssrf_port_bypass`. ✅
 
 ---
 
@@ -510,55 +372,66 @@ domain set. This is correct behaviour: the true network target of such a URL is
 
 | Test | Status | Notes |
 |------|--------|-------|
-| `test_security.py::test_ssrf_port_bypass` | ✅ Exists | Covers the specific bypass vector |
+| `test_security.py::test_ssrf_port_bypass` | ✅ Exists | Covers SSRF bypass vector |
 | `test_tool_spec_adapters.py` | ✅ Exists | Covers all provider adapters |
 | `test_agent_framework_integration.py` | ✅ Exists | Covers AF bridge, provider, middleware |
-| LangGraph 1.2.2 regression | ✅ No API changes | No new test needed |
-| `test_ssrf_general_invalid_port` | ⚠️ **Needs confirmation** | Optional: add test for `http://example.com:evil.com` to document the expected `"example.com"` extraction behaviour |
+| AF 1.7.0 regression | ✅ No API changes to core | No new test needed |
+| `anthropic 0.105.0` regression | ✅ No breaking changes | No new test needed |
+| `test_anthropic_features.py` claude-opus-4-8 | ⚠️ **Recommended** | Add assertions for `claude-opus-4-8` in thinking-mode guards |
+| `test_ssrf_general_invalid_port` | ⚠️ Optional | Document `http://example.com:evil.com` expected behaviour |
 
 ### 8.2 Regeneration checklist
 
-- [x] `uv.lock` regenerated (`langchain`, `langchain-openai`, `langgraph` updated).
-- [ ] VCR recordings / golden HTTP responses — none present in this repo; not applicable.
-- [ ] Schema snapshots — not present; not applicable.
+- [x] `uv.lock` regenerated: agent-framework 1.5.0→1.7.0, anthropic 0.104.1→0.105.2.
+- [ ] VCR recordings / golden HTTP responses — none present; not applicable.
+- [ ] Schema snapshots — none present; not applicable.
 
 ### 8.3 Changelog-ready migration notes
 
 ```
-## [0.4.x] — 2026-05-27
+## [0.4.x] — 2026-05-29
 
 ### Changed
-- `langchain` floor bumped `>=1.3.1 → >=1.3.2` (patch; no API changes).
-- `langchain-openai` floor bumped `>=1.2.1 → >=1.2.2` (patch; no API changes).
-- `langgraph` floor bumped `>=1.2.1 → >=1.2.2` (patch; no API changes).
-- `pyproject.toml` comments updated for `crewai` (1.14.5), `google-adk` (2.1.0),
-  and `google-genai` (2.6.0) to reflect current latest stable versions.
+- `agent-framework` floor bumped `>=1.5.0,<2.0.0 → >=1.7.0,<2.0.0` (HarnessAgent,
+  A2AAgentSession improvements; declarative breaking change is in
+  agent-framework-declarative which Gantry does not use).
+- `anthropic` floor bumped `>=0.104.1 → >=0.105.0` (claude-opus-4-8 model support,
+  mid-conversation system blocks, usage.output_tokens_details).
+- `anthropic_features.py` updated to document claude-opus-4-8 thinking-mode
+  restrictions (adaptive only; no extended thinking).
+- `pyproject.toml` comments updated for google-genai (2.7.0).
 
-### Fixed
-- SSRF bypass via malformed URL ports (`http://@:evil.com/…`) in
-  `SecurityPolicy._extract_domains` — URLs that lack a valid hostname after a
-  port-parsing `ValueError` are now blocked as `<invalid_domain>`.
+### Deprecated (external)
+- `claude-sonnet-4-20250514` and `claude-opus-4-20250514` retire on **June 15, 2026**.
+  No code in this repository uses those IDs; no migration needed.
+
+### Previously (2026-05-27)
+- `langchain`, `langchain-openai`, `langgraph` floor bumps (patch releases).
+- SSRF bypass via malformed URL ports fixed in `SecurityPolicy._extract_domains`.
 ```
 
 ---
 
 ## 9 · Must-Change Now vs Good Next Steps
 
-### Must-change now (completed in this run)
+### Must-change now (completed in this and previous run)
 
 | # | Change | File | Status |
 |---|--------|------|--------|
-| 1 | Bump `langchain>=1.3.2` | `pyproject.toml` | ✅ Done |
-| 2 | Bump `langchain-openai>=1.2.2` | `pyproject.toml` | ✅ Done |
-| 3 | Bump `langgraph>=1.2.2` | `pyproject.toml` | ✅ Done |
+| 1 | Bump `agent-framework>=1.7.0,<2.0.0` | `pyproject.toml` | ✅ Done |
+| 2 | Bump `anthropic>=0.105.0` | `pyproject.toml` | ✅ Done |
+| 3 | Add claude-opus-4-8 to thinking-mode docs | `anthropic_features.py` | ✅ Done |
 | 4 | Regenerate `uv.lock` | `uv.lock` | ✅ Done |
+| 5 | Bump `langchain>=1.3.2` | `pyproject.toml` | ✅ Done (2026-05-27) |
+| 6 | Bump `langchain-openai>=1.2.2` | `pyproject.toml` | ✅ Done (2026-05-27) |
+| 7 | Bump `langgraph>=1.2.2` | `pyproject.toml` | ✅ Done (2026-05-27) |
 
 ### Good next-step improvements
 
 | # | Change | File | Risk |
 |---|--------|------|------|
-| 1 | Validate `semantic-kernel>=1.42.0` in isolation with `agent-framework`; bump floor if compatible | `pyproject.toml` | Safe with shim |
-| 2 | Validate `google-adk>=2.1.0` in standalone env; add docs page showing `google-adk 2.x` Workflow Runtime pattern | `docs/`, `examples/` | Safe with shim |
-| 3 | Add optional test for `http://example.com:evil.com` → documents expected hostname extraction behaviour | `tests/test_security.py` | Safe internal |
-| 4 | Add a MAF migration guide (`docs/migrating-from-autogen.md`) for teams moving from AutoGen/AG2 to AF 1.x | `docs/` | Documentation |
-| 5 | Assess `google-adk 2.x` Workflow Runtime as a possible replacement for custom `WorkflowAgent` wrappers in `examples/agent_frameworks/google_adk_example.py` | `examples/` | Needs confirmation |
+| 1 | Add `claude-opus-4-8` thinking-mode guard tests | `tests/test_anthropic_features.py` | Safe internal |
+| 2 | Explore `HarnessAgent` for long-running Gantry pipelines | `agent_framework_bridge.py` | Safe with shim |
+| 3 | Validate `google-adk>=2.1.0` standalone; add Workflow Runtime example | `examples/agent_frameworks/` | Safe with shim |
+| 4 | Validate `semantic-kernel>=1.42.0` in isolation with `agent-framework` | `pyproject.toml` | Safe with shim |
+| 5 | Add MAF migration guide for teams moving from AutoGen/AG2 | `docs/` | Documentation |

--- a/agent_gantry/integrations/anthropic_features.py
+++ b/agent_gantry/integrations/anthropic_features.py
@@ -29,14 +29,14 @@ class AnthropicFeatures:
     """Configuration for Anthropic beta features."""
 
     enable_interleaved_thinking: bool = False
-    # Extended thinking: fixed budget via budget_tokens. Not supported on claude-opus-4-7
-    # (which only supports adaptive thinking). Supported on claude-sonnet-4-6,
-    # claude-opus-4-6, claude-haiku-4-5, and earlier Claude 4 models.
-    # Source: https://platform.claude.com/docs/en/docs/about-claude/models
+    # Extended thinking: fixed budget via budget_tokens. Not supported on claude-opus-4-8
+    # or claude-opus-4-7 (both support adaptive thinking only). Supported on
+    # claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5, and earlier Claude 4 models.
+    # Source: https://platform.claude.com/docs/en/docs/about-claude/models/overview
     enable_extended_thinking: bool = False
     thinking_budget_tokens: int | None = None
-    # Adaptive thinking: model self-regulates depth; recommended for Opus 4.7, Opus 4.6+,
-    # Sonnet 4.6+. Not available on claude-haiku-4-5.
+    # Adaptive thinking: model self-regulates depth; recommended for Opus 4.8, Opus 4.7,
+    # Opus 4.6+, Sonnet 4.6+. Not available on claude-haiku-4-5.
     # Mutually exclusive with enable_extended_thinking.
     adaptive_thinking_effort: Literal["low", "medium", "high"] | None = None
     # Controls whether thinking blocks appear in the response content.
@@ -53,12 +53,12 @@ class AnthropicClient:
     Supports:
     - Interleaved thinking (``interleaved-thinking-2025-05-14`` beta header; required for
       Opus 4.5 / Sonnet 4.5 and earlier Claude 4 models; silently ignored on Opus 4.6+,
-      Sonnet 4.6+, and Opus 4.7 where adaptive thinking is automatic)
+      Sonnet 4.6+, Opus 4.7, and Opus 4.8 where adaptive thinking is automatic)
     - Extended thinking (``thinking={type: "enabled", budget_tokens: N}``; supported on
       claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5, and earlier Claude 4 models;
-      **not supported on claude-opus-4-7** — use adaptive thinking instead)
+      **not supported on claude-opus-4-8 or claude-opus-4-7** — use adaptive thinking instead)
     - Adaptive thinking (``thinking={type: "adaptive", effort: "medium"}``; recommended
-      for claude-opus-4-7, claude-opus-4-6, claude-sonnet-4-6; not available on
+      for claude-opus-4-8, claude-opus-4-7, claude-opus-4-6, claude-sonnet-4-6; not available on
       claude-haiku-4-5; set ``adaptive_thinking_effort`` in ``AnthropicFeatures`` or use
       ``enable_thinking="adaptive"`` in ``create_anthropic_client``)
     - Automatic tool retrieval and execution
@@ -88,8 +88,8 @@ class AnthropicClient:
         self._features = features or AnthropicFeatures()
 
         # The interleaved-thinking beta header is required for Opus 4.5 / Sonnet 4.5 and
-        # earlier Claude 4 models. On Opus 4.6+, Sonnet 4.6+, and Opus 4.7 the header is
-        # deprecated and silently ignored — adaptive thinking is automatic on those models.
+        # earlier Claude 4 models. On Opus 4.6+, Sonnet 4.6+, Opus 4.7, and Opus 4.8 the
+        # header is deprecated and silently ignored — adaptive thinking is automatic.
         # Extended thinking does NOT need a beta header; it is activated via the `thinking`
         # parameter in each create_message() call (see below).
         extra_headers = {}
@@ -330,8 +330,9 @@ async def create_anthropic_client(
         gantry: AgentGantry instance
         enable_thinking: Type of thinking to enable — ``"interleaved"`` (beta header, pre-4.6
             models), ``"extended"`` (fixed budget via ``thinking_budget_tokens``; not supported
-            on claude-opus-4-7), or ``"adaptive"`` (model self-regulates depth; supported on
-            claude-opus-4-7, claude-opus-4-6, claude-sonnet-4-6; recommended for Opus 4.7+)
+            on claude-opus-4-8 or claude-opus-4-7), or ``"adaptive"`` (model self-regulates
+            depth; supported on claude-opus-4-8, claude-opus-4-7, claude-opus-4-6,
+            claude-sonnet-4-6; recommended for Opus 4.8+)
         thinking_budget_tokens: Budget for extended thinking (ignored for other modes)
         adaptive_effort: Effort level for adaptive thinking — ``"low"``, ``"medium"`` (default),
             or ``"high"`` (ignored unless ``enable_thinking="adaptive"``)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,14 @@ dev = [
     "python-dotenv>=1.0.0",
 ]
 agent-frameworks = [
-    # Range: >=1.5.0,<2.0.0.
+    # Range: >=1.7.0,<2.0.0.
+    # AF 1.7.0 (released 2026-05-28): new HarnessAgent / background-agents harness
+    # provider; A2AAgentSession with referenced task IDs and input-required support;
+    # experimental prompt-agent conversion and deployment APIs (foundry).
+    # Breaking change in 1.7.0: Python-only declarative actions removed and alias
+    # kinds renamed in agent-framework-declarative — Gantry does NOT use
+    # agent-framework-declarative, so this is a no-op for this integration.
+    # openai-chatkit transitive dep floor raised to >=1.6.4 in AF 1.7.0.
     # AF 1.6.0 (released 2026-05-22) introduced instrumentation enabled by
     # default.  Its ContextVar tokens cannot be reset across asyncio child
     # contexts, so calling two Agent.run() coroutines concurrently via
@@ -81,7 +88,7 @@ agent-frameworks = [
     # AgentResponse — use str() or .content to extract text.
     # Source: https://pypi.org/pypi/agent-framework/json
     #         https://github.com/microsoft/agent-framework/releases
-    "agent-framework>=1.5.0,<2.0.0",
+    "agent-framework>=1.7.0,<2.0.0",
     "autogen-agentchat>=0.7.5",
     "autogen-ext[openai]>=0.7.5",
     # crewai 1.14.5 (latest stable, 2026-05-27) pins opentelemetry-api~=1.34.0 (<1.35),
@@ -203,22 +210,26 @@ a2a = [
 ]
 # LLM provider SDK dependencies
 anthropic = [
-    # 0.104.1 (released 2026-05-22): 0.104.0 added thinking-token-count beta for
-    # streaming; 0.104.1 is a patch fixing encrypted_content not being carried
-    # through the beta compaction accumulator. No breaking changes.
+    # 0.105.0 (released 2026-05-28): adds claude-opus-4-8 support,
+    # mid-conversation system blocks, and usage.output_tokens_details.
+    # 0.104.1 fixed encrypted_content handling in the beta compaction accumulator;
+    # 0.104.0 added thinking-token-count beta for streaming.
+    # No breaking changes from 0.104.x to 0.105.x.
     # Source: https://pypi.org/pypi/anthropic/json
-    "anthropic>=0.104.1",
+    "anthropic>=0.105.0",
 ]
 google-genai = [
-    # google-genai 2.6.0 (latest stable 2026-05-27) — breaking changes in 2.0.0 were
+    # google-genai 2.7.0 (latest stable 2026-05-28) — no breaking changes to
+    # GenerateContent or function calling across 1.x and 2.x. 2.7.0 adds computer_use
+    # field support for Vertex and Reinforcement Tuning. Breaking changes in 2.0.0 were
     # limited to the Interactions API (SSE event renames, response_format restructuring);
-    # GenerateContent and function calling are entirely unaffected across 1.x and 2.x.
+    # GenerateContent and function calling are entirely unaffected.
     # google-adk (in the agent-frameworks extra) requires google-genai<2.0.0 across all
     # versions up to 2.0.0, so the combined all[] extra keeps a 1.x-compatible floor.
-    # The pip resolver picks the latest compatible version (2.6.0 for standalone
+    # The pip resolver picks the latest compatible version (2.7.0 for standalone
     # [google-genai] installs; >=1.75.0,<2.0.0 when google-adk is co-installed).
     # Standalone 2.x upgrade: pip install "agent-gantry[google-genai]"
-    # Source: https://pypi.org/pypi/google-genai/json (verified 2026-05-27)
+    # Source: https://pypi.org/pypi/google-genai/json (verified 2026-05-29)
     "google-genai>=1.75.0",
 ]
 google-vertexai = [

--- a/uv.lock
+++ b/uv.lock
@@ -60,14 +60,14 @@ wheels = [
 
 [[package]]
 name = "agent-framework"
-version = "1.5.0"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-framework-core", extra = ["all"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/2b/fc64914b8740c6cdbecfb1cd68b2a793af4d793653c920661042f4bac8ff/agent_framework-1.5.0.tar.gz", hash = "sha256:f6f29de2e992d886720256f20d5e0264669acbb2b19f60fa5c78640c3b207899", size = 5299676, upload-time = "2026-05-20T00:28:48.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/58/8235e9e9f008993f8d400c54eb552046c6bd50ab693a648e4fd7de087d3f/agent_framework-1.7.0.tar.gz", hash = "sha256:ce716c88b042cc6389f88dfb408723834db9fa6e287904d6ff763fdc796b377c", size = 5455470, upload-time = "2026-05-28T10:54:02.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/f3/d618e18d55a8d0fec7a00bfaebacba7a514deba4bc8179cf2b08b5253d4b/agent_framework-1.5.0-py3-none-any.whl", hash = "sha256:1341e12df4b780521296358e7fc0e785123f4f0b3eea94ee568badc2afebb68e", size = 5686, upload-time = "2026-05-20T00:28:31.752Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/40/d281775d7807da8dc6226c4ee9bc291e78d7e62efdc9f5b116628740d770/agent_framework-1.7.0-py3-none-any.whl", hash = "sha256:53091b92fe367d83ef0205de350faedbe605af128904def0a6784a59c7578290", size = 5687, upload-time = "2026-05-28T10:53:46.641Z" },
 ]
 
 [[package]]
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework-core"
-version = "1.5.0"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -244,8 +244,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "typing-extensions" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/75/62/b0e85774b2d9b4060376e0b13444b958aa9bff98a6bd6cfd2d1827e53fdb/agent_framework_core-1.7.0.tar.gz", hash = "sha256:b8974ce59af89ef02148e5ba267a67cf1593c19ee9e6146b31528558938ddb2f", size = 391175, upload-time = "2026-05-28T10:54:14.751Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/a9/748bbc433615db46efab8e780ea8d8fc70a67748071753707ddf6fac9008/agent_framework_core-1.5.0-py3-none-any.whl", hash = "sha256:cc1ccd2e3cefc22f8f933b1d8e53da7752ed735c222e686e8b503c6be61de331", size = 418892, upload-time = "2026-05-20T00:25:08.852Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/84/e982fcd1e279b06014814f245d487da91e4de7f62cd90a426377bbadab8a/agent_framework_core-1.7.0-py3-none-any.whl", hash = "sha256:7c2e210846656b28875f79998350e6e2837e24d352cdcdae2ab5d48aecd997cd", size = 435474, upload-time = "2026-05-28T10:54:13.053Z" },
 ]
 
 [package.optional-dependencies]
@@ -658,10 +659,10 @@ vector-stores = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.5.0,<2.0.0" },
+    { name = "agent-framework", marker = "extra == 'agent-frameworks'", specifier = ">=1.7.0,<2.0.0" },
     { name = "agent-gantry", extras = ["dev", "embeddings", "openai", "cohere", "vector-stores", "lancedb", "nomic", "mcp", "a2a", "llm-providers", "agent-frameworks", "example-tools"], marker = "extra == 'all'" },
     { name = "agent-gantry", extras = ["openai", "anthropic", "google-genai", "google-vertexai", "mistral", "groq"], marker = "extra == 'llm-providers'" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.104.1" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.105.0" },
     { name = "asyncpg", marker = "extra == 'pgvector'", specifier = ">=0.29.0" },
     { name = "asyncpg", marker = "extra == 'vector-stores'", specifier = ">=0.29.0" },
     { name = "autogen-agentchat", marker = "extra == 'agent-frameworks'", specifier = ">=0.7.5" },
@@ -920,7 +921,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.104.1"
+version = "0.105.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -932,9 +933,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/c7/7a655b948916f777354648ce979f68b94d5b8dbdb5f61fed1f37fad9378c/anthropic-0.104.1.tar.gz", hash = "sha256:17362b6c45f527afcc9b0fdf62011ffd359726ab2ebcb1978ea0cc41bd8d8d40", size = 850081, upload-time = "2026-05-22T15:36:57.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/46/47581b8c689c743ceabf6a0f9ff48472160900ce802d26c0fb50423997b3/anthropic-0.105.2.tar.gz", hash = "sha256:0e26b90841c2dced7cc6e98d21d5517d0be33f1876b8e779f478202e28bcaa07", size = 853789, upload-time = "2026-05-29T00:21:14.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/12/d9ab42790494d7c428391a46cd28492395566a6a8ccb138d681978594455/anthropic-0.104.1-py3-none-any.whl", hash = "sha256:35c8cb456f5a4405aafe1f10f03f6fcc54fa51fa8ec01d655cc4b437d120e9b7", size = 832996, upload-time = "2026-05-22T15:36:59.519Z" },
+    { url = "https://files.pythonhosted.org/packages/83/75/be0c357e33a5a56c8f9db5b4212f886138d2bf59c0952d858f6b75d710ef/anthropic-0.105.2-py3-none-any.whl", hash = "sha256:e53ed5f6bf36fb1ecb9b25d8634cfd30e02fab9fb3374a0c2d5c585874757230", size = 837507, upload-time = "2026-05-29T00:21:15.528Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Full compatibility and modernisation audit run against the latest stable SDK releases as of 2026-05-29. Supersedes the 2026-05-27 audit run (PR #209).

### Must-change items completed

| # | Change | File | Risk |
|---|--------|------|------|
| 1 | Bump `agent-framework` floor `>=1.5.0,<2.0.0 → >=1.7.0,<2.0.0` | `pyproject.toml` | Safe internal |
| 2 | Bump `anthropic` floor `>=0.104.1 → >=0.105.0` | `pyproject.toml` | Safe internal |
| 3 | Add `claude-opus-4-8` to thinking-mode capability tables | `anthropic_features.py` | Safe internal |
| 4 | Regenerate `uv.lock` (AF 1.5.0→1.7.0, anthropic 0.104.1→0.105.2) | `uv.lock` | Safe internal |
| 5 | Update `pyproject.toml` comments (AF 1.7.0 analysis, google-genai 2.7.0) | `pyproject.toml` | Documentation |
| 6 | Update `AUDIT.md` with 2026-05-29 findings | `AUDIT.md` | Documentation |

### Rationale

**`agent-framework` 1.7.0** (released 2026-05-28) — lock was resolving to 1.5.0. New features: `HarnessAgent`, `A2AAgentSession` with referenced task IDs. Breaking change in `agent-framework-declarative` (Python-only declarative actions removed; alias kinds renamed) — **does not affect Gantry**, which uses only core primitives (`Agent`, `WorkflowBuilder`, `ContextProvider`, etc.).
Source: https://github.com/microsoft/agent-framework/releases

**`anthropic` 0.105.0/0.105.2** (released 2026-05-28/29) — adds `claude-opus-4-8` model support, mid-conversation system blocks, and `usage.output_tokens_details`. No breaking changes.
Source: https://github.com/anthropics/anthropic-sdk-python/releases

**`claude-opus-4-8`** — now Anthropic's primary Opus model. Adaptive thinking only (no extended thinking). All model-capability comments in `anthropic_features.py` updated to reflect this.
Source: https://platform.claude.com/docs/en/docs/about-claude/models/overview

**Model retirement warning (no code changes needed)** — `claude-sonnet-4-20250514` and `claude-opus-4-20250514` retire **June 15, 2026**. A full grep confirms neither deprecated ID appears anywhere in this repository.

**`google-genai` 2.7.0** — no breaking changes to `generateContent` or function calling. Comment-only update; floor unchanged at `>=1.75.0` (google-adk conflict in the combined extra).
Source: https://github.com/googleapis/python-genai/releases

### Good next-step improvements (not in this PR)

- Add `claude-opus-4-8` thinking-mode guard tests in `test_anthropic_features.py`
- Explore `HarnessAgent` for long-running Gantry pipelines
- Validate `google-adk>=2.1.0` standalone and add Workflow Runtime example
- Validate `semantic-kernel>=1.42.0` in isolation with `agent-framework`
- Add MAF migration guide for teams moving from AutoGen/AG2

## Test plan

- [ ] CI passes (no breaking API changes in upgraded packages)
- [ ] `uv sync --extra agent-frameworks --extra anthropic` resolves without conflicts
- [ ] `uv run pytest tests/test_agent_framework_integration.py` passes
- [ ] `uv run pytest tests/test_anthropic_features.py` passes
- [ ] `uv run pytest tests/test_tool_spec_adapters.py` passes

https://claude.ai/code/session_013P3VY8ZsAeQxaA5evLMguy

---
_Generated by [Claude Code](https://claude.ai/code/session_013P3VY8ZsAeQxaA5evLMguy)_