### PR TITLE
🎨 Palette: [UX improvement] Enhance search combobox state retention and keyboard clearing

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
+## 2026-05-30 - [State Retention and Quick Clearing in Search Comboboxes]
+**Learning:** When users click away from a custom search combobox and click back into the input, the dropdown typically remains hidden, resulting in a UX dead end. Furthermore, `Escape` is commonly used to dismiss dropdowns, but if the dropdown is already closed, users expect `Escape` to quickly clear the input field to start a new search.
+**Action:** Always add a `focus` event listener to search inputs that selects the existing text and re-evaluates/displays results if a query exists. Additionally, improve the `Escape` key handler to clear the input field if the results dropdown is already hidden.
+
 ## 2026-04-17 - [External Link Decorative Icon Accessibility]
 **Learning:** For accessibility in HTML/JS components, add `aria-hidden="true"` to decorative external link icons. Instead of appending a visually hidden `.sr-only` span, which can cause visual regressions if the CSS is missing or misapplied, prefer setting an `aria-label` directly on the link element (e.g., `link.setAttribute('aria-label', originalText + ' (opens in a new tab)');`).
 **Action:** Update external link icon scripts to append the `aria-label` to the anchor tag itself, making sure to capture the original textContent before any new child nodes (like icons) are appended.

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -310,8 +310,28 @@
       }, 200);
     });
 
+    // Handle focus to retain search state
+    searchInput.addEventListener("focus", function (e) {
+      const query = e.target.value.trim();
+      e.target.select();
+      if (query.length >= 2) {
+        const results = search(query);
+        displayResults(results);
+      }
+    });
+
     // Handle keyboard navigation in results
     searchInput.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        if (searchResults && searchResults.style.display !== "none") {
+          hideResults();
+        } else {
+          searchInput.value = "";
+        }
+        return;
+      }
+
       if (!searchResults || searchResults.style.display === "none") return;
 
       const items = searchResults.querySelectorAll(".search-result-item");
@@ -337,10 +357,6 @@
         } else if (items[0]) {
           items[0].click();
         }
-        return;
-      } else if (e.key === "Escape") {
-        e.preventDefault();
-        hideResults();
         return;
       } else {
         return;

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,4 +1,4 @@
-💡 What: Replaced a list comprehension that iterated over the entire call history in `RateLimiter.get_stats()` with a fast reverse iterator that breaks early.
-🎯 Why: Iterating over an entire sliding window history is highly inefficient when checking for recent items, resulting in an O(N) operation instead of O(1).
-📊 Impact: Expected to reduce CPU time overhead for stats generation by >20x for large history sliding windows, matching the optimization already present in `_sliding_window_check()`.
-🔬 Measurement: Verify using `uv run pytest tests/test_rate_limiter.py`.
+💡 What: Added `focus` state retention to search input and improved `Escape` key quick clear.
+🎯 Why: If a user clicked away from the search input and then back to it, their search results didn't reappear, creating a UX dead end. Also, users expect `Escape` to clear a search input if the results dropdown is already closed.
+📸 Before/After: Verified via Playwright screenshots internally.
+♿ Accessibility: Improves keyboard navigation support by making it easier to quickly clear search fields using the keyboard.


### PR DESCRIPTION
💡 What: Added `focus` state retention to search input and improved `Escape` key quick clear.
🎯 Why: If a user clicked away from the search input and then back to it, their search results didn't reappear, creating a UX dead end. Also, users expect `Escape` to clear a search input if the results dropdown is already closed.
📸 Before/After: Verified via Playwright screenshots internally.
♿ Accessibility: Improves keyboard navigation support by making it easier to quickly clear search fields using the keyboard.

---
*PR created automatically by Jules for task [2121610626762145796](https://jules.google.com/task/2121610626762145796) started by @CodeHalwell*