### PR TITLE
chore(audit): modernisation audit v0.4.0 — groq 1.4.0, mcp 1.27.2, claude-opus-4-8 guard tests

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,15 +1,16 @@
 # Agent-Gantry Modernisation Audit
 
-**Date:** 2026-05-29 (supersedes 2026-05-27 run)
+**Date:** 2026-05-30 (supersedes 2026-05-29 run)
 **Repository:** `CodeHalwell/Agent-Gantry` · version `0.4.0`
-**Branch:** `claude/cool-hopper-34gYr` (based on `main`)
+**Branch:** `claude/cool-hopper-7ZK9O` (based on `claude/cool-hopper-34gYr`)
 **Auditor:** Claude (Sonnet 4.6)
 
-> **PR history incorporated.** This audit builds on the 2026-05-27 run which
-> already incorporated security fix PR #207 (SSRF bypass), accessibility fix PR #208
-> (search combobox Escape focus), audit+lock-bump commit #209 (langchain/langgraph),
-> and docs CSS commit #210 (prefers-reduced-motion). The 2026-05-29 run adds
-> agent-framework 1.7.0, anthropic 0.105.0, and claude-opus-4-8 model awareness.
+> **PR history incorporated.** This audit builds on the 2026-05-29 run (PR #213)
+> which added agent-framework 1.7.0, anthropic 0.105.0, claude-opus-4-8 model
+> awareness, and AF declarative breaking-change analysis.  The 2026-05-30 run
+> adds groq 1.4.0, mcp 1.27.2 floor bumps, a crewai version note, and the
+> claude-opus-4-8 thinking-mode guard tests identified as "good next-step" in PR #213.
+> Also incorporates open PRs #214 (SSRF file:// fix) and #215 (search UX) from main.
 
 ---
 
@@ -17,44 +18,39 @@
 
 | Severity | Count | Areas |
 |----------|-------|-------|
-| **Must-change now** | 3 | AF floor bump (1.5.0→1.7.0), anthropic floor bump (0.104.1→0.105.0), claude-opus-4-8 model awareness in anthropic_features.py |
-| **Good next-step** | 4 | google-genai comment refresh (2.7.0), HarnessAgent exploration, google-adk 2.x standalone docs, MAF migration guide |
+| **Must-change now** | 0 | No breaking or imminent issues found this run |
+| **Good next-step** | 3 | HarnessAgent exploration for long-running pipelines, google-adk 2.x standalone docs, MAF migration guide |
 
-The repository remains in excellent overall health for `v0.4.0`. All three provider API
-surfaces are current and no Assistants API or deprecated model IDs were found.
+The repository remains in excellent overall health for `v0.4.0`. All provider API
+surfaces are current. No Assistants API usage or retired model IDs found.
+Model retirement deadline: `claude-sonnet-4-20250514` / `claude-opus-4-20250514`
+retire **June 15, 2026** — confirmed absent from the codebase ✅.
 
-**New findings this run (2026-05-29):**
+**New findings this run (2026-05-30):**
 
-1. **`agent-framework` 1.7.0** (released 2026-05-28) — lock was pinned to 1.5.0. The
-   1.7.0 breaking change (removed Python-only declarative actions in
-   `agent-framework-declarative`) does **not** affect Gantry, which uses only core
-   primitives. Floor bumped to `>=1.7.0,<2.0.0`; lock updated.
+1. **`groq` 1.4.0** (released 2026-05-28) — adds realtime audio transcription and
+   updated model aliases. No breaking changes to `chat.completions`. Floor bumped
+   from `>=1.2.0` to `>=1.4.0`.
 
-2. **`anthropic` 0.105.0/0.105.2** (released 2026-05-28/29) — adds `claude-opus-4-8`
-   model support, mid-conversation system blocks, and `usage.output_tokens_details`.
-   Floor bumped to `>=0.105.0`; lock updated.
+2. **`mcp` 1.27.2** (released 2026-05-29) — patch release, no API changes.
+   Floor bumped from `>=1.27.1` to `>=1.27.2`.
 
-3. **`claude-opus-4-8`** is now Anthropic's primary/latest Opus model. Adaptive thinking
-   only (no extended thinking). `anthropic_features.py` updated to include it.
+3. **`crewai` 1.14.6** (latest stable, 2026-05-30) — patch release over 1.14.5.
+   Still blocked from upgrade in the combined `agent-frameworks` extra (OTel conflict).
+   Comment updated; floor remains `>=1.6.1`.
 
-4. **Model retirement warning** — `claude-sonnet-4-20250514` and
-   `claude-opus-4-20250514` retire on **June 15, 2026** (17 days from today). A grep
-   confirms neither deprecated ID appears anywhere in the codebase. ✅
+4. **`claude-opus-4-8` thinking-mode guard tests** — added
+   `TestClaudeOpus48ThinkingGuards` to `tests/test_anthropic_features.py`.
+   Documents that adaptive thinking is correct for this model and extended thinking
+   is incompatible. Converts the "good next-step" item from the 2026-05-29 audit.
 
-5. **`google-genai` 2.7.0** — no breaking changes to function calling. Comment updated;
-   floor unchanged at `>=1.75.0` (google-adk conflict in combined extra).
-
-**Actionable items completed in this audit run:**
-1. Bump `agent-framework` floor `>=1.5.0,<2.0.0 → >=1.7.0,<2.0.0`.
-2. Bump `anthropic` floor `>=0.104.1 → >=0.105.0`.
-3. Update `pyproject.toml` comments for `agent-framework` 1.7.0, `google-genai` 2.7.0.
-4. Update `anthropic_features.py` to add `claude-opus-4-8` to model support tables.
-5. Regenerate `uv.lock` (agent-framework 1.5.0→1.7.0, anthropic 0.104.1→0.105.2).
-
-**Items completed in the 2026-05-27 run (preserved):**
-6. Bump `langchain>=1.3.2`, `langchain-openai>=1.2.2`, `langgraph>=1.2.2`.
-7. Regenerated `uv.lock` for those three packages.
-8. Fixed SSRF bypass (PR #207), accessibility (PR #208).
+**Items completed in prior runs (preserved):**
+5. Bump `agent-framework` floor `>=1.5.0,<2.0.0 → >=1.7.0,<2.0.0` (2026-05-29 run).
+6. Bump `anthropic` floor `>=0.104.1 → >=0.105.0` (2026-05-29 run).
+7. Update `pyproject.toml` comments for AF 1.7.0, `google-genai` 2.7.0 (2026-05-29 run).
+8. Update `anthropic_features.py` for `claude-opus-4-8` (2026-05-29 run).
+9. Bump `langchain>=1.3.2`, `langchain-openai>=1.2.2`, `langgraph>=1.2.2` (2026-05-27).
+10. Fixed SSRF bypass (PR #207), accessibility (PR #208), search UX (PR #215).
 
 ---
 
@@ -66,8 +62,8 @@ Sources verified against PyPI JSON API (cited URLs below).
 
 | Package | Previous floor | Current floor | Latest stable | Action | Risk |
 |---------|---------------|---------------|---------------|--------|------|
-| `agent-framework` | `>=1.5.0,<2.0.0` | `>=1.7.0,<2.0.0` | `1.7.0` | **Bumped ✅** | Safe internal — breaking change in `declarative` sub-package, not used by Gantry |
-| `anthropic` | `>=0.104.1` | `>=0.105.0` | `0.105.2` | **Bumped ✅** | Safe internal |
+| `agent-framework` | `>=1.5.0,<2.0.0` | `>=1.7.0,<2.0.0` | `1.7.0` | **Bumped ✅** (2026-05-29) | Safe internal — breaking change in `declarative` sub-package, not used by Gantry |
+| `anthropic` | `>=0.104.1` | `>=0.105.0` | `0.105.2` | **Bumped ✅** (2026-05-29) | Safe internal |
 | `google-genai` | `>=1.75.0` | `>=1.75.0` | `2.7.0` | Comment updated ✅ | Floor unchanged (google-adk conflict) |
 | `openai` | `>=2.38.0` | `>=2.38.0` | `2.38.0` | ✅ at latest | — |
 | `langchain` | `>=1.3.2` | `>=1.3.2` | `1.3.2` | ✅ at latest | — |
@@ -75,35 +71,36 @@ Sources verified against PyPI JSON API (cited URLs below).
 | `langgraph` | `>=1.2.2` | `>=1.2.2` | `1.2.2` | ✅ at latest | — |
 | `autogen-agentchat` | `>=0.7.5` | `>=0.7.5` | `0.7.5` | ✅ at latest | — |
 | `autogen-ext[openai]` | `>=0.7.5` | `>=0.7.5` | `0.7.5` | ✅ at latest | — |
-| `crewai` | `>=1.6.1` | `>=1.6.1` | `1.14.5` | Note only — OTel conflict | Blocked |
+| `crewai` | `>=1.6.1` | `>=1.6.1` | `1.14.6` | Comment updated ✅ — OTel conflict | Blocked in combined extra |
 | `google-adk` | `>=1.14.1` | `>=1.14.1` | `2.1.0` | Note only — langgraph conflict | Blocked |
-| `mcp` | `>=1.27.1` | `>=1.27.1` | `1.27.1` | ✅ at latest | — |
-| `groq` | `>=1.2.0` | `>=1.2.0` | `1.2.0` | ✅ at latest | — |
+| `mcp` | `>=1.27.1` | `>=1.27.2` | `1.27.2` | **Bumped ✅** (2026-05-30) | Safe patch |
+| `groq` | `>=1.2.0` | `>=1.4.0` | `1.4.0` | **Bumped ✅** (2026-05-30) | Safe minor |
 | `semantic-kernel` | `>=1.36.0` | `>=1.36.0` | `1.42.0` | Note only — OTel conflict | Blocked |
 | `llama-index-core` | `>=0.14.22` | `>=0.14.22` | `0.14.22` | ✅ at latest | — |
 
-**Citation sources (verified 2026-05-29):**
+**Citation sources (verified 2026-05-30):**
 - `agent-framework 1.7.0`: https://pypi.org/pypi/agent-framework/json · https://github.com/microsoft/agent-framework/releases
 - `anthropic 0.105.2`: https://pypi.org/pypi/anthropic/json · https://github.com/anthropics/anthropic-sdk-python/releases
 - `google-genai 2.7.0`: https://pypi.org/pypi/google-genai/json · https://github.com/googleapis/python-genai/releases
 - `openai 2.38.0`: https://pypi.org/pypi/openai/json
 - `langchain 1.3.2`: https://pypi.org/pypi/langchain/json
 - `langgraph 1.2.2`: https://pypi.org/pypi/langgraph/json
-- `mcp 1.27.1`: https://pypi.org/pypi/mcp/json
+- `mcp 1.27.2`: https://pypi.org/pypi/mcp/json
+- `groq 1.4.0`: https://pypi.org/pypi/groq/json
 
 ### 2.2 Commands applied in this run
 
 ```bash
-# Bumped floors in pyproject.toml, then regenerated the lock:
+# 2026-05-29 run (PR #213):
 uv lock --upgrade-package agent-framework --upgrade-package anthropic
+# Updated agent-framework v1.5.0 -> v1.7.0, anthropic v0.104.1 -> v0.105.2
 
-# Output:
-# Updated agent-framework v1.5.0 -> v1.7.0
-# Updated agent-framework-core v1.5.0 -> v1.7.0
-# Updated anthropic v0.104.1 -> v0.105.2
+# 2026-05-30 run (this PR):
+uv lock --upgrade-package groq --upgrade-package mcp
+# Updated groq v1.2.0 -> v1.4.0, mcp v1.27.1 -> v1.27.2
 ```
 
-No solver conflicts were raised. The two packages updated cleanly within the existing
+No solver conflicts were raised. All packages updated cleanly within the existing
 constraint set.
 
 ### 2.3 agent-framework 1.7.0 — breaking change analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,9 +91,9 @@ agent-frameworks = [
     "agent-framework>=1.7.0,<2.0.0",
     "autogen-agentchat>=0.7.5",
     "autogen-ext[openai]>=0.7.5",
-    # crewai 1.14.5 (latest stable, 2026-05-27) pins opentelemetry-api~=1.34.0 (<1.35),
+    # crewai 1.14.6 (latest stable, 2026-05-30) pins opentelemetry-api~=1.34.0 (<1.35),
     # which conflicts with agent-framework>=1.2.1 (requires opentelemetry-api>=1.39.0).
-    # crewai==1.6.1 co-installs with agent-framework. For crewai 1.14.5 (standalone),
+    # crewai==1.6.1 co-installs with agent-framework. For crewai 1.14.6 (standalone),
     # install in a separate environment without agent-framework.
     # Source: https://pypi.org/pypi/crewai/json
     "crewai>=1.6.1",
@@ -201,7 +201,9 @@ nomic = [
     "einops>=0.8.1",
 ]
 mcp = [
-    "mcp>=1.27.1",
+    # mcp 1.27.2 (released 2026-05-29): patch release, no API changes.
+    # Source: https://pypi.org/pypi/mcp/json
+    "mcp>=1.27.2",
 ]
 a2a = [
     "httpx>=0.24.0",
@@ -246,7 +248,10 @@ mistral = [
     "openai>=2.38.0",
 ]
 groq = [
-    "groq>=1.2.0",
+    # groq 1.4.0 (released 2026-05-28): adds realtime audio transcription and
+    # updated model aliases. No breaking changes to chat.completions.
+    # Source: https://pypi.org/pypi/groq/json
+    "groq>=1.4.0",
 ]
 # Combined LLM provider dependencies
 llm-providers = [

--- a/tests/test_anthropic_features.py
+++ b/tests/test_anthropic_features.py
@@ -375,3 +375,89 @@ class TestCreateAnthropicClient:
             gantry=gantry,
         )
         assert client._gantry == gantry
+
+
+class TestClaudeOpus48ThinkingGuards:
+    """Guard tests documenting claude-opus-4-8 thinking-mode constraints.
+
+    claude-opus-4-8 supports adaptive thinking only.  Extended thinking
+    (``budget_tokens``) is **not** supported by the model and will cause an
+    API error when submitted.  These tests verify that the recommended
+    ``AnthropicFeatures`` configuration is correct and that the convenience
+    factory produces the right payload for this model family.
+
+    Source: https://platform.claude.com/docs/en/docs/about-claude/models/overview
+    """
+
+    def test_adaptive_config_is_correct_for_opus48(self):
+        """AnthropicFeatures with adaptive thinking is the right config for opus-4-8."""
+        features = AnthropicFeatures(adaptive_thinking_effort="medium")
+        assert features.adaptive_thinking_effort == "medium"
+        assert features.enable_extended_thinking is False
+        assert features.thinking_budget_tokens is None
+
+    def test_all_adaptive_effort_levels_accepted_for_opus48(self):
+        """low / medium / high effort levels are all valid for adaptive mode on opus-4-8."""
+        for effort in ("low", "medium", "high"):
+            features = AnthropicFeatures(adaptive_thinking_effort=effort)
+            assert features.adaptive_thinking_effort == effort
+            assert features.enable_extended_thinking is False
+
+    def test_default_features_safe_for_opus48(self):
+        """Default AnthropicFeatures has no thinking enabled — safe for opus-4-8."""
+        features = AnthropicFeatures()
+        assert features.enable_extended_thinking is False
+        assert features.thinking_budget_tokens is None
+        assert features.adaptive_thinking_effort is None
+
+    def test_extended_thinking_config_documents_incompatibility_with_opus48(self):
+        """Extended thinking must NOT be combined with claude-opus-4-8.
+
+        The dataclass accepts the flag (there is no model-level guard at
+        the client layer); the caller is responsible for not passing
+        enable_extended_thinking=True when targeting opus-4-8.  This test
+        documents the boundary so that future guard implementations have a
+        clear regression point.
+        """
+        correct = AnthropicFeatures(adaptive_thinking_effort="high")
+        assert correct.enable_extended_thinking is False
+
+        incompatible = AnthropicFeatures(
+            enable_extended_thinking=True, thinking_budget_tokens=8000
+        )
+        assert incompatible.enable_extended_thinking is True
+
+    @pytest.mark.asyncio
+    async def test_create_anthropic_client_adaptive_for_opus48(self):
+        """create_anthropic_client(enable_thinking='adaptive') is correct for opus-4-8."""
+        client = await create_anthropic_client(
+            api_key="test-key",
+            enable_thinking="adaptive",
+            adaptive_effort="medium",
+        )
+        assert client._features.adaptive_thinking_effort == "medium"
+        assert client._features.enable_extended_thinking is False
+        assert client._features.enable_interleaved_thinking is False
+
+    @pytest.mark.asyncio
+    async def test_opus48_adaptive_thinking_payload_shape(self):
+        """Verify the thinking payload emitted for opus-4-8 adaptive mode."""
+        features = AnthropicFeatures(adaptive_thinking_effort="high")
+        client = AnthropicClient(api_key="test-key", features=features)
+
+        mock_response = MagicMock()
+        mock_response.content = []
+        client._client.messages.create = AsyncMock(return_value=mock_response)
+
+        await client.create_message(
+            model="claude-opus-4-8",
+            messages=[{"role": "user", "content": "Explain quantum entanglement"}],
+            auto_retrieve_tools=False,
+        )
+
+        call_kwargs = client._client.messages.create.call_args.kwargs
+        assert call_kwargs["model"] == "claude-opus-4-8"
+        assert "thinking" in call_kwargs
+        assert call_kwargs["thinking"]["type"] == "adaptive"
+        assert call_kwargs["thinking"]["effort"] == "high"
+        assert "budget_tokens" not in call_kwargs["thinking"]

--- a/uv.lock
+++ b/uv.lock
@@ -679,7 +679,7 @@ requires-dist = [
     { name = "google-adk", marker = "extra == 'agent-frameworks'", specifier = ">=1.14.1" },
     { name = "google-cloud-aiplatform", marker = "extra == 'google-vertexai'", specifier = ">=1.70.0" },
     { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=1.75.0" },
-    { name = "groq", marker = "extra == 'groq'", specifier = ">=1.2.0" },
+    { name = "groq", marker = "extra == 'groq'", specifier = ">=1.4.0" },
     { name = "httpx", marker = "extra == 'a2a'", specifier = ">=0.24.0" },
     { name = "huggingface-hub", extras = ["hf-xet"], marker = "extra == 'example-tools'", specifier = ">=0.36.0" },
     { name = "jsonschema", specifier = ">=4.18.0" },
@@ -690,7 +690,7 @@ requires-dist = [
     { name = "llama-index-core", marker = "extra == 'agent-frameworks'", specifier = ">=0.14.22" },
     { name = "llama-index-llms-openai", marker = "extra == 'agent-frameworks'", specifier = ">=0.7.7" },
     { name = "matplotlib", marker = "extra == 'example-tools'", specifier = ">=3.7.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.27.1" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.27.2" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'embeddings'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'nomic'", specifier = ">=1.24.0" },
@@ -3072,7 +3072,7 @@ wheels = [
 
 [[package]]
 name = "groq"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3082,9 +3082,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/51/4728c13611849ff6cf8536740ae78ba3ee5e665d67b572a47c9ead0f9788/groq-1.2.0.tar.gz", hash = "sha256:85459e27c9c17f22404349c785cd08680362cfe85e07cc060be46c4832f108c3", size = 155609, upload-time = "2026-04-18T10:43:50.68Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/84/d99c4894d32ed52bf2763127804343d9323dce22beb61d42aebc7d9c5f4d/groq-1.4.0.tar.gz", hash = "sha256:09b1ed51408c6969a11ef1a4dfe44d42ec975b5f1510e5de3f3dab56e22dffc6", size = 158123, upload-time = "2026-05-28T03:11:47.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/748639c95c60ad8846c65b167ca611c815d06d5f67a9e73b23486dce4fdf/groq-1.2.0-py3-none-any.whl", hash = "sha256:1002060a743b27c8f86765e1bc9749c98498e961d9fe2e4902bf7804a71c3c84", size = 142334, upload-time = "2026-04-18T10:43:49.125Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5b/28cfd8937be95c0814fd9458710a8a257fb8424a39e291b7bbd494476108/groq-1.4.0-py3-none-any.whl", hash = "sha256:99a3bcd57c71538f69cf11c75cdae91598983d2681b9a14008636a018c4b6d17", size = 143699, upload-time = "2026-05-28T03:11:46.23Z" },
 ]
 
 [[package]]
@@ -4347,7 +4347,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "1.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4365,9 +4365,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Full compatibility and modernisation audit run against the latest stable SDK releases as of 2026-05-30. Targets the PR #213 branch (`claude/cool-hopper-34gYr`) so that the AF 1.7.0 / anthropic 0.105.0 changes from that run are included.

### Must-change items completed

| # | Change | File | Risk |
|---|--------|------|------|
| 1 | Bump `groq` floor `>=1.2.0 → >=1.4.0` | `pyproject.toml` | Safe internal |
| 2 | Bump `mcp` floor `>=1.27.1 → >=1.27.2` | `pyproject.toml` | Safe internal |
| 3 | Update crewai note: 1.14.5 → 1.14.6 (still blocked in combined extra) | `pyproject.toml` | Documentation |
| 4 | Add `TestClaudeOpus48ThinkingGuards` (6 tests) to `test_anthropic_features.py` | `tests/test_anthropic_features.py` | Safe internal |
| 5 | Regenerate `uv.lock` (groq 1.2.0→1.4.0, mcp 1.27.1→1.27.2) | `uv.lock` | Safe internal |
| 6 | Update `AUDIT.md` with 2026-05-30 findings | `AUDIT.md` | Documentation |

### Rationale

**`groq` 1.4.0** (released 2026-05-28) — adds realtime audio transcription and updated model aliases. No breaking changes to `chat.completions` interface used by Gantry.
Source: https://pypi.org/pypi/groq/json

**`mcp` 1.27.2** (released 2026-05-29) — patch release, no API changes.
Source: https://pypi.org/pypi/mcp/json

**`crewai` 1.14.6** — patch release over 1.14.5. Still blocked from upgrade in the combined `agent-frameworks` extra due to `opentelemetry-api~=1.34.0 (<1.35)` conflicting with `agent-framework>=1.2.1` (`opentelemetry-api>=1.39.0`). Comment updated; floor stays at `>=1.6.1`.

**`claude-opus-4-8` thinking-mode guard tests** — closes the "good next-step" item from the 2026-05-29 audit (PR #213). Six tests in `TestClaudeOpus48ThinkingGuards` document that:
- Adaptive thinking (`effort="low|medium|high"`) is the correct configuration for `claude-opus-4-8`.
- Extended thinking (`budget_tokens`) is **incompatible** with this model (Anthropic API returns an error).
- The `AnthropicFeatures` default config is safe for `claude-opus-4-8` (no thinking enabled by default).
- The `create_anthropic_client(enable_thinking="adaptive")` factory produces the correct payload shape.
Source: https://platform.claude.com/docs/en/docs/about-claude/models/overview

### Good next-step improvements (not in this PR)

- Explore `HarnessAgent` for long-running Gantry pipelines (AF 1.7.0 new feature)
- Validate `google-adk>=2.1.0` standalone and add Workflow Runtime example
- Add MAF migration guide for teams moving from AutoGen/AG2

## Test plan

- [x] All 28 tests in `tests/test_anthropic_features.py` pass (6 new + 22 existing)
- [x] All 92 tests in `tests/test_tool_spec_adapters.py`, `test_agent_framework_integration.py`, `test_agent_framework_orchestration.py`, `test_agent_framework_provider.py` pass
- [x] `uv lock --upgrade-package groq --upgrade-package mcp` resolves without conflicts
- [x] `uv lock` output confirms: groq 1.2.0→1.4.0, mcp 1.27.1→1.27.2

https://claude.ai/code/session_017P6L8pKsoJhvv1qYEKoGK9

---
_Generated by [Claude Code](https://claude.ai/code/session_017P6L8pKsoJhvv1qYEKoGK9)_