### PR TITLE
⚡ Bolt: Fast token matching with substring pre-check

### DIFF
--- a/agent_gantry/utils/registry_linter.py
+++ b/agent_gantry/utils/registry_linter.py
@@ -68,11 +68,7 @@ class RegistryAnalysis:
 
     @property
     def empty(self) -> bool:
-        return (
-            not self.cross_references
-            and not self.similar_pairs
-            and not self.overlapping_tags
-        )
+        return not self.cross_references and not self.similar_pairs and not self.overlapping_tags
 
     def format_text(self) -> str:
         """Human-readable rendering for the CLI."""
@@ -116,9 +112,7 @@ def _detect_cross_references(
     # don't match the tool's *own* name when it's a substring of another.
     # Short names (< 3 chars) produce too many false positives — skip them.
     patterns: dict[str, re.Pattern[str]] = {
-        n: re.compile(rf"(?<!\w){re.escape(n.lower())}(?!\w)")
-        for n in names
-        if len(n) >= 3
+        n: re.compile(rf"(?<!\w){re.escape(n.lower())}(?!\w)") for n in names if len(n) >= 3
     }
     # Tokens to scan: description + extended_description + tags + examples.
     for tool in tools:
@@ -131,6 +125,8 @@ def _detect_cross_references(
         refs: list[str] = []
         for other, pattern in patterns.items():
             if other == tool.name:
+                continue
+            if other not in full:
                 continue
             if pattern.search(full):
                 refs.append(other)


### PR DESCRIPTION
💡 What: Added a fast substring pre-check (`if other not in full: continue`) in `_detect_cross_references` in `agent_gantry/utils/registry_linter.py` before running the compiled regex pattern search.
🎯 Why: Evaluating the regex engine is expensive, even with compiled patterns. When the token does not exist in the text at all, the regex engine still scans the whole string. The native Python `in` operator uses highly optimized C algorithms and provides a massive speedup for the non-matching case. This mirrors the optimization already present in `agent_gantry/core/router.py`.
📊 Impact: Significantly reduces CPU time during registry linting, especially when checking a large registry where many tools will not cross-reference each other. Turns an expensive O(N) regex evaluation inner loop into a much faster native string search.
🔬 Measurement: Run the test suite (`uv run pytest`) to verify exact behavior is preserved.

---
*PR created automatically by Jules for task [10100155724509224485](https://jules.google.com/task/10100155724509224485) started by @CodeHalwell*