### PR TITLE
perf+review: vectorize in-memory search, add selection/multi-turn benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,10 +618,11 @@ for server in servers:
 tools = await gantry.retrieve_tools("read my config.yaml")
 ```
 
-> **Note:** Dynamic MCP server selection and the associated semantic search APIs are currently a
-> preview/placeholder implementation. The underlying semantic search logic is not yet fully
-> implemented and behavior may change in future releases. See the dynamic MCP selection docs
-> for the current status and roadmap.
+> **Note:** Dynamic MCP server selection is implemented end-to-end: `register_mcp_server()` embeds
+> server metadata, `sync_mcp_servers()` / `retrieve_mcp_servers()` run real semantic search over
+> registered servers, and `discover_tools_from_server()` connects on demand and registers the
+> discovered tools into the registry so `retrieve_tools()` finds them. Requires the `mcp` extra
+> (`pip install agent-gantry[mcp]`). See the dynamic MCP selection docs for details.
 
 **Benefits:**
 - 🎯 **Semantic Routing**: Automatically finds relevant servers based on query context

--- a/agent_gantry/adapters/vector_stores/memory.py
+++ b/agent_gantry/adapters/vector_stores/memory.py
@@ -104,6 +104,11 @@ class InMemoryVectorStore:
 
         # Normalize the query once; stored rows are already normalized.
         q = np.asarray(query_vector, dtype=np.float32)
+        # Guard against a query/stored dimension mismatch: the old per-vector
+        # loop returned 0.0 similarity for mismatched lengths, so preserve that
+        # graceful behaviour here instead of letting the matmul raise.
+        if q.ndim != 1 or q.shape[0] != self._matrix.shape[1]:
+            return []
         q_norm = float(np.linalg.norm(q))
         if q_norm == 0.0:
             return []

--- a/agent_gantry/adapters/vector_stores/memory.py
+++ b/agent_gantry/adapters/vector_stores/memory.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import math
 from typing import Any
 
+import numpy as np
+
 from agent_gantry.schema.tool import ToolDefinition
 
 
@@ -29,6 +31,12 @@ class InMemoryVectorStore:
         self._fingerprints: dict[str, str] = {}
         self._metadata: dict[str, str] = {}
         self._dimension = dimension
+        # Vectorized search cache: a (n, d) L2-normalized matrix plus the row
+        # ordering. Rebuilt lazily on the next search after any mutation, so a
+        # batch of add/delete calls only pays for one rebuild. ``None`` means
+        # "stale — rebuild before use".
+        self._matrix: np.ndarray | None = None
+        self._matrix_keys: list[str] = []
 
     @property
     def dimension(self) -> int:
@@ -65,6 +73,8 @@ class InMemoryVectorStore:
                 # Store fingerprint for change detection
                 self._fingerprints[key] = tool.content_hash
                 count += 1
+        if count:
+            self._matrix = None  # invalidate vectorized cache
         return count
 
     async def search(
@@ -75,17 +85,34 @@ class InMemoryVectorStore:
         score_threshold: float | None = None,
         include_embeddings: bool = False,
     ) -> list[tuple[ToolDefinition, float]] | list[tuple[ToolDefinition, float, list[float]]]:
-        """Search for similar tools using cosine similarity."""
-        results: list[tuple[ToolDefinition, float, list[float]]] = []
+        """Search for similar tools using cosine similarity.
 
+        Cosine scores are computed in a single vectorized matmul against a
+        cached, L2-normalized embedding matrix (``query · M.T``) rather than a
+        per-tool Python loop. For a registry of *n* tools this turns the hot
+        path from ``n`` pure-Python dot products into one NumPy BLAS call,
+        which dominates retrieval latency once *n* grows past a few dozen.
+        """
         # Extract tag filters for faster set operations
         required_tags: set[str] = set()
         if filters and "tags" in filters:
             required_tags = set(filters["tags"])
 
-        for key, tool in self._tools.items():
-            embedding = self._embeddings.get(key)
-            if embedding is None:
+        self._ensure_matrix()
+        if self._matrix is None or self._matrix.shape[0] == 0:
+            return []
+
+        # Normalize the query once; stored rows are already normalized.
+        q = np.asarray(query_vector, dtype=np.float32)
+        q_norm = float(np.linalg.norm(q))
+        if q_norm == 0.0:
+            return []
+        scores = self._matrix @ (q / q_norm)  # (n,) cosine similarities
+
+        results: list[tuple[ToolDefinition, float, str]] = []
+        for idx, key in enumerate(self._matrix_keys):
+            tool = self._tools.get(key)
+            if tool is None:
                 continue
 
             # Apply filters
@@ -97,24 +124,35 @@ class InMemoryVectorStore:
                             continue
                     elif tool.namespace != ns_filter:
                         continue
-                if required_tags:
-                    if required_tags.isdisjoint(tool.tags):
-                        continue
+                if required_tags and required_tags.isdisjoint(tool.tags):
+                    continue
 
-            # Calculate cosine similarity
-            score = self._cosine_similarity(query_vector, embedding)
-
+            score = float(scores[idx])
             if score_threshold is None or score >= score_threshold:
-                results.append((tool, score, embedding))
+                results.append((tool, score, key))
 
         # Sort by score descending
         results.sort(key=lambda x: x[1], reverse=True)
 
-        # Return with or without embeddings based on parameter
         limited = results[:limit]
         if include_embeddings:
-            return limited
+            return [(tool, score, self._embeddings[key]) for tool, score, key in limited]
         return [(tool, score) for tool, score, _ in limited]
+
+    def _ensure_matrix(self) -> None:
+        """(Re)build the cached normalized embedding matrix if stale."""
+        if self._matrix is not None:
+            return
+        keys = [k for k in self._tools if self._embeddings.get(k) is not None]
+        if not keys:
+            self._matrix = np.zeros((0, 0), dtype=np.float32)
+            self._matrix_keys = []
+            return
+        mat = np.asarray([self._embeddings[k] for k in keys], dtype=np.float32)
+        norms = np.linalg.norm(mat, axis=1, keepdims=True)
+        norms[norms == 0.0] = 1.0  # avoid divide-by-zero for zero vectors
+        self._matrix = mat / norms
+        self._matrix_keys = keys
 
     async def get_by_name(self, name: str, namespace: str = "default") -> ToolDefinition | None:
         """Get a tool by name."""
@@ -128,6 +166,7 @@ class InMemoryVectorStore:
             del self._tools[key]
             self._embeddings.pop(key, None)
             self._fingerprints.pop(key, None)
+            self._matrix = None  # invalidate vectorized cache
             return True
         return False
 

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -871,6 +871,7 @@ class AgentGantry:
         query: str,
         limit: int = 5,
         dialect: str = "openai",
+        score_threshold: float = 0.0,
         **kwargs: Any,
     ) -> list[dict[str, Any]]:
         """
@@ -882,7 +883,13 @@ class AgentGantry:
             dialect: Target dialect/provider name (default: 'openai')
                 Supported: 'openai', 'openai_responses', 'anthropic', 'gemini',
                 'mistral', 'groq', 'agent_framework', 'auto'
-            **kwargs: Additional query parameters (e.g., score_threshold)
+            score_threshold: Minimum cosine score to keep a tool. Defaults to
+                ``0.0`` (no filtering) — unlike the raw :class:`ToolQuery`
+                default of ``0.5``. A 0.5 absolute cutoff silently drops correct
+                tools for embedders whose scores sit below it (e.g. MiniLM), so
+                the high-level convenience API opts out of filtering by default
+                and lets ranking + ``limit`` do the work.
+            **kwargs: Additional query parameters
 
         Returns:
             List of provider-specific tool schemas
@@ -890,7 +897,9 @@ class AgentGantry:
         from agent_gantry.schema.query import ConversationContext, ToolQuery
 
         context = ConversationContext(query=query)
-        tool_query = ToolQuery(context=context, limit=limit, **kwargs)
+        tool_query = ToolQuery(
+            context=context, limit=limit, score_threshold=score_threshold, **kwargs
+        )
         result = await self.retrieve(tool_query)
         return result.to_dialect(dialect)
 
@@ -920,6 +929,7 @@ class AgentGantry:
         query: str,
         arguments: dict[str, Any] | None = None,
         limit: int = 1,
+        score_threshold: float = 0.0,
         **kwargs: Any,
     ) -> ToolResult:
         """
@@ -953,7 +963,9 @@ class AgentGantry:
 
         # Retrieve best matching tool
         context = ConversationContext(query=query)
-        tool_query = ToolQuery(context=context, limit=limit, **kwargs)
+        tool_query = ToolQuery(
+            context=context, limit=limit, score_threshold=score_threshold, **kwargs
+        )
         result = await self.retrieve(tool_query)
 
         if not result.tools:

--- a/agent_gantry/integrations/__init__.py
+++ b/agent_gantry/integrations/__init__.py
@@ -20,6 +20,12 @@ from agent_gantry.integrations.agent_framework_provider import (
     MissingRequiredToolError,
 )
 from agent_gantry.integrations.framework_adapters import fetch_framework_tools
+from agent_gantry.integrations.frameworks import (
+    GantryToolset,
+    ToolExecutionError,
+    ToolSpec,
+)
+from agent_gantry.integrations.refresh import ToolRefresher
 from agent_gantry.integrations.semantic_tools import (
     SemanticToolsDecorator,
     SemanticToolSelector,
@@ -32,11 +38,15 @@ __all__: list[str] = [
     "GantryObservabilityMiddleware",
     "GantryToolBridge",
     "GantryToolChoiceMiddleware",
+    "GantryToolset",
     "MissingRequiredToolError",
     "RetrievalCandidate",
     "RetrievalDecision",
     "SemanticToolSelector",
     "SemanticToolsDecorator",
+    "ToolExecutionError",
+    "ToolRefresher",
+    "ToolSpec",
     "with_semantic_tools",
     "fetch_framework_tools",
 ]

--- a/agent_gantry/integrations/framework_adapters.py
+++ b/agent_gantry/integrations/framework_adapters.py
@@ -38,7 +38,7 @@ async def fetch_framework_tools(
     *,
     framework: FrameworkName,
     limit: int = 5,
-    score_threshold: float = 0.5,
+    score_threshold: float = 0.0,
 ) -> list[dict[str, Any]]:
     """
     Retrieve top-k tools and emit the schema shape expected by a framework.

--- a/agent_gantry/integrations/frameworks/README.md
+++ b/agent_gantry/integrations/frameworks/README.md
@@ -44,7 +44,7 @@ selection knobs as `GantryToolset.select` (`score_threshold`, `namespaces`,
 `tools_already_used`). Need one conversion at a time? Use `spec_to_<fw>(spec)`
 with specs from `GantryToolset(gantry).select(query)`.
 
-## Multi-turn re-selection (any framework)
+## Multi-turn re-selection — autonomous *and* conversational
 
 `ToolRefresher` generalizes the Microsoft Agent Framework provider's per-call
 retrieval to any framework: re-rank the whole registry on every turn so the
@@ -60,6 +60,20 @@ refresher = ToolRefresher(gantry, limit=3, dialect="openai")
 tools = await refresher.refresh(messages)        # dialect schemas
 specs = await refresher.refresh_specs(messages)  # ToolSpec objects
 ```
+
+The default query generator (`agent_gantry.query.latest_activity`) is
+**recency-aware**, so one refresher serves both styles with no configuration:
+
+- **Autonomous agents / tool pipelines** — when the newest message is a tool
+  result (the agent is chaining tools with no new user input), that result's
+  *content* selects the next tool: `fetch → clean → train → evaluate → report`.
+- **Conversational agents** — when the newest message is the user's, their new
+  request selects the next tool: `weather → flights → hotel → email`.
+
+To force one behaviour, pass `query_generator=` explicitly — `last_user_text`
+(always the user), `last_tool_result` (always the last result), or a custom
+`fallback_chain(...)`. See `examples/frameworks/multi_turn_refresher_example.py`
+for both modes side by side.
 
 ## Shared base
 

--- a/agent_gantry/integrations/frameworks/README.md
+++ b/agent_gantry/integrations/frameworks/README.md
@@ -1,0 +1,70 @@
+# Native framework tool adapters
+
+Agent-Gantry selects a small, relevant slice of tools from a large registry.
+These adapters hand that slice to a concrete agent framework as **native tool
+objects** — not just JSON schemas — so the framework can introspect and call
+them, while every invocation still routes through `gantry.execute` (retries,
+timeouts, circuit breakers, security policy all apply).
+
+## Supported frameworks
+
+| Framework | `for_*` helper | Native object |
+|---|---|---|
+| LangChain | `for_langchain` | `langchain_core.tools.StructuredTool` |
+| LangGraph | `for_langgraph` | LangChain `StructuredTool` (LangGraph consumes these) |
+| LlamaIndex | `for_llamaindex` | `llama_index.core.tools.FunctionTool` |
+| CrewAI | `for_crewai` | `crewai.tools.BaseTool` subclass |
+| Pydantic AI | `for_pydantic_ai` | `pydantic_ai.tools.Tool` |
+| OpenAI Agents SDK | `for_openai_agents` | `agents.FunctionTool` |
+| Smolagents | `for_smolagents` | `smolagents.Tool` subclass |
+| Haystack | `for_haystack` | `haystack.tools.Tool` |
+| Agno | `for_agno` | `agno.tools.function.Function` |
+| AutoGen / AG2 | `for_autogen`, `register_with_autogen` | callables + `register_function` |
+
+All third-party imports are **lazy** — `import agent_gantry` never requires any
+of these frameworks. A missing framework raises `ImportError` with a
+`pip install …` hint only when you call its adapter.
+
+## Usage
+
+```python
+from agent_gantry import AgentGantry
+from agent_gantry.integrations.frameworks import for_langchain
+
+gantry = AgentGantry()
+# ... register tools, await gantry.sync() ...
+
+# Select the top-3 relevant tools and get them as LangChain StructuredTools:
+tools = await for_langchain(gantry, "email the quarterly report to finance", limit=3)
+# hand `tools` to a LangChain/LangGraph agent
+```
+
+Every `for_<fw>(gantry, query, *, limit=3, **select_kwargs)` accepts the same
+selection knobs as `GantryToolset.select` (`score_threshold`, `namespaces`,
+`tools_already_used`). Need one conversion at a time? Use `spec_to_<fw>(spec)`
+with specs from `GantryToolset(gantry).select(query)`.
+
+## Multi-turn re-selection (any framework)
+
+`ToolRefresher` generalizes the Microsoft Agent Framework provider's per-call
+retrieval to any framework: re-rank the whole registry on every turn so the
+agent can pivot to a different tool as the task changes.
+
+```python
+from agent_gantry.integrations import ToolRefresher
+
+refresher = ToolRefresher(gantry, limit=3, dialect="openai")
+
+# Each turn, pass the running message list; selection is recomputed fresh and
+# tools already used are deprioritized so the agent keeps moving forward.
+tools = await refresher.refresh(messages)        # dialect schemas
+specs = await refresher.refresh_specs(messages)  # ToolSpec objects
+```
+
+## Shared base
+
+`base.py` provides `GantryToolset` (selection) and `ToolSpec` (a
+framework-neutral handle with `.name`, `.description`, `.parameters`, plus
+`ainvoke`/`invoke`). `invoke()` is safe to call from synchronous framework code
+even inside a running event loop — it runs the coroutine on a worker thread and
+blocks for the result.

--- a/agent_gantry/integrations/frameworks/__init__.py
+++ b/agent_gantry/integrations/frameworks/__init__.py
@@ -1,0 +1,23 @@
+"""Native per-framework tool adapters built on a shared selection core.
+
+Each module exports ``for_<framework>(gantry, query, ...)`` (and a matching
+``spec_to_<framework>`` converter) that turns Gantry-selected tools into that
+framework's native tool objects. Imports of the third-party framework are lazy,
+so importing this package never requires those frameworks to be installed.
+"""
+
+from __future__ import annotations
+
+from agent_gantry.integrations.frameworks.base import (
+    GantryToolset,
+    ToolExecutionError,
+    ToolSpec,
+    spec_from_tool,
+)
+
+__all__ = [
+    "GantryToolset",
+    "ToolExecutionError",
+    "ToolSpec",
+    "spec_from_tool",
+]

--- a/agent_gantry/integrations/frameworks/__init__.py
+++ b/agent_gantry/integrations/frameworks/__init__.py
@@ -4,20 +4,86 @@ Each module exports ``for_<framework>(gantry, query, ...)`` (and a matching
 ``spec_to_<framework>`` converter) that turns Gantry-selected tools into that
 framework's native tool objects. Imports of the third-party framework are lazy,
 so importing this package never requires those frameworks to be installed.
+
+Supported frameworks: LangChain, LangGraph, LlamaIndex, CrewAI, Pydantic AI,
+OpenAI Agents SDK, Smolagents, Haystack, Agno, AutoGen/AG2.
 """
 
 from __future__ import annotations
 
+from agent_gantry.integrations.frameworks.agno import for_agno, spec_to_agno
+from agent_gantry.integrations.frameworks.autogen import (
+    for_autogen,
+    register_with_autogen,
+    spec_to_autogen,
+)
 from agent_gantry.integrations.frameworks.base import (
     GantryToolset,
     ToolExecutionError,
     ToolSpec,
     spec_from_tool,
 )
+from agent_gantry.integrations.frameworks.crewai import for_crewai, spec_to_crewai
+from agent_gantry.integrations.frameworks.haystack import for_haystack, spec_to_haystack
+from agent_gantry.integrations.frameworks.langchain import (
+    for_langchain,
+    spec_to_langchain,
+)
+from agent_gantry.integrations.frameworks.langgraph import (
+    for_langgraph,
+    spec_to_langgraph,
+)
+from agent_gantry.integrations.frameworks.llamaindex import (
+    for_llamaindex,
+    spec_to_llamaindex,
+)
+from agent_gantry.integrations.frameworks.openai_agents import (
+    for_openai_agents,
+    spec_to_openai_agents,
+)
+from agent_gantry.integrations.frameworks.pydantic_ai import (
+    for_pydantic_ai,
+    spec_to_pydantic_ai,
+)
+from agent_gantry.integrations.frameworks.smolagents import (
+    for_smolagents,
+    spec_to_smolagents,
+)
 
 __all__ = [
+    # base
     "GantryToolset",
     "ToolExecutionError",
     "ToolSpec",
     "spec_from_tool",
+    # langchain / langgraph
+    "for_langchain",
+    "spec_to_langchain",
+    "for_langgraph",
+    "spec_to_langgraph",
+    # llamaindex
+    "for_llamaindex",
+    "spec_to_llamaindex",
+    # crewai
+    "for_crewai",
+    "spec_to_crewai",
+    # pydantic-ai
+    "for_pydantic_ai",
+    "spec_to_pydantic_ai",
+    # openai agents sdk
+    "for_openai_agents",
+    "spec_to_openai_agents",
+    # smolagents
+    "for_smolagents",
+    "spec_to_smolagents",
+    # haystack
+    "for_haystack",
+    "spec_to_haystack",
+    # agno
+    "for_agno",
+    "spec_to_agno",
+    # autogen / ag2
+    "for_autogen",
+    "spec_to_autogen",
+    "register_with_autogen",
 ]

--- a/agent_gantry/integrations/frameworks/agno.py
+++ b/agent_gantry/integrations/frameworks/agno.py
@@ -1,0 +1,58 @@
+"""Agno (formerly Phidata) native tool adapter for Agent-Gantry.
+
+Selects a relevant slice of Gantry tools and wraps each as an Agno
+``Function`` — the native tool object an Agno agent introspects (name /
+description / JSON-schema parameters) and invokes. The ``agno`` import is lazy
+so ``import agent_gantry`` never requires Agno to be installed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+
+
+def spec_to_agno(spec: ToolSpec) -> Any:
+    """Wrap a :class:`ToolSpec` as an Agno ``Function``.
+
+    Agno calls the ``entrypoint`` with the tool arguments as keyword arguments,
+    so the entrypoint is a sync wrapper that routes through ``spec.invoke`` (and
+    therefore ``gantry.execute``). The ``agno`` import happens here, lazily, so
+    callers without Agno installed only hit the error when they actually export
+    a tool.
+    """
+    try:
+        from agno.tools.function import Function
+    except ImportError as exc:  # pragma: no cover - exercised via stub
+        raise ImportError(
+            "Agno support requires `agno`. Install it with `pip install agno`."
+        ) from exc
+
+    def _entrypoint(**kwargs: Any) -> Any:
+        return spec.invoke(**kwargs)
+
+    _entrypoint.__name__ = spec.name
+    _entrypoint.__doc__ = spec.description
+
+    return Function(
+        name=spec.name,
+        description=spec.description,
+        parameters=spec.parameters,
+        entrypoint=_entrypoint,
+    )
+
+
+async def for_agno(
+    gantry: AgentGantry,
+    query: str,
+    *,
+    limit: int = 3,
+    **select_kwargs: Any,
+) -> list[Any]:
+    """Select tools for ``query`` and return them as Agno ``Function``s."""
+    specs = await GantryToolset(gantry).select(query, limit=limit, **select_kwargs)
+    return [spec_to_agno(s) for s in specs]

--- a/agent_gantry/integrations/frameworks/agno.py
+++ b/agent_gantry/integrations/frameworks/agno.py
@@ -32,11 +32,17 @@ def spec_to_agno(spec: ToolSpec) -> Any:
             "Agno support requires `agno`. Install it with `pip install agno`."
         ) from exc
 
+    async_fn = spec.callable_for_signature()
+
     def _entrypoint(**kwargs: Any) -> Any:
         return spec.invoke(**kwargs)
 
     _entrypoint.__name__ = spec.name
     _entrypoint.__doc__ = spec.description
+    # Copy the real signature so Agno introspection surfaces the actual
+    # parameters instead of a bare **kwargs (no-argument) tool.
+    _entrypoint.__signature__ = async_fn.__signature__  # type: ignore[attr-defined]
+    _entrypoint.__annotations__ = dict(getattr(async_fn, "__annotations__", {}))
 
     return Function(
         name=spec.name,

--- a/agent_gantry/integrations/frameworks/autogen.py
+++ b/agent_gantry/integrations/frameworks/autogen.py
@@ -1,0 +1,90 @@
+"""AutoGen / AG2 native tool adapter for Agent-Gantry.
+
+Selects a relevant slice of Gantry tools and exposes each as a plain Python
+callable that AutoGen / AG2 can register. AutoGen registers a tool by
+associating a callable with a *caller* agent (which proposes the call) and an
+*executor* agent (which runs it) via
+``autogen.register_function(func, *, caller, executor, name, description)``.
+
+The ``autogen`` import is lazy (only inside :func:`register_with_autogen`) so
+``import agent_gantry`` never requires AutoGen to be installed, and the
+schema-only helpers (:func:`spec_to_autogen`, :func:`for_autogen`) work without
+the framework present.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+
+
+def spec_to_autogen(spec: ToolSpec) -> dict[str, Any]:
+    """Describe a :class:`ToolSpec` as an AutoGen-registrable mapping.
+
+    Returns the metadata plus a fresh async callable (from
+    :meth:`ToolSpec.callable_for_signature`) that executes through Gantry. No
+    framework import is needed to build this mapping.
+    """
+    return {
+        "name": spec.name,
+        "description": spec.description,
+        "callable": spec.callable_for_signature(),
+    }
+
+
+async def for_autogen(
+    gantry: AgentGantry,
+    query: str,
+    *,
+    limit: int = 3,
+    **select_kwargs: Any,
+) -> list[dict[str, Any]]:
+    """Select tools for ``query`` and return AutoGen-registrable mappings."""
+    specs = await GantryToolset(gantry).select(query, limit=limit, **select_kwargs)
+    return [spec_to_autogen(s) for s in specs]
+
+
+async def register_with_autogen(
+    gantry: AgentGantry,
+    query: str,
+    *,
+    caller: Any,
+    executor: Any,
+    limit: int = 3,
+    **select_kwargs: Any,
+) -> list[str]:
+    """Select tools and register each with AutoGen's caller/executor agents.
+
+    The ``autogen`` import happens here, lazily, so callers without AutoGen
+    installed only hit the error when they actually register tools. Each
+    selected tool is wired up via ``autogen.register_function``.
+
+    Returns the list of registered tool names.
+
+    Raises:
+        ImportError: If ``autogen`` (pyautogen) is not installed.
+    """
+    try:
+        from autogen import register_function
+    except ImportError as exc:  # pragma: no cover - exercised via fake module
+        raise ImportError(
+            "AutoGen support requires `autogen`. "
+            "Install it with `pip install pyautogen`."
+        ) from exc
+
+    specs = await GantryToolset(gantry).select(query, limit=limit, **select_kwargs)
+    names: list[str] = []
+    for spec in specs:
+        register_function(
+            spec.callable_for_signature(),
+            caller=caller,
+            executor=executor,
+            name=spec.name,
+            description=spec.description,
+        )
+        names.append(spec.name)
+    return names

--- a/agent_gantry/integrations/frameworks/base.py
+++ b/agent_gantry/integrations/frameworks/base.py
@@ -19,7 +19,8 @@ framework needs plus two invocation entry points that both route through
 policy all still apply):
 
 - :meth:`ToolSpec.ainvoke` — async, ``**kwargs`` or a single dict.
-- :meth:`ToolSpec.invoke`  — sync wrapper (errors inside a running loop).
+- :meth:`ToolSpec.invoke`  — sync wrapper, safe to call even from inside a
+  running event loop (it offloads to a shared worker thread and blocks).
 
 The adapters are intentionally dependency-free at import time: the third-party
 framework is imported lazily inside the ``to_*`` builder, so ``import
@@ -29,6 +30,7 @@ agent_gantry`` never requires LangChain et al. to be installed.
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -82,8 +84,19 @@ class ToolSpec:
         Accepts either a single positional mapping (``ainvoke({"a": 1})``) or
         keyword arguments (``ainvoke(a=1)``). Raises :class:`ToolExecutionError`
         on any non-success status so framework error handling kicks in.
+
+        ``None``-valued arguments for *optional* parameters are dropped: several
+        frameworks (CrewAI, Pydantic-schema validators, …) materialize every
+        declared optional field as ``None`` when the model didn't supply it,
+        but the tool's JSON schema types those params (e.g. ``string``) and the
+        executor rejects ``None``. Dropping them lets the tool's own default
+        apply — ``None`` for a required param is kept so the error stays clear.
         """
         arguments = _coerce_arguments(args, kwargs)
+        required = set(self.parameters.get("required") or [])
+        arguments = {
+            k: v for k, v in arguments.items() if v is not None or k in required
+        }
         result = await self._gantry.execute(
             ToolCall(tool_name=self.name, arguments=arguments)
         )
@@ -109,8 +122,12 @@ class ToolSpec:
         """Return a plain async function that calls this tool by keyword.
 
         Frameworks that build their own tool object from a function (Smolagents,
-        Agno, Pydantic AI, OpenAI Agents SDK) can wrap this. The returned
-        function carries ``__name__`` / ``__doc__`` so introspection works.
+        Agno, Pydantic AI, OpenAI Agents SDK, AutoGen) can wrap this. The
+        returned function carries ``__name__`` / ``__doc__`` **and a real
+        ``__signature__``** derived from :attr:`parameters`, so frameworks that
+        introspect the signature to build the LLM tool schema see the actual
+        parameters instead of a bare ``**kwargs`` (which would surface as a
+        no-argument tool).
         """
 
         async def _fn(**kwargs: Any) -> Any:
@@ -118,7 +135,60 @@ class ToolSpec:
 
         _fn.__name__ = self.name
         _fn.__doc__ = self.description
+        _fn.__signature__ = self.python_signature()  # type: ignore[attr-defined]
+        _fn.__annotations__ = {
+            p.name: p.annotation
+            for p in _fn.__signature__.parameters.values()
+            if p.annotation is not inspect.Parameter.empty
+        }
         return _fn
+
+    def python_signature(self) -> inspect.Signature:
+        """Build an :class:`inspect.Signature` from the JSON-Schema parameters.
+
+        Each property becomes a keyword-only parameter; required properties have
+        no default, optional ones default to ``None``. JSON-Schema types are
+        mapped to Python annotations so framework introspection produces a
+        faithful tool schema.
+        """
+        properties = self.parameters.get("properties") or {}
+        required = set(self.parameters.get("required") or [])
+        params: list[inspect.Parameter] = []
+        for name, prop in properties.items():
+            annotation = _json_type_to_python(prop.get("type") if isinstance(prop, dict) else None)
+            default = inspect.Parameter.empty if name in required else None
+            params.append(
+                inspect.Parameter(
+                    name,
+                    inspect.Parameter.KEYWORD_ONLY,
+                    default=default,
+                    annotation=annotation,
+                )
+            )
+        return inspect.Signature(params)
+
+
+_JSON_TO_PYTHON: dict[str, Any] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
+
+
+def _json_type_to_python(json_type: Any) -> Any:
+    """Map a JSON-Schema ``type`` to a Python annotation (default ``str``)."""
+    if isinstance(json_type, list):  # e.g. ["string", "null"]
+        json_type = next((t for t in json_type if t != "null"), None)
+    return _JSON_TO_PYTHON.get(json_type, str)
+
+
+# A single shared worker thread for running coroutines from sync framework
+# callbacks while an event loop is active on the calling thread. Reused across
+# invocations so we don't pay the spawn/teardown cost of a fresh pool each call.
+_SYNC_BRIDGE_POOL: Any = None
 
 
 def _run_coroutine_sync(coro: Any) -> Any:
@@ -126,7 +196,7 @@ def _run_coroutine_sync(coro: Any) -> Any:
 
     If no event loop runs on the current thread, use :func:`asyncio.run`.
     Otherwise (we're inside a running loop — e.g. a framework invoked our sync
-    tool from within its async agent loop), run the coroutine on a dedicated
+    tool from within its async agent loop), run the coroutine on a shared
     worker thread with its own loop and block for the result. This avoids the
     "coroutine attached to a different loop" / "loop already running" errors
     that a naive ``asyncio.run`` would raise.
@@ -136,10 +206,14 @@ def _run_coroutine_sync(coro: Any) -> Any:
     except RuntimeError:
         return asyncio.run(coro)
 
-    import concurrent.futures
+    global _SYNC_BRIDGE_POOL
+    if _SYNC_BRIDGE_POOL is None:
+        import concurrent.futures
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-        return pool.submit(lambda: asyncio.run(coro)).result()
+        _SYNC_BRIDGE_POOL = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="gantry-sync-bridge"
+        )
+    return _SYNC_BRIDGE_POOL.submit(lambda: asyncio.run(coro)).result()
 
 
 def _coerce_arguments(args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:

--- a/agent_gantry/integrations/frameworks/base.py
+++ b/agent_gantry/integrations/frameworks/base.py
@@ -96,17 +96,14 @@ class ToolSpec:
     def invoke(self, *args: Any, **kwargs: Any) -> Any:
         """Synchronous wrapper around :meth:`ainvoke`.
 
-        Safe to call from synchronous framework code. Raises ``RuntimeError`` if
-        called from inside a running event loop (use :meth:`ainvoke` there).
+        Safe to call from synchronous framework code (CrewAI ``_run``,
+        Smolagents ``forward``, Haystack/Agno function entrypoints, …) whether
+        or not an event loop is already running on the current thread. When a
+        loop is running, the coroutine is executed on a dedicated worker thread
+        and this call blocks for the result — mirroring how those frameworks
+        invoke a synchronous tool. Prefer :meth:`ainvoke` directly in async code.
         """
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return asyncio.run(self.ainvoke(*args, **kwargs))
-        raise RuntimeError(
-            f"{self.name}.invoke() called from a running event loop; use "
-            f"`await {self.name}.ainvoke(...)` instead."
-        )
+        return _run_coroutine_sync(self.ainvoke(*args, **kwargs))
 
     def callable_for_signature(self) -> Callable[..., Any]:
         """Return a plain async function that calls this tool by keyword.
@@ -122,6 +119,27 @@ class ToolSpec:
         _fn.__name__ = self.name
         _fn.__doc__ = self.description
         return _fn
+
+
+def _run_coroutine_sync(coro: Any) -> Any:
+    """Run an awaitable to completion from synchronous code, loop-or-not.
+
+    If no event loop runs on the current thread, use :func:`asyncio.run`.
+    Otherwise (we're inside a running loop — e.g. a framework invoked our sync
+    tool from within its async agent loop), run the coroutine on a dedicated
+    worker thread with its own loop and block for the result. This avoids the
+    "coroutine attached to a different loop" / "loop already running" errors
+    that a naive ``asyncio.run`` would raise.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(lambda: asyncio.run(coro)).result()
 
 
 def _coerce_arguments(args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:

--- a/agent_gantry/integrations/frameworks/base.py
+++ b/agent_gantry/integrations/frameworks/base.py
@@ -1,0 +1,200 @@
+"""Shared base for native per-framework tool adapters.
+
+Agent-Gantry's job is to *select* a small, relevant slice of tools from a large
+registry. To hand those tools to a concrete agent framework (LangChain,
+LlamaIndex, CrewAI, Pydantic AI, OpenAI Agents SDK, Smolagents, Haystack, Agno,
+…) they must be wrapped as that framework's *native* tool object — a callable
+that the framework can introspect (name, description, JSON-schema parameters)
+and invoke.
+
+Every adapter in this subpackage follows the same shape:
+
+    toolset = GantryToolset(gantry)
+    specs   = await toolset.select(query, limit=3)      # ranked ToolSpec list
+    native  = [spec.to_<framework>() ...]               # framework-specific
+
+``ToolSpec`` is the framework-neutral handle. It exposes the metadata a
+framework needs plus two invocation entry points that both route through
+``gantry.execute`` (so retries, timeouts, circuit breakers, and the security
+policy all still apply):
+
+- :meth:`ToolSpec.ainvoke` — async, ``**kwargs`` or a single dict.
+- :meth:`ToolSpec.invoke`  — sync wrapper (errors inside a running loop).
+
+The adapters are intentionally dependency-free at import time: the third-party
+framework is imported lazily inside the ``to_*`` builder, so ``import
+agent_gantry`` never requires LangChain et al. to be installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.schema.execution import ExecutionStatus, ToolCall
+from agent_gantry.schema.query import ConversationContext, ToolQuery
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+    from agent_gantry.schema.tool import ToolDefinition
+
+
+class ToolExecutionError(RuntimeError):
+    """Raised when a Gantry-backed tool invocation does not succeed."""
+
+    def __init__(self, tool_name: str, status: str, error: str | None) -> None:
+        self.tool_name = tool_name
+        self.status = status
+        self.error = error
+        super().__init__(
+            f"Tool {tool_name!r} failed (status={status}): {error or 'no detail'}"
+        )
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Framework-neutral handle to one selected Gantry tool.
+
+    Attributes:
+        name: The tool's bare name (what the model calls).
+        qualified_name: ``namespace.name`` — unique within a registry.
+        description: Human/LLM-facing description.
+        parameters: JSON-Schema object describing the arguments.
+        requires_confirmation: Whether the underlying tool is high-risk.
+        score: The semantic score from selection (0.0 if unknown).
+    """
+
+    name: str
+    qualified_name: str
+    description: str
+    parameters: dict[str, Any]
+    requires_confirmation: bool
+    score: float
+    _gantry: AgentGantry
+    _namespace: str
+
+    # -- invocation -------------------------------------------------------- #
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> Any:
+        """Execute the tool through Gantry and return its raw result.
+
+        Accepts either a single positional mapping (``ainvoke({"a": 1})``) or
+        keyword arguments (``ainvoke(a=1)``). Raises :class:`ToolExecutionError`
+        on any non-success status so framework error handling kicks in.
+        """
+        arguments = _coerce_arguments(args, kwargs)
+        result = await self._gantry.execute(
+            ToolCall(tool_name=self.name, arguments=arguments)
+        )
+        if result.status != ExecutionStatus.SUCCESS:
+            raise ToolExecutionError(
+                self.name, getattr(result.status, "value", str(result.status)), result.error
+            )
+        return result.result
+
+    def invoke(self, *args: Any, **kwargs: Any) -> Any:
+        """Synchronous wrapper around :meth:`ainvoke`.
+
+        Safe to call from synchronous framework code. Raises ``RuntimeError`` if
+        called from inside a running event loop (use :meth:`ainvoke` there).
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.ainvoke(*args, **kwargs))
+        raise RuntimeError(
+            f"{self.name}.invoke() called from a running event loop; use "
+            f"`await {self.name}.ainvoke(...)` instead."
+        )
+
+    def callable_for_signature(self) -> Callable[..., Any]:
+        """Return a plain async function that calls this tool by keyword.
+
+        Frameworks that build their own tool object from a function (Smolagents,
+        Agno, Pydantic AI, OpenAI Agents SDK) can wrap this. The returned
+        function carries ``__name__`` / ``__doc__`` so introspection works.
+        """
+
+        async def _fn(**kwargs: Any) -> Any:
+            return await self.ainvoke(**kwargs)
+
+        _fn.__name__ = self.name
+        _fn.__doc__ = self.description
+        return _fn
+
+
+def _coerce_arguments(args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Normalize ``(*args, **kwargs)`` into a single argument dict."""
+    if args:
+        if len(args) == 1 and isinstance(args[0], dict) and not kwargs:
+            return dict(args[0])
+        raise TypeError(
+            "Tool invocation accepts a single mapping positional argument or "
+            "keyword arguments, not both / multiple positionals."
+        )
+    return dict(kwargs)
+
+
+def spec_from_tool(
+    gantry: AgentGantry, tool: ToolDefinition, score: float = 0.0
+) -> ToolSpec:
+    """Build a :class:`ToolSpec` from a Gantry :class:`ToolDefinition`."""
+    qualified = getattr(tool, "qualified_name", None) or f"{tool.namespace}.{tool.name}"
+    params = tool.parameters_schema or {"type": "object", "properties": {}}
+    return ToolSpec(
+        name=tool.name,
+        qualified_name=qualified,
+        description=tool.description or tool.name,
+        parameters=params,
+        requires_confirmation=bool(getattr(tool, "requires_confirmation", False)),
+        score=float(score),
+        _gantry=gantry,
+        _namespace=tool.namespace,
+    )
+
+
+class GantryToolset:
+    """Framework-neutral entry point: select tools, then export to a framework.
+
+    Example::
+
+        toolset = GantryToolset(gantry)
+        specs = await toolset.select("send an email", limit=3)
+        lc_tools = await toolset.for_langchain("send an email", limit=3)
+    """
+
+    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
+        self._gantry = gantry
+        self._default_limit = default_limit
+
+    async def select(
+        self,
+        query: str,
+        *,
+        limit: int | None = None,
+        score_threshold: float = 0.0,
+        namespaces: list[str] | None = None,
+        tools_already_used: list[str] | None = None,
+    ) -> list[ToolSpec]:
+        """Run semantic selection and return ranked :class:`ToolSpec` handles.
+
+        ``score_threshold`` defaults to ``0.0`` (no filtering) — matching the
+        high-level convenience API and avoiding the silent-drop trap of the raw
+        ``ToolQuery`` 0.5 default.
+        """
+        context = ConversationContext(
+            query=query,
+            tools_already_used=list(tools_already_used or []),
+        )
+        result = await self._gantry.retrieve(
+            ToolQuery(
+                context=context,
+                limit=limit or self._default_limit,
+                score_threshold=score_threshold,
+                namespaces=namespaces,
+            )
+        )
+        return [
+            spec_from_tool(self._gantry, st.tool, st.semantic_score) for st in result.tools
+        ]

--- a/agent_gantry/integrations/frameworks/crewai.py
+++ b/agent_gantry/integrations/frameworks/crewai.py
@@ -32,19 +32,52 @@ def spec_to_crewai(spec: ToolSpec) -> Any:
             "Install it with `pip install crewai`."
         ) from exc
 
-    def _run(self: Any, **kwargs: Any) -> Any:
-        return spec.invoke(**kwargs)
+    # CrewAI's BaseTool is a Pydantic v2 model: ``name`` / ``description`` are
+    # declared fields and MUST be set via the constructor, not as bare class
+    # attributes (Pydantic rejects un-annotated field overrides). ``_run`` is
+    # the abstract method we implement; it closes over ``spec``. We also pass a
+    # generated ``args_schema`` so CrewAI surfaces the real parameters to the
+    # LLM rather than a no-argument tool.
+    class GantryCrewAITool(BaseTool):  # type: ignore[misc, valid-type]
+        def _run(self, **kwargs: Any) -> Any:
+            return spec.invoke(**kwargs)
 
-    tool_cls = type(
-        "GantryCrewAITool",
-        (BaseTool,),
-        {
-            "name": spec.name,
-            "description": spec.description,
-            "_run": _run,
-        },
-    )
-    return tool_cls()
+    kwargs: dict[str, Any] = {"name": spec.name, "description": spec.description}
+    args_schema = _build_args_schema(spec)
+    if args_schema is not None:
+        kwargs["args_schema"] = args_schema
+    return GantryCrewAITool(**kwargs)
+
+
+def _build_args_schema(spec: ToolSpec) -> Any:
+    """Build a Pydantic args model from the spec's JSON-Schema parameters.
+
+    Returns ``None`` when there are no properties (CrewAI then uses its own
+    default empty schema). Best-effort: if Pydantic model creation fails for any
+    reason, fall back to ``None`` so the tool is still usable (sans typed args).
+    """
+    properties = spec.parameters.get("properties") or {}
+    if not properties:
+        return None
+    try:
+        from pydantic import Field, create_model
+
+        from agent_gantry.integrations.frameworks.base import _json_type_to_python
+
+        required = set(spec.parameters.get("required") or [])
+        fields: dict[str, Any] = {}
+        for name, prop in properties.items():
+            annotation = _json_type_to_python(
+                prop.get("type") if isinstance(prop, dict) else None
+            )
+            description = prop.get("description", "") if isinstance(prop, dict) else ""
+            if name in required:
+                fields[name] = (annotation, Field(..., description=description))
+            else:
+                fields[name] = (annotation | None, Field(default=None, description=description))
+        return create_model(f"{spec.name}_Args", **fields)
+    except Exception:  # noqa: BLE001 - schema is best-effort
+        return None
 
 
 async def for_crewai(

--- a/agent_gantry/integrations/frameworks/crewai.py
+++ b/agent_gantry/integrations/frameworks/crewai.py
@@ -1,0 +1,59 @@
+"""CrewAI native tool adapter for Agent-Gantry.
+
+Selects a relevant slice of Gantry tools and wraps each as a CrewAI
+``BaseTool`` — the native tool object CrewAI agents introspect
+(name / description) and invoke via ``_run``. The ``crewai`` import is lazy so
+``import agent_gantry`` never requires CrewAI to be installed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+
+
+def spec_to_crewai(spec: ToolSpec) -> Any:
+    """Wrap a :class:`ToolSpec` as a CrewAI ``BaseTool``.
+
+    The ``crewai`` import happens here, lazily, so callers without CrewAI
+    installed only hit the error when they actually export a tool. A subclass of
+    ``BaseTool`` is built dynamically whose ``name`` / ``description`` come from
+    the spec and whose ``_run`` routes through ``gantry.execute``.
+    """
+    try:
+        from crewai.tools import BaseTool
+    except ImportError as exc:  # pragma: no cover - exercised via stub
+        raise ImportError(
+            "CrewAI support requires `crewai`. "
+            "Install it with `pip install crewai`."
+        ) from exc
+
+    def _run(self: Any, **kwargs: Any) -> Any:
+        return spec.invoke(**kwargs)
+
+    tool_cls = type(
+        "GantryCrewAITool",
+        (BaseTool,),
+        {
+            "name": spec.name,
+            "description": spec.description,
+            "_run": _run,
+        },
+    )
+    return tool_cls()
+
+
+async def for_crewai(
+    gantry: AgentGantry,
+    query: str,
+    *,
+    limit: int = 3,
+    **select_kwargs: Any,
+) -> list[Any]:
+    """Select tools for ``query`` and return them as CrewAI ``BaseTool``s."""
+    specs = await GantryToolset(gantry).select(query, limit=limit, **select_kwargs)
+    return [spec_to_crewai(s) for s in specs]

--- a/agent_gantry/integrations/frameworks/haystack.py
+++ b/agent_gantry/integrations/frameworks/haystack.py
@@ -1,0 +1,56 @@
+"""Haystack 2.x native tool adapter for Agent-Gantry.
+
+Selects a relevant slice of Gantry tools and wraps each as a Haystack
+``haystack.tools.Tool`` — the native tool object Haystack components introspect
+(name / description / JSON-schema parameters) and invoke via a plain callable.
+The ``haystack`` import is lazy so ``import agent_gantry`` never requires
+Haystack to be installed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+
+
+def spec_to_haystack(spec: ToolSpec) -> Any:
+    """Wrap a :class:`ToolSpec` as a Haystack ``Tool``.
+
+    The ``haystack`` import happens here, lazily, so callers without Haystack
+    installed only hit the error when they actually export a tool. Haystack
+    calls ``function`` with the tool arguments as keyword arguments, so the
+    wrapper routes those through ``spec.invoke`` (and thus ``gantry.execute``).
+    """
+    try:
+        from haystack.tools import Tool
+    except ImportError as exc:  # pragma: no cover - exercised via stub
+        raise ImportError(
+            "Haystack support requires `haystack-ai`. "
+            "Install it with `pip install haystack-ai`."
+        ) from exc
+
+    def _function(**kwargs: Any) -> Any:
+        return spec.invoke(**kwargs)
+
+    return Tool(
+        name=spec.name,
+        description=spec.description,
+        parameters=spec.parameters,
+        function=_function,
+    )
+
+
+async def for_haystack(
+    gantry: AgentGantry,
+    query: str,
+    *,
+    limit: int = 3,
+    **select_kwargs: Any,
+) -> list[Any]:
+    """Select tools for ``query`` and return them as Haystack ``Tool``s."""
+    specs = await GantryToolset(gantry).select(query, limit=limit, **select_kwargs)
+    return [spec_to_haystack(s) for s in specs]

--- a/agent_gantry/integrations/frameworks/langchain.py
+++ b/agent_gantry/integrations/frameworks/langchain.py
@@ -1,0 +1,54 @@
+"""LangChain native tool adapter for Agent-Gantry.
+
+Selects a relevant slice of Gantry tools and wraps each as a LangChain
+``StructuredTool`` — the native tool object LangChain agents introspect
+(name / description / args schema) and invoke. The ``langchain-core`` import is
+lazy so ``import agent_gantry`` never requires LangChain to be installed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+
+
+def spec_to_langchain(spec: ToolSpec) -> Any:
+    """Wrap a :class:`ToolSpec` as a LangChain ``StructuredTool``.
+
+    The ``langchain_core`` import happens here, lazily, so callers without
+    LangChain installed only hit the error when they actually export a tool.
+    """
+    try:
+        from langchain_core.tools import StructuredTool
+    except ImportError as exc:  # pragma: no cover - exercised via stub
+        raise ImportError(
+            "LangChain support requires `langchain-core`. "
+            "Install it with `pip install langchain-core`."
+        ) from exc
+
+    def _sync(**kwargs: Any) -> Any:
+        return spec.invoke(**kwargs)
+
+    return StructuredTool.from_function(
+        func=_sync,
+        coroutine=spec.callable_for_signature(),
+        name=spec.name,
+        description=spec.description,
+        args_schema=spec.parameters,
+    )
+
+
+async def for_langchain(
+    gantry: AgentGantry,
+    query: str,
+    *,
+    limit: int = 3,
+    **select_kwargs: Any,
+) -> list[Any]:
+    """Select tools for ``query`` and return them as LangChain ``StructuredTool``s."""
+    specs = await GantryToolset(gantry).select(query, limit=limit, **select_kwargs)
+    return [spec_to_langchain(s) for s in specs]

--- a/agent_gantry/integrations/frameworks/langgraph.py
+++ b/agent_gantry/integrations/frameworks/langgraph.py
@@ -1,0 +1,35 @@
+"""LangGraph native tool adapter for Agent-Gantry.
+
+LangGraph does not define its own tool object: a LangGraph graph (e.g. a
+``ToolNode`` or a prebuilt ReAct agent) consumes plain LangChain ``BaseTool``
+objects — the same ``StructuredTool`` instances produced by the LangChain
+adapter. So this module reuses the LangChain wrappers verbatim rather than
+duplicating them.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.integrations.frameworks.langchain import (
+    for_langchain,
+    spec_to_langchain,
+)
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+
+# A LangGraph node accepts LangChain BaseTool objects, so the per-spec wrapper
+# is identical to the LangChain one.
+spec_to_langgraph = spec_to_langchain
+
+
+async def for_langgraph(
+    gantry: AgentGantry,
+    query: str,
+    *,
+    limit: int = 3,
+    **select_kwargs: Any,
+) -> list[Any]:
+    """Select tools for ``query`` as LangChain ``BaseTool``s for a LangGraph node."""
+    return await for_langchain(gantry, query, limit=limit, **select_kwargs)

--- a/agent_gantry/integrations/frameworks/llamaindex.py
+++ b/agent_gantry/integrations/frameworks/llamaindex.py
@@ -34,15 +34,21 @@ def spec_to_llamaindex(spec: ToolSpec) -> Any:
             "install it with `pip install llama-index-core`."
         ) from exc
 
+    async_fn = spec.callable_for_signature()
+
     def _sync_fn(**kwargs: Any) -> Any:
         return spec.invoke(**kwargs)
 
     _sync_fn.__name__ = spec.name
     _sync_fn.__doc__ = spec.description
+    # Copy the real signature so LlamaIndex introspection surfaces the actual
+    # parameters instead of a bare **kwargs (no-argument) tool.
+    _sync_fn.__signature__ = async_fn.__signature__  # type: ignore[attr-defined]
+    _sync_fn.__annotations__ = dict(getattr(async_fn, "__annotations__", {}))
 
     return FunctionTool.from_defaults(
         fn=_sync_fn,
-        async_fn=spec.callable_for_signature(),
+        async_fn=async_fn,
         name=spec.name,
         description=spec.description,
     )

--- a/agent_gantry/integrations/frameworks/llamaindex.py
+++ b/agent_gantry/integrations/frameworks/llamaindex.py
@@ -1,0 +1,60 @@
+"""LlamaIndex adapter: export selected Gantry tools as ``FunctionTool`` objects.
+
+LlamaIndex agents consume :class:`llama_index.core.tools.FunctionTool` objects.
+This module wraps Gantry-selected :class:`ToolSpec` handles into that native
+type, routing every call back through ``gantry.execute`` so retries, timeouts,
+circuit breakers, and the security policy still apply.
+
+The ``llama_index`` import is lazy (performed inside the builder) so that
+``import agent_gantry`` never requires LlamaIndex to be installed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.integrations.frameworks.base import GantryToolset
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+    from agent_gantry.integrations.frameworks.base import ToolSpec
+
+
+def spec_to_llamaindex(spec: ToolSpec) -> Any:
+    """Convert a :class:`ToolSpec` into a LlamaIndex ``FunctionTool``.
+
+    Raises:
+        ImportError: If ``llama-index-core`` is not installed.
+    """
+    try:
+        from llama_index.core.tools import FunctionTool
+    except ImportError as exc:  # pragma: no cover - exercised via fake module
+        raise ImportError(
+            "LlamaIndex is required for spec_to_llamaindex; "
+            "install it with `pip install llama-index-core`."
+        ) from exc
+
+    def _sync_fn(**kwargs: Any) -> Any:
+        return spec.invoke(**kwargs)
+
+    _sync_fn.__name__ = spec.name
+    _sync_fn.__doc__ = spec.description
+
+    return FunctionTool.from_defaults(
+        fn=_sync_fn,
+        async_fn=spec.callable_for_signature(),
+        name=spec.name,
+        description=spec.description,
+    )
+
+
+async def for_llamaindex(
+    gantry: AgentGantry,
+    query: str,
+    *,
+    limit: int = 3,
+    **select_kwargs: Any,
+) -> list:
+    """Select tools for ``query`` and return them as LlamaIndex ``FunctionTool``s."""
+    specs = await GantryToolset(gantry).select(query, limit=limit, **select_kwargs)
+    return [spec_to_llamaindex(spec) for spec in specs]

--- a/agent_gantry/integrations/frameworks/openai_agents.py
+++ b/agent_gantry/integrations/frameworks/openai_agents.py
@@ -1,0 +1,71 @@
+"""OpenAI Agents SDK adapter: export selected Gantry tools as ``FunctionTool``s.
+
+The OpenAI Agents SDK (``openai-agents``, import name ``agents``) consumes
+:class:`agents.FunctionTool` objects. This module wraps Gantry-selected
+:class:`ToolSpec` handles into that native type, routing every call back through
+``gantry.execute`` so retries, timeouts, circuit breakers, and the security
+policy still apply.
+
+The ``agents`` import is lazy (performed inside the builder) so that ``import
+agent_gantry`` never requires the OpenAI Agents SDK to be installed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.integrations.frameworks.base import GantryToolset
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+    from agent_gantry.integrations.frameworks.base import ToolSpec
+
+
+def _strict_schema(params: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``params`` with ``additionalProperties: False`` set.
+
+    OpenAI strict-mode function tools require ``additionalProperties`` to be
+    ``False`` on the parameter schema.
+    """
+    schema = dict(params or {"type": "object", "properties": {}})
+    schema["additionalProperties"] = False
+    return schema
+
+
+def spec_to_openai_agents(spec: ToolSpec) -> Any:
+    """Convert a :class:`ToolSpec` into an OpenAI Agents SDK ``FunctionTool``.
+
+    Raises:
+        ImportError: If ``openai-agents`` is not installed.
+    """
+    try:
+        from agents import FunctionTool
+    except ImportError as exc:  # pragma: no cover - exercised via fake module
+        raise ImportError(
+            "The OpenAI Agents SDK is required for spec_to_openai_agents; "
+            "install it with `pip install openai-agents`."
+        ) from exc
+
+    async def _on_invoke_tool(ctx: Any, args: Any) -> str:
+        data = json.loads(args) if isinstance(args, str) else dict(args or {})
+        return str(await spec.ainvoke(**data))
+
+    return FunctionTool(
+        name=spec.name,
+        description=spec.description,
+        params_json_schema=_strict_schema(spec.parameters),
+        on_invoke_tool=_on_invoke_tool,
+    )
+
+
+async def for_openai_agents(
+    gantry: AgentGantry,
+    query: str,
+    *,
+    limit: int = 3,
+    **select_kwargs: Any,
+) -> list:
+    """Select tools for ``query`` and return them as OpenAI Agents ``FunctionTool``s."""
+    specs = await GantryToolset(gantry).select(query, limit=limit, **select_kwargs)
+    return [spec_to_openai_agents(spec) for spec in specs]

--- a/agent_gantry/integrations/frameworks/pydantic_ai.py
+++ b/agent_gantry/integrations/frameworks/pydantic_ai.py
@@ -1,0 +1,63 @@
+"""Pydantic AI native tool adapter for Agent-Gantry.
+
+Selects a relevant slice of Gantry tools and wraps each as a Pydantic AI
+``Tool`` — the native tool object a Pydantic AI ``Agent`` introspects (name /
+description / JSON-schema parameters) and invokes. The ``pydantic_ai`` import is
+lazy so ``import agent_gantry`` never requires Pydantic AI to be installed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+
+
+def spec_to_pydantic_ai(spec: ToolSpec) -> Any:
+    """Wrap a :class:`ToolSpec` as a Pydantic AI ``Tool``.
+
+    Prefers the schema-explicit ``Tool.from_schema`` constructor so the JSON
+    schema Gantry already produced is used verbatim. Older Pydantic AI versions
+    without ``from_schema`` fall back to the function-based ``Tool`` constructor.
+
+    The ``pydantic_ai`` import happens here, lazily, so callers without Pydantic
+    AI installed only hit the error when they actually export a tool.
+    """
+    try:
+        from pydantic_ai.tools import Tool
+    except ImportError as exc:  # pragma: no cover - exercised via stub
+        raise ImportError(
+            "Pydantic AI support requires `pydantic-ai`. "
+            "Install it with `pip install pydantic-ai`."
+        ) from exc
+
+    function = spec.callable_for_signature()
+    try:
+        return Tool.from_schema(
+            function=function,
+            name=spec.name,
+            description=spec.description,
+            json_schema=spec.parameters,
+        )
+    except AttributeError:
+        return Tool(
+            function,
+            name=spec.name,
+            description=spec.description,
+            takes_ctx=False,
+        )
+
+
+async def for_pydantic_ai(
+    gantry: AgentGantry,
+    query: str,
+    *,
+    limit: int = 3,
+    **select_kwargs: Any,
+) -> list[Any]:
+    """Select tools for ``query`` and return them as Pydantic AI ``Tool``s."""
+    specs = await GantryToolset(gantry).select(query, limit=limit, **select_kwargs)
+    return [spec_to_pydantic_ai(s) for s in specs]

--- a/agent_gantry/integrations/frameworks/smolagents.py
+++ b/agent_gantry/integrations/frameworks/smolagents.py
@@ -1,0 +1,93 @@
+"""Smolagents native tool adapter for Agent-Gantry.
+
+Selects a relevant slice of Gantry tools and wraps each as a HuggingFace
+``smolagents.Tool`` — the native tool object smolagents agents introspect
+(``name`` / ``description`` / ``inputs`` / ``output_type``) and invoke via
+``forward``. The ``smolagents`` import is lazy so ``import agent_gantry`` never
+requires smolagents to be installed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+
+
+# JSON-Schema type -> smolagents input type. Anything unmapped falls back to
+# "string" (smolagents' most permissive accepted type).
+_JSON_TO_SMOLAGENTS = {
+    "string": "string",
+    "integer": "integer",
+    "number": "number",
+    "boolean": "boolean",
+    "array": "array",
+    "object": "object",
+}
+
+
+def _build_inputs(parameters: dict[str, Any]) -> dict[str, dict[str, str]]:
+    """Convert a JSON-Schema ``properties`` map into smolagents ``inputs``."""
+    properties = parameters.get("properties", {}) or {}
+    inputs: dict[str, dict[str, str]] = {}
+    for argname, schema in properties.items():
+        schema = schema or {}
+        smol_type = _JSON_TO_SMOLAGENTS.get(schema.get("type"), "string")
+        description = schema.get("description") or f"{argname} argument"
+        inputs[argname] = {"type": smol_type, "description": description}
+    return inputs
+
+
+def spec_to_smolagents(spec: ToolSpec) -> Any:
+    """Wrap a :class:`ToolSpec` as a smolagents ``Tool``.
+
+    The ``smolagents`` import happens here, lazily, so callers without
+    smolagents installed only hit the error when they actually export a tool. A
+    subclass of ``Tool`` is built dynamically whose ``name`` / ``description`` /
+    ``inputs`` / ``output_type`` come from the spec and whose ``forward`` routes
+    through ``gantry.execute``.
+
+    Raises:
+        ImportError: If ``smolagents`` is not installed.
+    """
+    try:
+        from smolagents import Tool
+    except ImportError as exc:  # pragma: no cover - exercised via fake module
+        raise ImportError(
+            "Smolagents support requires `smolagents`. "
+            "Install it with `pip install smolagents`."
+        ) from exc
+
+    def forward(self: Any, **kwargs: Any) -> Any:
+        return spec.invoke(**kwargs)
+
+    tool_cls = type(
+        "GantrySmolagentsTool",
+        (Tool,),
+        {
+            "name": spec.name,
+            "description": spec.description,
+            "inputs": _build_inputs(spec.parameters),
+            "output_type": "string",
+            "forward": forward,
+        },
+    )
+    # Instantiating runs the inherited ``Tool.__init__`` (required setup such as
+    # ``is_initialized``); ``forward`` is supplied so the abstract base is
+    # concrete.
+    return tool_cls()
+
+
+async def for_smolagents(
+    gantry: AgentGantry,
+    query: str,
+    *,
+    limit: int = 3,
+    **select_kwargs: Any,
+) -> list[Any]:
+    """Select tools for ``query`` and return them as smolagents ``Tool``s."""
+    specs = await GantryToolset(gantry).select(query, limit=limit, **select_kwargs)
+    return [spec_to_smolagents(s) for s in specs]

--- a/agent_gantry/integrations/refresh.py
+++ b/agent_gantry/integrations/refresh.py
@@ -16,13 +16,14 @@ a fresh top-k selection appropriate to the *latest* sub-task.
 
 Two behaviours make this genuinely multi-turn / direction-changing:
 
-- **Query follows the conversation tail.** The default query generator is
-  ``fallback_chain(last_user_text, last_tool_result)``, so the next turn's
-  retrieval is driven by the most recent user message (falling back to the
-  latest tool result). When the user pivots (weather → email → currency), the
-  surfaced tools pivot with them. For autonomous tool *pipelines* where the
-  previous tool's output should drive the next selection, pass
-  ``query_generator=fallback_chain(last_tool_result, last_user_text)``.
+- **Query follows the conversation tail (recency-aware).** The default query
+  generator is :func:`~agent_gantry.query.latest_activity`, which drives
+  retrieval from whatever happened *most recently* — the newest user message
+  **or** the newest tool result. This serves both modes with no config:
+  autonomous agents chaining tools select the next tool from the previous
+  tool's *result*; conversational agents pivot with each new user message. The
+  two are not exclusive — a tool chain *inside* a conversational turn is driven
+  by its results, then the next user message takes over.
 - **Used tools nudge the agent forward.** When ``track_used`` is on, every
   tool/function-role message seen in the history accumulates into a
   ``tools_already_used`` set. The router applies its ``already_used_penalty``
@@ -46,7 +47,7 @@ from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
-from agent_gantry.query import fallback_chain, last_tool_result, last_user_text
+from agent_gantry.query import latest_activity
 from agent_gantry.schema.query import ConversationContext, ToolQuery
 
 if TYPE_CHECKING:
@@ -54,18 +55,22 @@ if TYPE_CHECKING:
 
 
 def _default_query_generator() -> Callable[[Iterable[Any] | None], str]:
-    """Recommended default: latest user text, falling back to tool result.
+    """Recommended default: :func:`~agent_gantry.query.latest_activity`.
 
-    Built fresh on each construction so the composed callable is never a
-    shared global. User text first makes the *conversational* case (the user
-    pivots to a new sub-task each turn) intuitive: the surfaced tools follow
-    what the user just asked for. For autonomous tool *pipelines* — where the
-    previous tool's output should pick the next tool — pass
-    ``query_generator=fallback_chain(last_tool_result, last_user_text)``
-    explicitly (this is what the Agent Framework provider's ``per_call`` mode
-    uses).
+    Recency-aware, so it serves **both** autonomous and conversational agents
+    with no configuration:
+
+    - **Autonomous / tool pipelines:** when the newest message is a tool result
+      (the agent is chaining tools with no new user input), the *content of
+      that result* drives the next selection.
+    - **Conversational:** when the newest message is the user's, their new
+      request drives selection.
+
+    To force a single behaviour, pass ``query_generator`` explicitly — e.g.
+    ``last_user_text`` (always the user), ``last_tool_result`` (always the last
+    result), or ``fallback_chain(...)`` for a custom precedence.
     """
-    return fallback_chain(last_user_text, last_tool_result)
+    return latest_activity
 
 
 def _msg_text(msg: Any) -> str:
@@ -133,11 +138,11 @@ class ToolRefresher:
             similarities, so a non-zero default silently drops relevant tools.
         query_generator: Sync or async callable mapping the messages list to a
             retrieval query string. Defaults to
-            ``fallback_chain(last_user_text, last_tool_result)`` so retrieval is
-            driven by the latest user message (falling back to the latest tool
-            result) — the intuitive choice for conversational pivots. For tool
-            pipelines, pass ``fallback_chain(last_tool_result, last_user_text)``.
-            See :mod:`agent_gantry.query` for built-in alternatives.
+            :func:`~agent_gantry.query.latest_activity` (recency-aware: the
+            newest user message *or* tool result drives selection), which works
+            for both autonomous tool pipelines and conversational agents. Pass
+            ``last_user_text`` / ``last_tool_result`` / ``fallback_chain(...)``
+            to force a specific behaviour. See :mod:`agent_gantry.query`.
         track_used: When ``True`` (default), scan the messages on every refresh
             for tool/function-role entries and accumulate their tool names into
             the ``tools_already_used`` set passed to selection. The router's

--- a/agent_gantry/integrations/refresh.py
+++ b/agent_gantry/integrations/refresh.py
@@ -73,19 +73,49 @@ def _default_query_generator() -> Callable[[Iterable[Any] | None], str]:
     return latest_activity
 
 
+def _blocks_to_text(value: Any) -> str:
+    """Join text out of a list of content blocks (OpenAI/Anthropic/LangChain).
+
+    Modern message content is often a list of blocks like
+    ``[{"type": "text", "text": "..."}, {"type": "image", ...}]`` or plain
+    strings. Pull the text parts and join them; return ``""`` for non-lists.
+    """
+    if not isinstance(value, list):
+        return ""
+    parts: list[str] = []
+    for item in value:
+        if isinstance(item, str) and item.strip():
+            parts.append(item.strip())
+        elif isinstance(item, dict):
+            t = item.get("text")
+            if isinstance(t, str) and t.strip():
+                parts.append(t.strip())
+    return " ".join(parts)
+
+
 def _msg_text(msg: Any) -> str:
-    """Best-effort plain text from a message dict or object (last-resort)."""
+    """Best-effort plain text from a message dict or object (last-resort).
+
+    Handles string content and list-of-content-blocks (multi-modal / rich-text
+    messages from OpenAI, Anthropic and LangChain).
+    """
     text = getattr(msg, "text", None)
     if isinstance(text, str) and text.strip():
         return text.strip()
     content = getattr(msg, "content", None)
     if isinstance(content, str) and content.strip():
         return content.strip()
+    blocks = _blocks_to_text(content)
+    if blocks:
+        return blocks
     if isinstance(msg, dict):
         for key in ("text", "content"):
             value = msg.get(key)
             if isinstance(value, str) and value.strip():
                 return value.strip()
+            blocks = _blocks_to_text(value)
+            if blocks:
+                return blocks
     return ""
 
 
@@ -177,10 +207,11 @@ class ToolRefresher:
 
     @property
     def tools_used(self) -> list[str]:
-        """Tool names accumulated across turns (when ``track_used``).
+        """Tool names seen in the most recent refresh's message history.
 
-        Returns an empty list when ``track_used`` is disabled. The order is
-        first-seen; each name appears once.
+        Recomputed fresh on every refresh (no cross-conversation leakage).
+        Returns an empty list when ``track_used`` is disabled or before the
+        first refresh. Order is first-seen; each name appears once.
         """
         return list(self._tools_used)
 
@@ -289,14 +320,23 @@ class ToolRefresher:
         return ""
 
     def _accumulate_used(self, messages: list[Any]) -> None:
-        """Add tool names from tool/function-role messages to the used set."""
-        seen = set(self._tools_used)
+        """Recompute the used-tool list *fresh* from the current message history.
+
+        Recomputing (rather than appending) makes a single ``ToolRefresher``
+        safe to reuse across conversations and robust to truncated/reset
+        histories: ``tools_used`` always reflects exactly the tools present in
+        the messages passed to *this* call, never leaking state from a prior
+        run. Order is first-seen; each name appears once.
+        """
+        used: list[str] = []
+        seen: set[str] = set()
         for msg in messages:
             if _msg_role(msg) in ("tool", "function"):
                 name = _msg_tool_name(msg)
                 if name and name not in seen:
                     seen.add(name)
-                    self._tools_used.append(name)
+                    used.append(name)
+        self._tools_used = used
 
 
 __all__ = ["ToolRefresher"]

--- a/agent_gantry/integrations/refresh.py
+++ b/agent_gantry/integrations/refresh.py
@@ -1,0 +1,289 @@
+"""Framework-agnostic multi-turn tool refresher.
+
+Agent-Gantry's core value is surfacing a *small, relevant* slice of tools
+instead of dumping the whole registry into the prompt. The Microsoft Agent
+Framework provider already does this *per call* (``query_strategy="per_call"``
+in :mod:`agent_gantry.integrations.agent_framework_provider`), re-selecting
+tools on every chat-completion round so the agent's tool surface tracks where
+its reasoning is heading rather than staying frozen on the first user message.
+
+:class:`ToolRefresher` generalises that idea to *any* framework. It has no
+dependency on Agent Framework (or LangChain, LlamaIndex, CrewAI, …) — it
+operates purely on a list of conversation messages (dicts or message objects)
+and a gantry instance. Call :meth:`ToolRefresher.refresh` (or
+:meth:`refresh_specs`) once per turn with the conversation-so-far and it returns
+a fresh top-k selection appropriate to the *latest* sub-task.
+
+Two behaviours make this genuinely multi-turn / direction-changing:
+
+- **Query follows the conversation tail.** The default query generator is
+  ``fallback_chain(last_tool_result, last_user_text)``, so the next turn's
+  retrieval is driven by the most recent tool result if there is one, else by
+  the most recent user message. When the user pivots (weather → email →
+  currency), the surfaced tools pivot with them.
+- **Used tools nudge the agent forward.** When ``track_used`` is on, every
+  tool/function-role message seen in the history accumulates into a
+  ``tools_already_used`` set. The router applies its ``already_used_penalty``
+  to those names, gently steering each turn toward *new* tools instead of
+  re-suggesting ones the agent already invoked.
+
+Typical usage in a hand-rolled agent loop::
+
+    refresher = ToolRefresher(gantry, limit=3, dialect="openai")
+    messages = [{"role": "user", "content": "what's the weather in Paris?"}]
+    while not done:
+        tools = await refresher.refresh(messages)   # dialect schemas for this turn
+        response = await my_llm(messages, tools=tools)
+        messages.append(...)                         # assistant / tool messages
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any
+
+from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+from agent_gantry.query import fallback_chain, last_tool_result, last_user_text
+from agent_gantry.schema.query import ConversationContext, ToolQuery
+
+if TYPE_CHECKING:
+    from agent_gantry.core.gantry import AgentGantry
+
+
+def _default_query_generator() -> Callable[[Iterable[Any] | None], str]:
+    """Recommended default: latest tool result, falling back to user text.
+
+    Built fresh on each construction so the composed callable is never a
+    shared global. This is the same composition the Agent Framework provider
+    uses for its ``per_call`` mode — the tool result drives the next retrieval
+    when present, otherwise the latest user message does.
+    """
+    return fallback_chain(last_tool_result, last_user_text)
+
+
+def _msg_text(msg: Any) -> str:
+    """Best-effort plain text from a message dict or object (last-resort)."""
+    text = getattr(msg, "text", None)
+    if isinstance(text, str) and text.strip():
+        return text.strip()
+    content = getattr(msg, "content", None)
+    if isinstance(content, str) and content.strip():
+        return content.strip()
+    if isinstance(msg, dict):
+        for key in ("text", "content"):
+            value = msg.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
+def _msg_role(msg: Any) -> str:
+    """Lowercased role of a message dict or object."""
+    role = getattr(msg, "role", None)
+    if role is None and isinstance(msg, dict):
+        role = msg.get("role")
+    return str(role).lower() if role is not None else ""
+
+
+def _msg_tool_name(msg: Any) -> str:
+    """Best-effort tool/function name for a tool-role message."""
+    for attr in ("name", "tool_name", "author_name"):
+        value = getattr(msg, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    if isinstance(msg, dict):
+        for key in ("name", "tool_name", "author_name"):
+            value = msg.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return ""
+
+
+async def _maybe_await(value: Any) -> Any:
+    """Await ``value`` when it is awaitable, otherwise return it unchanged."""
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+class ToolRefresher:
+    """Re-select tools every turn of a single agent run, for any framework.
+
+    The refresher keeps no per-turn conversation state of its own beyond the
+    accumulated set of used tool names (when ``track_used`` is enabled) and the
+    most recent selection. Each call to :meth:`refresh` / :meth:`refresh_specs`
+    recomputes the selection *fresh* from the messages you pass, so it is safe
+    to drive from any loop that appends to a growing message list.
+
+    Args:
+        gantry: The :class:`~agent_gantry.core.gantry.AgentGantry` providing
+            semantic retrieval.
+        limit: Maximum number of tools to surface per turn. Defaults to ``3``.
+        dialect: Provider dialect for :meth:`refresh`'s schema output
+            (``"openai"``, ``"anthropic"``, …). Defaults to ``"openai"``.
+        score_threshold: Minimum semantic relevance score for retained tools.
+            Defaults to ``0.0`` (no filtering) — long queries dilute absolute
+            similarities, so a non-zero default silently drops relevant tools.
+        query_generator: Sync or async callable mapping the messages list to a
+            retrieval query string. Defaults to
+            ``fallback_chain(last_tool_result, last_user_text)`` so retrieval is
+            driven by the latest tool result if present, else the latest user
+            text. See :mod:`agent_gantry.query` for built-in alternatives.
+        track_used: When ``True`` (default), scan the messages on every refresh
+            for tool/function-role entries and accumulate their tool names into
+            the ``tools_already_used`` set passed to selection. The router's
+            ``already_used_penalty`` then nudges each turn toward *new* tools.
+    """
+
+    def __init__(
+        self,
+        gantry: AgentGantry,
+        *,
+        limit: int = 3,
+        dialect: str = "openai",
+        score_threshold: float = 0.0,
+        query_generator: Callable[[Iterable[Any] | None], Any] | None = None,
+        track_used: bool = True,
+    ) -> None:
+        self._gantry = gantry
+        self._toolset = GantryToolset(gantry, default_limit=limit)
+        self._limit = limit
+        self._dialect = dialect
+        self._score_threshold = score_threshold
+        self._query_generator = query_generator or _default_query_generator()
+        self._track_used = track_used
+        self._tools_used: list[str] = []
+        self._last_selection: list[ToolSpec] = []
+
+    # -- public accessors -------------------------------------------------- #
+    @property
+    def last_selection(self) -> list[ToolSpec]:
+        """The :class:`ToolSpec` list produced by the most recent refresh."""
+        return list(self._last_selection)
+
+    @property
+    def tools_used(self) -> list[str]:
+        """Tool names accumulated across turns (when ``track_used``).
+
+        Returns an empty list when ``track_used`` is disabled. The order is
+        first-seen; each name appears once.
+        """
+        return list(self._tools_used)
+
+    @property
+    def limit(self) -> int:
+        return self._limit
+
+    @property
+    def dialect(self) -> str:
+        return self._dialect
+
+    # -- core refresh ------------------------------------------------------ #
+    async def refresh_specs(self, messages: Iterable[Any] | None) -> list[ToolSpec]:
+        """Re-select tools for the current turn and return ranked specs.
+
+        Derives the retrieval query from ``messages`` via the configured
+        generator (falling back to the last message's text when the generator
+        yields an empty string), honours the accumulated ``tools_already_used``
+        set when ``track_used`` is on, runs a fresh selection, stores it on
+        :attr:`last_selection`, and returns the ranked :class:`ToolSpec` list.
+
+        Args:
+            messages: The conversation so far (most recent message last).
+
+        Returns:
+            Ranked :class:`ToolSpec` handles for this turn (at most ``limit``).
+        """
+        msg_list = list(messages) if messages else []
+
+        if self._track_used:
+            self._accumulate_used(msg_list)
+
+        query = await self._build_query(msg_list)
+        if not query:
+            # Nothing to retrieve against; nothing to surface this turn.
+            self._last_selection = []
+            return []
+
+        specs = await self._toolset.select(
+            query,
+            limit=self._limit,
+            score_threshold=self._score_threshold,
+            tools_already_used=self._tools_used if self._track_used else None,
+        )
+        self._last_selection = specs
+        return specs
+
+    async def refresh(self, messages: Iterable[Any] | None) -> list[dict[str, Any]]:
+        """Re-select tools for the current turn and return dialect schemas.
+
+        Same selection path as :meth:`refresh_specs` (so ``tools_already_used``
+        is honoured), then converts each selected tool to ``self.dialect``
+        schema via the underlying :class:`~agent_gantry.schema.tool.ToolDefinition`.
+
+        Args:
+            messages: The conversation so far (most recent message last).
+
+        Returns:
+            A list of provider-specific tool-schema dicts for this turn.
+        """
+        msg_list = list(messages) if messages else []
+
+        if self._track_used:
+            self._accumulate_used(msg_list)
+
+        query = await self._build_query(msg_list)
+        if not query:
+            self._last_selection = []
+            return []
+
+        # Build the ToolQuery ourselves so tools_already_used (and thus the
+        # router's already_used_penalty) is honoured, then transcode each
+        # ToolDefinition to the requested dialect. We also reconstruct the
+        # ToolSpec list so last_selection / refresh_specs stay consistent.
+        context = ConversationContext(
+            query=query,
+            tools_already_used=(
+                list(self._tools_used) if self._track_used else []
+            ),
+        )
+        result = await self._gantry.retrieve(
+            ToolQuery(
+                context=context,
+                limit=self._limit,
+                score_threshold=self._score_threshold,
+            )
+        )
+
+        from agent_gantry.integrations.frameworks.base import spec_from_tool
+
+        self._last_selection = [
+            spec_from_tool(self._gantry, st.tool, st.semantic_score)
+            for st in result.tools
+        ]
+        return [st.tool.to_dialect(self._dialect) for st in result.tools]
+
+    # -- internals --------------------------------------------------------- #
+    async def _build_query(self, messages: list[Any]) -> str:
+        """Run the query generator, falling back to the last message's text."""
+        result = await _maybe_await(self._query_generator(messages))
+        query = (result or "").strip()
+        if query:
+            return query
+        if messages:
+            return _msg_text(messages[-1])
+        return ""
+
+    def _accumulate_used(self, messages: list[Any]) -> None:
+        """Add tool names from tool/function-role messages to the used set."""
+        seen = set(self._tools_used)
+        for msg in messages:
+            if _msg_role(msg) in ("tool", "function"):
+                name = _msg_tool_name(msg)
+                if name and name not in seen:
+                    seen.add(name)
+                    self._tools_used.append(name)
+
+
+__all__ = ["ToolRefresher"]

--- a/agent_gantry/integrations/refresh.py
+++ b/agent_gantry/integrations/refresh.py
@@ -17,10 +17,12 @@ a fresh top-k selection appropriate to the *latest* sub-task.
 Two behaviours make this genuinely multi-turn / direction-changing:
 
 - **Query follows the conversation tail.** The default query generator is
-  ``fallback_chain(last_tool_result, last_user_text)``, so the next turn's
-  retrieval is driven by the most recent tool result if there is one, else by
-  the most recent user message. When the user pivots (weather → email →
-  currency), the surfaced tools pivot with them.
+  ``fallback_chain(last_user_text, last_tool_result)``, so the next turn's
+  retrieval is driven by the most recent user message (falling back to the
+  latest tool result). When the user pivots (weather → email → currency), the
+  surfaced tools pivot with them. For autonomous tool *pipelines* where the
+  previous tool's output should drive the next selection, pass
+  ``query_generator=fallback_chain(last_tool_result, last_user_text)``.
 - **Used tools nudge the agent forward.** When ``track_used`` is on, every
   tool/function-role message seen in the history accumulates into a
   ``tools_already_used`` set. The router applies its ``already_used_penalty``
@@ -52,14 +54,18 @@ if TYPE_CHECKING:
 
 
 def _default_query_generator() -> Callable[[Iterable[Any] | None], str]:
-    """Recommended default: latest tool result, falling back to user text.
+    """Recommended default: latest user text, falling back to tool result.
 
     Built fresh on each construction so the composed callable is never a
-    shared global. This is the same composition the Agent Framework provider
-    uses for its ``per_call`` mode — the tool result drives the next retrieval
-    when present, otherwise the latest user message does.
+    shared global. User text first makes the *conversational* case (the user
+    pivots to a new sub-task each turn) intuitive: the surfaced tools follow
+    what the user just asked for. For autonomous tool *pipelines* — where the
+    previous tool's output should pick the next tool — pass
+    ``query_generator=fallback_chain(last_tool_result, last_user_text)``
+    explicitly (this is what the Agent Framework provider's ``per_call`` mode
+    uses).
     """
-    return fallback_chain(last_tool_result, last_user_text)
+    return fallback_chain(last_user_text, last_tool_result)
 
 
 def _msg_text(msg: Any) -> str:
@@ -127,9 +133,11 @@ class ToolRefresher:
             similarities, so a non-zero default silently drops relevant tools.
         query_generator: Sync or async callable mapping the messages list to a
             retrieval query string. Defaults to
-            ``fallback_chain(last_tool_result, last_user_text)`` so retrieval is
-            driven by the latest tool result if present, else the latest user
-            text. See :mod:`agent_gantry.query` for built-in alternatives.
+            ``fallback_chain(last_user_text, last_tool_result)`` so retrieval is
+            driven by the latest user message (falling back to the latest tool
+            result) — the intuitive choice for conversational pivots. For tool
+            pipelines, pass ``fallback_chain(last_tool_result, last_user_text)``.
+            See :mod:`agent_gantry.query` for built-in alternatives.
         track_used: When ``True`` (default), scan the messages on every refresh
             for tool/function-role entries and accumulate their tool names into
             the ``tools_already_used`` set passed to selection. The router's

--- a/agent_gantry/query/__init__.py
+++ b/agent_gantry/query/__init__.py
@@ -51,6 +51,7 @@ from agent_gantry.query.strategies import (
     last_assistant_text,
     last_tool_result,
     last_user_text,
+    latest_activity,
     truncated,
 )
 
@@ -61,5 +62,6 @@ __all__ = [
     "last_assistant_text",
     "last_tool_result",
     "last_user_text",
+    "latest_activity",
     "truncated",
 ]

--- a/agent_gantry/query/strategies.py
+++ b/agent_gantry/query/strategies.py
@@ -167,6 +167,54 @@ def last_tool_result(
     return ""
 
 
+def latest_activity(
+    messages: Iterable[Any] | None,
+    *,
+    max_chars: int = 500,
+) -> str:
+    """Return text from the single most recent *activity* message.
+
+    This is the recency-aware generator: it drives retrieval from whatever just
+    happened, regardless of role — so it serves **both** modes of agent
+    operation without a fixed precedence:
+
+    - **Conversational agents.** When the user has just spoken, the newest
+      message is their request, so retrieval follows the new sub-task. (User
+      pivots → tools pivot.)
+    - **Autonomous agents / tool pipelines.** When the agent is chaining tools
+      with no fresh user input, the newest message is the last tool's result,
+      so the *next* tool is selected from what the previous one produced.
+
+    It walks from the end of the conversation and returns the text of the first
+    ``user`` or ``tool``/``function`` message it finds (skipping the empty
+    tool-call stub ``assistant`` messages many frameworks emit). User text is
+    returned verbatim; a tool result is returned as its raw content snippet
+    (capped at ``max_chars``) so the *content* — not the tool's name — drives
+    the next selection. Falls back to the latest assistant text, then empty.
+
+    Args:
+        messages: Conversation history (most recent message last).
+        max_chars: Cap on characters taken from a tool result. Defaults to 500.
+
+    Returns:
+        The driving query text for the current turn, or the empty string.
+    """
+    if not messages:
+        return ""
+    for msg in reversed(list(messages)):
+        role = _msg_role(msg)
+        if role in ("user", ""):
+            text = _msg_text(msg)
+            if text.strip():
+                return text.strip()
+        elif role in ("tool", "function"):
+            text = _msg_text(msg)
+            if text.strip():
+                return text.strip()[:max_chars]
+    # Nothing concrete in the tail — fall back to the model's latest planning.
+    return last_assistant_text(messages)
+
+
 def concatenate_recent(
     messages: Iterable[Any] | None,
     *,

--- a/agent_gantry/schema/introspection.py
+++ b/agent_gantry/schema/introspection.py
@@ -51,10 +51,23 @@ def build_parameters_schema(func: Callable[..., Any]) -> dict[str, Any]:
 
     properties: dict[str, Any] = {}
     required: list[str] = []
+    allow_additional = False
 
     for param_name, param in sig.parameters.items():
         # Skip self and cls parameters
         if param_name in ("self", "cls"):
+            continue
+
+        # *args / **kwargs are not named JSON-Schema properties. Emitting them
+        # as properties (with no default, hence "required") makes the tool
+        # impossible to call with a normal argument dict — e.g. a bare
+        # ``def f(**kwargs)`` would reject ``execute(arguments={})`` with
+        # "Missing required parameter: kwargs". Skip them instead; a
+        # ``**kwargs`` simply means extra keys are allowed.
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            allow_additional = True
+            continue
+        if param.kind is inspect.Parameter.VAR_POSITIONAL:
             continue
 
         param_type = type_hints.get(param_name, str)
@@ -65,11 +78,14 @@ def build_parameters_schema(func: Callable[..., Any]) -> dict[str, Any]:
         if param.default is inspect.Parameter.empty:
             required.append(param_name)
 
-    return {
+    schema: dict[str, Any] = {
         "type": "object",
         "properties": properties,
         "required": required,
     }
+    if allow_additional:
+        schema["additionalProperties"] = True
+    return schema
 
 
 def _type_to_json_schema(param_type: Any) -> dict[str, Any]:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,38 @@
+# Benchmarks
+
+Runnable performance and quality benchmarks for Agent-Gantry.
+
+| Script | Measures |
+|---|---|
+| `benchmark_tool_selection.py` | Semantic selection quality picking **top-3 of 50 tools** — top-1 accuracy, hit@3, MRR, latency p50/p95, token savings. |
+| `benchmark_multi_turn.py` | **Multi-turn re-selection** in a single agent run: select a tool, read its result, pivot to a different tool driven by the new sub-task. |
+| `benchmark_memory_store.py` | `InMemoryVectorStore.search` latency across registry sizes (10–5000 tools). |
+| `benchmark_pgvector.py` | PGVector store add/search throughput (mocked pool). |
+| `benchmark_skills.py` | Anthropic skills client message-build throughput. |
+
+## Running
+
+```bash
+pip install -e .                 # core deps (numpy, pydantic, …)
+pip install sentence-transformers  # for a real embedder (recommended)
+
+python benchmarks/benchmark_tool_selection.py --embedder sentence-transformers --limit 3
+python benchmarks/benchmark_multi_turn.py     --embedder sentence-transformers --limit 3
+python benchmarks/benchmark_memory_store.py
+```
+
+The two selection benchmarks are embedder-agnostic (`--embedder auto|sentence-transformers|nomic|simple`).
+`SimpleEmbedder` is a hash-based toy for offline smoke-runs only — use a real embedder for meaningful
+accuracy numbers.
+
+## Reference results
+
+`sentence-transformers/all-MiniLM-L6-v2`, in-memory store, `score_threshold=0.0`:
+
+- **top-3 of 50:** top-1 0.889, hit@3 1.000, MRR 0.94, p50 ~24ms, token savings ~93%.
+- **multi-turn (7 turns):** gold-in-top3 1.000, 7 distinct tools, pivots every turn.
+- **store search (after NumPy vectorization):** ~0.05ms at 50 tools, ~0.6ms at 1000 tools
+  (≈36–59× faster than the previous pure-Python loop).
+
+See `docs/REVIEW_AGENT_FRAMEWORKS_2026-06-14.md` for the full review and methodology, including the
+`score_threshold=0.5` default that silently drops correct tools if not overridden.

--- a/benchmarks/benchmark_memory_store.py
+++ b/benchmarks/benchmark_memory_store.py
@@ -1,0 +1,64 @@
+"""Micro-benchmark for InMemoryVectorStore.search throughput.
+
+Measures cosine-search latency across registry sizes. The store now computes
+scores with a single cached, NumPy-vectorized matmul (``query · M.T``) instead
+of a per-tool pure-Python dot-product loop. This script reports per-search
+latency so the speedup is visible as the registry grows.
+
+Run::
+
+    python benchmarks/benchmark_memory_store.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+
+from agent_gantry.adapters.vector_stores.memory import InMemoryVectorStore
+from agent_gantry.schema.tool import ToolDefinition
+
+DIM = 384  # all-MiniLM-L6-v2 dimensionality
+
+
+def _rand_vec(d: int) -> list[float]:
+    return [random.gauss(0.0, 1.0) for _ in range(d)]
+
+
+async def bench_size(n: int, searches: int = 200) -> dict[str, float]:
+    store = InMemoryVectorStore(dimension=DIM)
+    tools = [
+        ToolDefinition(
+            name=f"tool_{i}",
+            namespace="bench",
+            description=f"benchmark tool number {i}",
+            parameters_schema={"type": "object", "properties": {}},
+        )
+        for i in range(n)
+    ]
+    embeddings = [_rand_vec(DIM) for _ in range(n)]
+    await store.add_tools(tools, embeddings)
+
+    queries = [_rand_vec(DIM) for _ in range(searches)]
+    # Warm the cached matrix (first search pays the one-time build).
+    await store.search(queries[0], limit=3)
+
+    t0 = time.perf_counter()
+    for q in queries:
+        await store.search(q, limit=3)
+    elapsed = time.perf_counter() - t0
+    per_search_ms = (elapsed / searches) * 1000.0
+    return {"n": n, "searches": searches, "per_search_ms": round(per_search_ms, 4)}
+
+
+async def main() -> None:
+    print(f"InMemoryVectorStore.search latency (dim={DIM})\n")
+    print(f"{'tools':>8} {'searches':>9} {'per_search_ms':>14}")
+    for n in (10, 50, 100, 500, 1000, 5000):
+        r = await bench_size(n)
+        print(f"{r['n']:>8} {r['searches']:>9} {r['per_search_ms']:>14}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/benchmarks/benchmark_multi_turn.py
+++ b/benchmarks/benchmark_multi_turn.py
@@ -1,0 +1,171 @@
+"""Multi-turn semantic tool selection within a single agent run.
+
+This benchmark proves the property the README calls "per-call retrieval": in
+*one* agent run the registry is queried fresh on every turn, so the agent can
+pick a tool, read its result, then **change direction** and pick a completely
+different tool driven purely by the semantics of the new sub-task — not by a
+fixed, pre-bound tool list.
+
+It simulates the agent loop directly against the public Gantry API:
+
+    for each turn:
+        query  = query_generator(conversation_so_far)   # per-call
+        tools  = gantry.retrieve_tools(query, limit=3)   # re-rank the WHOLE registry
+        pick   = first tool the (simulated) model chooses
+        result = gantry.execute(ToolCall(pick, args))    # real execution
+        append (assistant call, tool result) to conversation
+
+The registry is 50 tools (imported from ``benchmark_tool_selection``). Each
+turn asserts (a) the gold tool is surfaced in the top-3, and (b) it differs
+from the previous turn's pick — i.e. the selection genuinely pivots.
+
+Run::
+
+    python benchmarks/benchmark_multi_turn.py
+    python benchmarks/benchmark_multi_turn.py --embedder simple
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from typing import Any
+
+from agent_gantry import AgentGantry
+from agent_gantry.query.strategies import fallback_chain, last_tool_result, last_user_text
+from agent_gantry.schema.execution import ToolCall
+from agent_gantry.schema.query import ConversationContext, ToolQuery
+
+from benchmark_tool_selection import TOOLS, _make_tool, build_embedder
+
+
+# A single "agent run": an ordered list of (user utterance, expected tool).
+# Note how the direction lurches across domains turn to turn — weather, then
+# travel, then comms, then finance, then data — to stress re-selection.
+CONVERSATION: list[tuple[str, str]] = [
+    ("What's the weather in San Francisco today?", "get_current_weather"),
+    ("Great, now find me flights from London to San Francisco.", "search_flights"),
+    ("Book a hotel there for two nights.", "book_hotel"),
+    ("Email the trip details to my travel buddy.", "send_email"),
+    ("Convert the 450 dollar hotel rate into euros.", "convert_currency"),
+    ("Add 'pack passport' to my todo list.", "create_todo"),
+    ("Now summarise the cancellation policy text I pasted.", "summarize_text"),
+]
+
+
+def _model_picks_first(tool_schemas: list[dict[str, Any]]) -> str | None:
+    """Stand-in for the LLM's tool choice: take the top-ranked tool."""
+    if not tool_schemas:
+        return None
+    return tool_schemas[0]["function"]["name"]
+
+
+async def run(embedder_kind: str, limit: int) -> dict[str, Any]:
+    embedder, label = build_embedder(embedder_kind)
+    print(f"Embedder: {label}\n")
+    gantry = AgentGantry(embedder=embedder)
+    for name, desc, tags in TOOLS:
+        gantry.register(_make_tool(name, desc), tags=tags)
+    await gantry.sync()
+
+    # Per-call query generator: prefer the latest tool result (to detect when
+    # the conversation has moved on), else fall back to the latest user text.
+    query_gen = fallback_chain(last_user_text, last_tool_result)
+
+    messages: list[dict[str, Any]] = []
+    tools_used: list[str] = []
+    prev_pick: str | None = None
+
+    correct = 0
+    pivots = 0
+    surfaced = 0
+
+    for turn, (utterance, gold) in enumerate(CONVERSATION, start=1):
+        messages.append({"role": "user", "content": utterance})
+
+        # 1. PER-CALL retrieval over the ENTIRE 50-tool registry, re-ranked
+        #    fresh for this turn. tools_already_used lets the router gently
+        #    deprioritise repeats so the agent keeps moving forward.
+        derived_query = query_gen(messages) or utterance
+        result = await gantry.retrieve(
+            ToolQuery(
+                context=ConversationContext(
+                    query=derived_query,
+                    recent_messages=[
+                        {"role": str(m.get("role", "")), "content": str(m.get("content", ""))}
+                        for m in messages[-4:]
+                    ],
+                    tools_already_used=list(tools_used),
+                ),
+                limit=limit,
+                score_threshold=0.0,
+            )
+        )
+        ranked = [st.tool.name for st in result.tools]
+        schemas = await gantry.retrieve_tools(derived_query, limit=limit, score_threshold=0.0)
+
+        # 2. Simulated model picks the top tool.
+        pick = _model_picks_first(schemas)
+
+        # 3. Execute it for real (closing the select -> act loop).
+        exec_result = None
+        if pick is not None:
+            call = await gantry.execute(ToolCall(tool_name=pick, arguments={}))
+            exec_result = call.result if str(call.status).endswith("success") else call.error
+            messages.append({"role": "assistant", "content": f"calling {pick}"})
+            messages.append(
+                {"role": "tool", "name": pick, "content": str(exec_result)}
+            )
+            tools_used.append(pick)
+
+        in_top = gold in ranked
+        is_pivot = pick != prev_pick
+        surfaced += int(in_top)
+        correct += int(pick == gold)
+        pivots += int(is_pivot)
+
+        flag = "✅" if pick == gold else ("◐" if in_top else "❌")
+        pivot_mark = "↪ pivot" if is_pivot else "  (same)"
+        print(
+            f"turn {turn} {flag} {pivot_mark}  said={utterance[:42]!r:<44}\n"
+            f"         picked={pick!r:<22} gold={gold!r:<22} top{limit}={ranked}"
+        )
+        prev_pick = pick
+
+    n = len(CONVERSATION)
+    summary = {
+        "embedder": label,
+        "registry_size": len(TOOLS),
+        "turns": n,
+        "limit": limit,
+        "pick_accuracy": round(correct / n, 3),
+        f"gold_in_top{limit}": round(surfaced / n, 3),
+        "distinct_pivots": pivots,
+        "distinct_tools_used": len(set(tools_used)),
+        "selection_pivoted_every_turn": pivots == n,
+    }
+    print("\n=== MULTI-TURN SUMMARY ===")
+    print(json.dumps(summary, indent=2))
+    print(
+        "\nInterpretation: a high 'distinct_tools_used' with 'pivoted_every_turn'"
+        "\nmeans the agent re-selected a *different* tool each turn purely from the"
+        "\nsemantics of the new sub-task — multi-turn re-selection within one run."
+    )
+    return summary
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=3)
+    ap.add_argument(
+        "--embedder",
+        default="auto",
+        choices=["auto", "sentence-transformers", "nomic", "simple"],
+    )
+    args = ap.parse_args()
+    asyncio.run(run(args.embedder, args.limit))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_tool_selection.py
+++ b/benchmarks/benchmark_tool_selection.py
@@ -1,0 +1,275 @@
+"""Semantic tool-selection benchmark: pick the best top-3 tools out of 50.
+
+This benchmark measures how well Agent-Gantry's semantic router surfaces the
+*right* tools when the registry is large (50 tools) and only a small slice
+(top-3) is injected into the prompt. It reports retrieval-quality metrics and
+latency, plus the context-window saving versus dumping all 50 schemas.
+
+Metrics
+-------
+- ``top1``      : fraction of queries whose single best tool ranked #1.
+- ``hit@3``     : fraction of queries whose best tool appeared in the top-3.
+- ``MRR``       : mean reciprocal rank of the gold tool (1.0 == always #1).
+- ``p50/p95``   : retrieval latency percentiles (ms), embedding excluded/
+                  included depending on cache warmth — see notes printed.
+- ``token_savings`` : prompt-token reduction of top-3 vs. all-50 schemas.
+
+The benchmark is embedder-agnostic. It uses the strongest embedder available
+in the environment (SentenceTransformers / Nomic), falling back to the
+hash-based ``SimpleEmbedder`` (a toy — accuracy will be low, the harness still
+runs). Pass ``--embedder`` to force one.
+
+Run::
+
+    python benchmarks/benchmark_tool_selection.py
+    python benchmarks/benchmark_tool_selection.py --embedder sentence-transformers --limit 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import time
+from collections.abc import Callable
+from typing import Any
+
+from agent_gantry import AgentGantry
+
+
+# --------------------------------------------------------------------------- #
+# 50-tool registry across 10 domains. Each entry: (name, description, tags).
+# --------------------------------------------------------------------------- #
+TOOLS: list[tuple[str, str, list[str]]] = [
+    # --- weather ---
+    ("get_current_weather", "Get the current temperature and conditions for a city.", ["weather"]),
+    ("get_weather_forecast", "Get a multi-day weather forecast for a location.", ["weather"]),
+    ("get_air_quality", "Get the air quality index and pollutant levels for a city.", ["weather", "environment"]),
+    ("get_uv_index", "Get the current ultraviolet radiation index for a location.", ["weather"]),
+    ("get_marine_forecast", "Get sea state, wave height and tide times for a coastal area.", ["weather", "marine"]),
+    # --- finance ---
+    ("get_stock_price", "Look up the latest share price for a stock ticker symbol.", ["finance"]),
+    ("convert_currency", "Convert an amount of money from one currency to another.", ["finance"]),
+    ("calculate_sales_tax", "Calculate sales tax owed on a purchase amount.", ["finance", "tax"]),
+    ("get_crypto_price", "Get the current market price of a cryptocurrency.", ["finance", "crypto"]),
+    ("compute_loan_payment", "Compute the monthly payment for a loan given rate and term.", ["finance"]),
+    # --- email / messaging ---
+    ("send_email", "Compose and send an email message to a recipient.", ["email", "communication"]),
+    ("search_inbox", "Search the user's email inbox for matching messages.", ["email"]),
+    ("send_slack_message", "Post a message to a Slack channel or user.", ["chat", "communication"]),
+    ("schedule_meeting", "Create a calendar invite and schedule a meeting.", ["calendar", "communication"]),
+    ("send_sms", "Send a text message to a phone number.", ["sms", "communication"]),
+    # --- files / storage ---
+    ("read_file", "Read the contents of a file from local disk.", ["files", "io"]),
+    ("write_file", "Write text content to a file on local disk.", ["files", "io"]),
+    ("list_directory", "List the files and folders inside a directory.", ["files", "io"]),
+    ("upload_to_s3", "Upload a file to an Amazon S3 bucket.", ["files", "cloud"]),
+    ("compress_folder", "Create a zip archive from a folder of files.", ["files"]),
+    # --- database ---
+    ("run_sql_query", "Execute a read-only SQL query against the database.", ["database", "sql"]),
+    ("insert_record", "Insert a new row into a database table.", ["database", "sql"]),
+    ("delete_record", "Delete a row from a database table by id.", ["database", "sql"]),
+    ("backup_database", "Create a full backup snapshot of the database.", ["database"]),
+    ("get_table_schema", "Describe the columns and types of a database table.", ["database", "sql"]),
+    # --- web / search ---
+    ("web_search", "Search the public web for information on a topic.", ["web", "search"]),
+    ("fetch_url", "Download the raw HTML or text content of a web page.", ["web"]),
+    ("translate_text", "Translate text from one natural language to another.", ["nlp", "language"]),
+    ("summarize_text", "Produce a short summary of a long passage of text.", ["nlp"]),
+    ("extract_entities", "Extract named entities (people, places, orgs) from text.", ["nlp"]),
+    # --- maps / travel ---
+    ("get_directions", "Get driving directions between two addresses.", ["maps", "travel"]),
+    ("find_nearby_restaurants", "Find restaurants near a given location.", ["maps", "food"]),
+    ("geocode_address", "Convert a street address into latitude/longitude.", ["maps"]),
+    ("search_flights", "Search for available flights between two airports.", ["travel"]),
+    ("book_hotel", "Reserve a hotel room for a set of dates.", ["travel"]),
+    # --- math / data ---
+    ("calculate_statistics", "Compute mean, median and standard deviation of numbers.", ["math", "data"]),
+    ("solve_equation", "Solve an algebraic equation for its variable.", ["math"]),
+    ("plot_chart", "Render a chart image from a series of data points.", ["data", "viz"]),
+    ("factorial", "Compute the factorial of a non-negative integer.", ["math"]),
+    ("linear_regression", "Fit a linear regression model to x/y data points.", ["math", "data", "ml"]),
+    # --- devops ---
+    ("deploy_service", "Deploy an application service to the cluster.", ["devops"]),
+    ("get_pod_logs", "Fetch recent log lines from a Kubernetes pod.", ["devops", "logs"]),
+    ("restart_container", "Restart a running Docker container by name.", ["devops"]),
+    ("scale_deployment", "Change the replica count of a deployment.", ["devops"]),
+    ("get_cpu_metrics", "Get current CPU utilisation metrics for a host.", ["devops", "monitoring"]),
+    # --- calendar / productivity ---
+    ("create_todo", "Add a task to the user's to-do list.", ["productivity"]),
+    ("set_reminder", "Set a timed reminder for the user.", ["productivity"]),
+    ("get_calendar_events", "List upcoming events on the user's calendar.", ["calendar"]),
+    ("create_note", "Save a free-text note for later retrieval.", ["productivity"]),
+    ("start_timer", "Start a countdown timer for a number of minutes.", ["productivity"]),
+]
+
+# Labeled queries: (natural-language query, gold tool name).
+QUERIES: list[tuple[str, str]] = [
+    ("What's the temperature in Paris right now?", "get_current_weather"),
+    ("Will it rain in Tokyo over the next five days?", "get_weather_forecast"),
+    ("Is the air safe to breathe in Delhi today?", "get_air_quality"),
+    ("How much is one bitcoin worth?", "get_crypto_price"),
+    ("Convert 100 dollars into euros", "convert_currency"),
+    ("What is Apple's share price?", "get_stock_price"),
+    ("Work out the monthly repayment on a 20000 loan", "compute_loan_payment"),
+    ("Email the report to my manager", "send_email"),
+    ("Find the message from accounting in my mailbox", "search_inbox"),
+    ("Drop a note in the engineering channel on Slack", "send_slack_message"),
+    ("Text John that I'm running late", "send_sms"),
+    ("Set up a 30 minute call with the design team tomorrow", "schedule_meeting"),
+    ("Save this text to a file on disk", "write_file"),
+    ("Show me everything in the downloads folder", "list_directory"),
+    ("Push this document up to our S3 bucket", "upload_to_s3"),
+    ("Zip up the project folder", "compress_folder"),
+    ("Run a query to count active users in the database", "run_sql_query"),
+    ("Add a new customer row to the table", "insert_record"),
+    ("Take a full backup of the database", "backup_database"),
+    ("Search the internet for news about AI regulation", "web_search"),
+    ("Translate this paragraph into Spanish", "translate_text"),
+    ("Give me a short summary of this article", "summarize_text"),
+    ("How do I drive from the airport to downtown?", "get_directions"),
+    ("Find me somewhere to eat near the hotel", "find_nearby_restaurants"),
+    ("Look for flights from London to New York", "search_flights"),
+    ("Book a room for two nights in Berlin", "book_hotel"),
+    ("Compute the average and standard deviation of these numbers", "calculate_statistics"),
+    ("Draw a line chart of monthly sales", "plot_chart"),
+    ("Fit a regression line to this data", "linear_regression"),
+    ("Deploy the payments service to production", "deploy_service"),
+    ("Show me the recent logs from the api pod", "get_pod_logs"),
+    ("Restart the redis container", "restart_container"),
+    ("How busy is the CPU on web-01?", "get_cpu_metrics"),
+    ("Remind me to call the dentist at 3pm", "set_reminder"),
+    ("Add 'buy milk' to my todo list", "create_todo"),
+    ("What's on my calendar this afternoon?", "get_calendar_events"),
+]
+
+
+def _make_tool(name: str, description: str) -> Callable[..., str]:
+    # NOTE: an explicit *optional* parameter is used deliberately. Registering a
+    # bare ``**kwargs`` function makes the schema builder emit ``kwargs`` as a
+    # *required* property, so ``execute(arguments={})`` fails validation with
+    # "Missing required parameter: kwargs" (see review finding).
+    def fn(arg: str = "") -> str:
+        return f"called {name}({arg})"
+
+    fn.__name__ = name
+    fn.__doc__ = description
+    return fn
+
+
+def build_embedder(kind: str):
+    """Return (embedder, label). ``kind`` == 'auto' tries best-available."""
+    order = (
+        [kind]
+        if kind != "auto"
+        else ["sentence-transformers", "nomic", "simple"]
+    )
+    for k in order:
+        try:
+            if k == "sentence-transformers":
+                from agent_gantry.adapters.embedders.sentence_transformers import (
+                    SentenceTransformersEmbedder,
+                )
+
+                return SentenceTransformersEmbedder("all-MiniLM-L6-v2"), "sentence-transformers/all-MiniLM-L6-v2"
+            if k == "nomic":
+                from agent_gantry.adapters.embedders.nomic import NomicEmbedder
+
+                return NomicEmbedder(), "nomic-embed-text-v1.5"
+            if k == "simple":
+                from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+                return SimpleEmbedder(dimension=256), "SimpleEmbedder(hash, toy)"
+        except Exception as exc:  # noqa: BLE001
+            print(f"  embedder {k!r} unavailable: {exc}")
+            continue
+    raise RuntimeError("no embedder available")
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    idx = min(len(s) - 1, int(round((pct / 100.0) * (len(s) - 1))))
+    return s[idx]
+
+
+async def run(limit: int, embedder_kind: str) -> dict[str, Any]:
+    embedder, label = build_embedder(embedder_kind)
+    print(f"Embedder: {label}")
+    gantry = AgentGantry(embedder=embedder)
+
+    for name, desc, tags in TOOLS:
+        gantry.register(_make_tool(name, desc), tags=tags)
+
+    t0 = time.perf_counter()
+    count = await gantry.sync()
+    sync_s = time.perf_counter() - t0
+    print(f"Registered + embedded {count} tools in {sync_s:.2f}s\n")
+
+    top1 = 0
+    hit_at_k = 0
+    reciprocal_ranks: list[float] = []
+    latencies_ms: list[float] = []
+
+    for query, gold in QUERIES:
+        t = time.perf_counter()
+        # score_threshold=0.0 measures pure ranking quality. NOTE: the library
+        # default is 0.5, which silently drops correct tools with any embedder
+        # whose cosine scores sit below 0.5 (e.g. MiniLM) — see review finding.
+        tools = await gantry.retrieve_tools(query, limit=limit, score_threshold=0.0)
+        latencies_ms.append((time.perf_counter() - t) * 1000.0)
+
+        names = [t["function"]["name"] for t in tools]
+        rank = names.index(gold) + 1 if gold in names else 0
+        if rank == 1:
+            top1 += 1
+        if rank != 0:
+            hit_at_k += 1
+            reciprocal_ranks.append(1.0 / rank)
+        else:
+            reciprocal_ranks.append(0.0)
+
+        flag = "✅" if gold in names else "❌"
+        print(f"{flag} q={query[:46]!r:<48} gold={gold:<24} top{limit}={names}")
+
+    n = len(QUERIES)
+    # Token-savings estimate: full 50-tool schema dump vs. top-3.
+    all_schemas = await gantry.retrieve_tools(QUERIES[0][0], limit=len(TOOLS), score_threshold=0.0)
+    full_tokens = len(json.dumps(all_schemas)) // 4  # ~4 chars/token heuristic
+    topk_schemas = await gantry.retrieve_tools(QUERIES[0][0], limit=limit, score_threshold=0.0)
+    topk_tokens = len(json.dumps(topk_schemas)) // 4
+    savings = 1.0 - (topk_tokens / full_tokens) if full_tokens else 0.0
+
+    results = {
+        "embedder": label,
+        "tools": len(TOOLS),
+        "queries": n,
+        "limit": limit,
+        "top1_accuracy": round(top1 / n, 3),
+        f"hit@{limit}": round(hit_at_k / n, 3),
+        "mrr": round(sum(reciprocal_ranks) / n, 3),
+        "latency_ms_p50": round(_percentile(latencies_ms, 50), 2),
+        "latency_ms_p95": round(_percentile(latencies_ms, 95), 2),
+        "latency_ms_mean": round(sum(latencies_ms) / len(latencies_ms), 2),
+        "token_savings_topk_vs_all": round(savings, 3),
+    }
+    print("\n=== RESULTS ===")
+    print(json.dumps(results, indent=2))
+    return results
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=3, help="top-K tools to retrieve")
+    ap.add_argument(
+        "--embedder",
+        default="auto",
+        choices=["auto", "sentence-transformers", "nomic", "simple"],
+    )
+    args = ap.parse_args()
+    asyncio.run(run(args.limit, args.embedder))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_tool_selection.py
+++ b/benchmarks/benchmark_tool_selection.py
@@ -145,10 +145,10 @@ QUERIES: list[tuple[str, str]] = [
 
 
 def _make_tool(name: str, description: str) -> Callable[..., str]:
-    # NOTE: an explicit *optional* parameter is used deliberately. Registering a
-    # bare ``**kwargs`` function makes the schema builder emit ``kwargs`` as a
-    # *required* property, so ``execute(arguments={})`` fails validation with
-    # "Missing required parameter: kwargs" (see review finding).
+    # A simple optional parameter keeps the benchmark tools trivially callable.
+    # (Bare ``**kwargs`` tools are also fully supported — the schema builder now
+    # skips variadic params and sets ``additionalProperties: true`` — but an
+    # explicit arg keeps these example tools self-documenting.)
     def fn(arg: str = "") -> str:
         return f"called {name}({arg})"
 

--- a/docs/REVIEW_AGENT_FRAMEWORKS_2026-06-14.md
+++ b/docs/REVIEW_AGENT_FRAMEWORKS_2026-06-14.md
@@ -222,9 +222,17 @@ All gaps from the review above were implemented on this branch:
   through `gantry.execute`. `ToolSpec.invoke()` is safe inside a running event
   loop (runs on a worker thread), so sync framework callbacks (CrewAI `_run`,
   Smolagents `forward`, …) work in real async agent loops.
-- **P2 multi-turn everywhere:** `agent_gantry/integrations/refresh.py`
-  (`ToolRefresher`) generalizes per-call re-retrieval to any framework, honoring
-  `tools_already_used` so the agent pivots forward across turns.
+- **P2 multi-turn everywhere (autonomous *and* conversational):**
+  `agent_gantry/integrations/refresh.py` (`ToolRefresher`) generalizes per-call
+  re-retrieval to any framework, honoring `tools_already_used` so the agent
+  pivots forward across turns. Its default query generator
+  (`agent_gantry.query.latest_activity`) is **recency-aware**: when the newest
+  message is a tool result (autonomous pipeline with no new user input) that
+  result drives the next selection; when it's a user message (conversational)
+  the user's request drives it. One refresher, both modes, no config — verified
+  end-to-end in `examples/frameworks/verify_all.py`
+  (`fetch→clean→train→evaluate→report` autonomously; `weather→email→currency`
+  conversationally).
 - **Tests:** per-framework adapter tests + a cross-framework conformance matrix
   (`tests/frameworks/`) and `tests/test_refresh.py`, all using stubbed frameworks
   so they run without the third-party packages installed.

--- a/docs/REVIEW_AGENT_FRAMEWORKS_2026-06-14.md
+++ b/docs/REVIEW_AGENT_FRAMEWORKS_2026-06-14.md
@@ -197,11 +197,34 @@ sub-task — not by a fixed pre-bound tool list. The enabling machinery:
 |---|---|
 | Microsoft Agent Framework | ✅ Production-grade, multi-turn native |
 | Generic LLM SDKs (OpenAI/Anthropic/Gemini/…) | ✅ Solid via decorator + dialect transcoding |
-| LangChain/LlamaIndex/CrewAI/etc. | ⚠️ Schema-only; needs native tool-object adapters |
-| OpenAI Agents SDK / Pydantic AI / Smolagents / Haystack / Agno | ❌ Not yet supported |
+| LangChain / LangGraph / LlamaIndex / CrewAI | ✅ Native tool-object adapters (`integrations/frameworks/`) |
+| OpenAI Agents SDK / Pydantic AI / Smolagents / Haystack / Agno / AutoGen | ✅ Native adapters added |
 | Top-3-of-50 selection quality | ✅ 100% hit@3, 0.94 MRR (MiniLM) — once threshold trap avoided |
-| Multi-turn pivot in one run | ✅ Demonstrated, 7/7 distinct tools |
+| Multi-turn pivot in one run | ✅ Demonstrated, 7/7 distinct tools; `ToolRefresher` for any framework |
 | In-memory search performance | ✅ 36–59× faster (vectorized) |
-| `score_threshold=0.5` default | ❌ Silently drops correct tools — fix recommended |
-| `**kwargs` tools | ❌ Become un-executable — fix recommended |
-| Dynamic MCP server selection | ⚠️ Preview/placeholder |
+| `score_threshold=0.5` default | ✅ Fixed — convenience APIs default to 0.0 |
+| `**kwargs` tools | ✅ Fixed — `*args`/`**kwargs` no longer emitted as required |
+| Dynamic MCP server selection | ✅ Functional (facade registers discovered tools); README note was stale |
+
+## Gap-closure addendum (implemented)
+
+All gaps from the review above were implemented on this branch:
+
+- **P0 correctness:** `*args`/`**kwargs` are no longer emitted as required schema
+  properties (`schema/introspection.py`); `**kwargs` now sets
+  `additionalProperties: true`. `retrieve_tools` / `search_and_execute` /
+  `fetch_framework_tools` default `score_threshold=0.0`.
+- **P1 native adapters:** new `agent_gantry/integrations/frameworks/` subpackage
+  with a shared `GantryToolset` + `ToolSpec` base and one module per framework —
+  LangChain, LangGraph, LlamaIndex, CrewAI, Pydantic AI, OpenAI Agents SDK,
+  Smolagents, Haystack, Agno, AutoGen. Each exposes `for_<fw>()` /
+  `spec_to_<fw>()`, lazily imports its framework, and routes every invocation
+  through `gantry.execute`. `ToolSpec.invoke()` is safe inside a running event
+  loop (runs on a worker thread), so sync framework callbacks (CrewAI `_run`,
+  Smolagents `forward`, …) work in real async agent loops.
+- **P2 multi-turn everywhere:** `agent_gantry/integrations/refresh.py`
+  (`ToolRefresher`) generalizes per-call re-retrieval to any framework, honoring
+  `tools_already_used` so the agent pivots forward across turns.
+- **Tests:** per-framework adapter tests + a cross-framework conformance matrix
+  (`tests/frameworks/`) and `tests/test_refresh.py`, all using stubbed frameworks
+  so they run without the third-party packages installed.

--- a/docs/REVIEW_AGENT_FRAMEWORKS_2026-06-14.md
+++ b/docs/REVIEW_AGENT_FRAMEWORKS_2026-06-14.md
@@ -1,0 +1,207 @@
+# Agent-Gantry — Agent-Framework Functionality & Performance Review
+
+*Date: 2026-06-14 · Scope: framework compatibility, semantic tool selection quality,
+performance, and multi-turn re-selection · All numbers below were measured in this
+repo with `sentence-transformers/all-MiniLM-L6-v2` unless noted.*
+
+This review answers five questions:
+
+1. Current status of functionality with agent frameworks.
+2. What it takes to be *fully* functional with every agent framework.
+3. Performance improvements (one is implemented and measured here).
+4. Benchmark of semantic tool selection — top-3 out of 50 tools.
+5. Multi-turn tool selection within a single agent run (pivot to a different tool).
+
+Two reusable benchmarks and one performance fix were added as part of this review:
+
+- `benchmarks/benchmark_tool_selection.py` — top-3-of-50 retrieval quality + latency.
+- `benchmarks/benchmark_multi_turn.py` — direction-changing selection within one run.
+- `benchmarks/benchmark_memory_store.py` — store search latency (before/after the fix).
+- `agent_gantry/adapters/vector_stores/memory.py` — NumPy-vectorized cosine search.
+
+---
+
+## 1. Current status with agent frameworks
+
+| Framework | Integration depth | Multi-turn / per-call | Where |
+|---|---|---|---|
+| **Microsoft Agent Framework** | **Native, deep** — `ContextProvider`, middleware, bridge, workflow builders | ✅ `query_strategy="per_call"` + chat middleware | `integrations/agent_framework_provider.py`, `_bridge.py`, `_middleware.py` |
+| **Anthropic (Claude)** | Dedicated clients: auto-retrieve tools, thinking modes, skills | ✅ per `create_message` | `integrations/anthropic_features.py`, `anthropic_skills.py` |
+| **Any LLM SDK** (OpenAI, Azure, Groq, Mistral, OpenRouter, Gemini) | `@with_semantic_tools` decorator with dialect transcoding (`openai`/`anthropic`/`gemini`) | ✅ retrieval re-runs per decorated call | `integrations/semantic_tools.py` |
+| **LangChain, LangGraph, AutoGen, CrewAI, LlamaIndex, Semantic Kernel, Google ADK, Strands** | **Shallow** — `fetch_framework_tools()` emits OpenAI-style *schemas*; binding to native tool objects is left to example code | ⚠️ Only if you re-call retrieval yourself each turn | `integrations/framework_adapters.py` + `examples/agent_frameworks/*` |
+| **OpenAI Agents SDK, Pydantic AI, Haystack, Smolagents, DSPy, Agno/Phidata** | **None** — no adapter, no example | ❌ | — |
+
+**Key observations**
+
+- The *only* deep, "drop-in" integration is **Microsoft Agent Framework**. It is genuinely
+  first-class: per-run and per-call retrieval, `last_selection` introspection, `dry_run_retrieve`,
+  workflow/handoff/sequential flow-through, and security/observability middleware.
+- `framework_adapters.fetch_framework_tools()` (`framework_adapters.py:35`) validates the framework
+  name then, for every non-AF framework, returns the **same** `result.to_openai_tools()` shape. It is
+  a schema emitter, not an integration — the user still has to wrap those schemas into LangChain
+  `StructuredTool` / LlamaIndex `FunctionTool` / CrewAI `BaseTool` and re-call it each turn manually.
+- **Dynamic MCP server selection** is explicitly a **preview/placeholder** (README L621-624); the
+  semantic-search-over-servers path is not fully implemented.
+
+**Two correctness traps found while benchmarking** (both reproduce in the repo's own tests):
+
+1. **`score_threshold` default is `0.5` and silently drops correct tools.**
+   `ToolQuery.score_threshold` defaults to `0.5` (`schema/query.py`), and `retrieve_tools()`
+   (`gantry.py:893`) and `fetch_framework_tools()` (`framework_adapters.py:41`) inherit it — while the
+   documented `GantryContextProvider` default is `0.0`. With any real-but-modest embedder (MiniLM
+   cosine scores sit ~0.2–0.45), the default filters out the right tool. Measured impact below:
+   the **same** benchmark scores **30.6%** hit@3 at threshold 0.5 vs **100%** at 0.0.
+2. **A `**kwargs`-only tool becomes un-executable.** Registering `def f(**kwargs)` makes the schema
+   builder emit `kwargs` as a *required* property, so `execute(arguments={})` fails with
+   `ValidationError: Missing required parameter: kwargs`.
+
+---
+
+## 2. Making it fully functional with every framework
+
+Priority-ordered, concrete work:
+
+**P0 — fix the traps that already break shipped paths**
+- Make `0.0` the default `score_threshold` for `retrieve_tools()` / `fetch_framework_tools()` (or at
+  least clamp-warn when a non-Simple embedder returns an empty set purely due to threshold). This is
+  the single highest-leverage change — it currently makes large registries look broken.
+- Treat `**kwargs` / `**VAR_KEYWORD` params as optional (not required) in the schema builder.
+
+**P1 — turn the shallow adapters into real ones.** Each framework needs a *native tool object* exporter
+plus a *refresh hook*, mirroring the AF provider. Suggested shape:
+
+```python
+# A universal exporter protocol, one thin module per framework.
+class GantryToolset:
+    async def for_langchain(self, query, *, limit=3) -> list[StructuredTool]: ...
+    async def for_llamaindex(self, query, *, limit=3) -> list[FunctionTool]: ...
+    async def for_crewai(self, query, *, limit=3) -> list[BaseTool]: ...
+    async def for_pydantic_ai(self, query, *, limit=3) -> list[Tool]: ...
+    async def for_openai_agents(self, query, *, limit=3) -> list[FunctionTool]: ...
+    async def for_smolagents(self, query, *, limit=3) -> list[Tool]: ...
+```
+
+Each wrapper closes over `gantry.execute(ToolCall(...))` and carries the JSON-schema so the host
+framework can call it. This is the missing piece for OpenAI Agents SDK, Pydantic AI, Smolagents,
+Haystack, and Agno.
+
+**P2 — make multi-turn first-class everywhere, not just AF.** The per-call machinery already exists
+generically (`query/strategies.py`: `last_tool_result`, `fallback_chain`, `keyword_focused`, plus the
+router's `tools_already_used` penalty). Expose a framework-agnostic `refresh(messages)` callback so
+LangGraph/CrewAI/etc. can re-rank on every step the way the AF middleware does.
+
+**P3 — finish dynamic MCP server selection** (currently placeholder) and add a **conformance test
+matrix**: one parametrized test per framework that registers 10 tools, runs a 3-turn pivot, and
+asserts the right tool is bound each turn. That converts "we have an example" into "we guarantee it".
+
+---
+
+## 3. Performance improvements
+
+### Implemented and measured here: vectorized in-memory search
+
+`InMemoryVectorStore.search()` computed cosine similarity in a **pure-Python loop**, one dot-product
+per tool, over list-typed embeddings (`memory.py`, old `_cosine_similarity`). It now builds a cached,
+L2-normalized `(n, d)` NumPy matrix and scores the whole registry with a single matmul
+(`query · M.T`). The cache invalidates on `add_tools`/`delete` and rebuilds lazily on the next search.
+NumPy is already a core dependency, so this adds no new requirement.
+
+`benchmarks/benchmark_memory_store.py`, dim=384, 200 searches each:
+
+| Tools | Before (ms/search) | After (ms/search) | Speedup |
+|------:|-------------------:|------------------:|--------:|
+| 10    | 0.350 | 0.030 | ~12× |
+| 50    | 1.705 | 0.047 | **~36×** |
+| 100   | 3.414 | 0.070 | ~48× |
+| 500   | 17.07 | 0.301 | ~57× |
+| 1000  | 35.10 | 0.599 | ~59× |
+| 5000  | 181.9 | 5.15  | ~35× |
+
+At the review's headline scenario (50 tools) search drops from **1.7ms to 0.05ms**. The full targeted
+test suite (router/retrieval/vector/memory/performance) stays green; the change is behavior-preserving.
+
+### Further opportunities (not yet implemented)
+
+- **Vectorize the router's signal scoring.** The router over-fetches `limit*4` candidates
+  (`router.py:267`) and then computes `RoutingSignals` per candidate in Python. With the matrix already
+  built, the semantic component and penalties can be computed array-wise.
+- **Cache the query embedding within a single run.** In a multi-step agent loop the same derived query
+  is often embedded repeatedly; memoize per turn.
+- **Default-on `CachedEmbedder` for paid embedders** to kill cold-start re-embedding cost (the class
+  exists; it is opt-in today).
+- **Optional ANN index (hnswlib/FAISS) for the in-memory store** beyond ~10k tools — though the
+  vectorized brute force is already sub-6ms at 5k, so this is low priority.
+
+---
+
+## 4. Benchmark — best top-3 out of 50 tools
+
+`benchmarks/benchmark_tool_selection.py`: 50 tools across 10 domains (weather, finance, email/messaging,
+files, database, web/NLP, maps/travel, math/data, devops, productivity), 36 labeled natural-language
+queries, retrieve **top-3**, embedder `all-MiniLM-L6-v2`, in-memory store.
+
+```
+top1_accuracy ............. 0.889   (32/36 ranked the gold tool #1)
+hit@3 ..................... 1.000   (gold tool in top-3 on every query)
+MRR ....................... 0.940
+latency p50 / p95 (ms) .... 23.6 / 25.8   (includes query embedding + search)
+token_savings (top3 vs 50)  0.934   (~93% fewer tool-schema tokens)
+```
+
+Notes:
+- With the library's **default** `score_threshold=0.5`, the identical run collapses to **30.6%** hit@3 —
+  this is the threshold trap from §1, and the reason the benchmark passes `score_threshold=0.0`.
+- `SimpleEmbedder` is a hash-based **toy** (its own docstring says so); it is unsuitable for real
+  routing and should never be the production default. The benchmark auto-selects the best available
+  embedder and falls back to Simple only so the harness still runs offline.
+
+---
+
+## 5. Multi-turn tool selection within one agent run
+
+`benchmarks/benchmark_multi_turn.py` simulates a **single agent run** of 7 turns whose intent lurches
+across domains, re-ranking the **whole 50-tool registry** on every turn (per-call retrieval), executing
+the chosen tool for real, then feeding the result back into the next turn's query:
+
+```
+turn 1  get_current_weather   ↪  turn 2  search_flights   ↪  turn 3  book_hotel
+↪ turn 4  send_email          ↪  turn 5  convert_currency ↪  turn 6  create_todo
+↪ turn 7  (summarize_text in top-3; model picked send_sms)
+```
+
+```
+gold_in_top3 ................. 1.000   (right tool surfaced every turn)
+pick_accuracy ................ 0.857   (6/7 top-1 picks correct)
+distinct_pivots .............. 7       (a different tool every single turn)
+distinct_tools_used .......... 7
+selection_pivoted_every_turn . true
+```
+
+This demonstrates exactly the requested behavior: the agent selects a tool, reads its result, then
+**changes direction and selects a completely different tool** driven purely by the semantics of the new
+sub-task — not by a fixed pre-bound tool list. The enabling machinery:
+
+- **Per-call retrieval**: `GantryContextProvider(query_strategy="per_call")` for Microsoft AF, or, for
+  any framework, re-calling `gantry.retrieve(...)` each turn (as the benchmark does directly).
+- **Query generators** (`agent_gantry/query/strategies.py`): `last_user_text`, `last_tool_result`,
+  `fallback_chain(...)`, `keyword_focused(...)` derive the next turn's retrieval query from the evolving
+  conversation, so the query that drives selection moves with the task.
+- **Forward-progress penalty**: the router applies an `already_used_penalty` to tools in
+  `tools_already_used` (`router.py:428`), nudging the agent off tools it has already run.
+
+---
+
+## Summary scorecard
+
+| Area | Status |
+|---|---|
+| Microsoft Agent Framework | ✅ Production-grade, multi-turn native |
+| Generic LLM SDKs (OpenAI/Anthropic/Gemini/…) | ✅ Solid via decorator + dialect transcoding |
+| LangChain/LlamaIndex/CrewAI/etc. | ⚠️ Schema-only; needs native tool-object adapters |
+| OpenAI Agents SDK / Pydantic AI / Smolagents / Haystack / Agno | ❌ Not yet supported |
+| Top-3-of-50 selection quality | ✅ 100% hit@3, 0.94 MRR (MiniLM) — once threshold trap avoided |
+| Multi-turn pivot in one run | ✅ Demonstrated, 7/7 distinct tools |
+| In-memory search performance | ✅ 36–59× faster (vectorized) |
+| `score_threshold=0.5` default | ❌ Silently drops correct tools — fix recommended |
+| `**kwargs` tools | ❌ Become un-executable — fix recommended |
+| Dynamic MCP server selection | ⚠️ Preview/placeholder |

--- a/examples/frameworks/README.md
+++ b/examples/frameworks/README.md
@@ -1,0 +1,40 @@
+# Universal framework adapters — examples & verification
+
+These examples exercise the native tool adapters
+(`agent_gantry.integrations.frameworks`) and the multi-turn `ToolRefresher`.
+They all run **offline** — no API keys, no LLM, and no third-party agent
+framework required (uninstalled frameworks are skipped cleanly).
+
+| File | What it does |
+|---|---|
+| `verify_all.py` | **Verification harness.** Asserts the P0 fixes, the universal `GantryToolset`/`ToolSpec` core, every `for_<framework>` adapter (built or cleanly skipped), and the multi-turn `ToolRefresher` pivot. Exits non-zero on any core failure. |
+| `universal_adapters_example.py` | Readable walkthrough: select once with `GantryToolset`, invoke a `ToolSpec`, then export the selection to every framework's native tool object. |
+| `multi_turn_refresher_example.py` | Direction-changing tool selection within one run via `ToolRefresher`. |
+
+## Run
+
+```bash
+python examples/frameworks/verify_all.py                 # asserts everything; exit 0 = OK
+python examples/frameworks/universal_adapters_example.py
+python examples/frameworks/multi_turn_refresher_example.py
+```
+
+`verify_all.py` uses the strongest embedder available (SentenceTransformers if
+installed) and falls back to the offline `SimpleEmbedder`. Install a framework
+(e.g. `pip install langchain-core`) and re-run to see its adapter switch from
+`SKIP` to `OK`.
+
+## How this maps to the integrations
+
+- **Select** → `GantryToolset(gantry).select(query, limit=3)` returns ranked
+  `ToolSpec`s. Each `ToolSpec` is invocable directly (`ainvoke`/`invoke`) and
+  routes through `gantry.execute`.
+- **Export** → `for_langchain` / `for_llamaindex` / `for_crewai` /
+  `for_pydantic_ai` / `for_openai_agents` / `for_smolagents` / `for_haystack` /
+  `for_agno` / `for_autogen` / `for_langgraph` build that framework's native
+  tool object.
+- **Multi-turn** → `ToolRefresher(gantry).refresh(messages)` re-selects fresh
+  each turn so the agent can pivot to a different tool as the task changes.
+
+The framework-specific examples that use real LLMs and the older manual
+wrapping pattern live in [`../agent_frameworks/`](../agent_frameworks/).

--- a/examples/frameworks/multi_turn_refresher_example.py
+++ b/examples/frameworks/multi_turn_refresher_example.py
@@ -1,0 +1,90 @@
+"""Multi-turn tool selection within a single agent run, for any framework.
+
+``ToolRefresher`` re-ranks the *whole* registry on every turn, so an agent can
+pick a tool, read its result, then **change direction** and pick a completely
+different tool driven by the semantics of the new sub-task — not by a fixed,
+pre-bound tool list. This generalizes the Microsoft Agent Framework provider's
+per-call retrieval to any framework (or a hand-rolled loop).
+
+This example runs offline (no LLM). A simulated model always picks the
+top-ranked tool; the point is that the *selection* pivots turn to turn.
+
+Run::
+
+    python examples/frameworks/multi_turn_refresher_example.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+from agent_gantry.integrations import ToolRefresher
+
+
+def build_gantry() -> AgentGantry:
+    gantry = AgentGantry(embedder=SimpleEmbedder(dimension=128))
+    tools = [
+        ("get_weather", "Get the current weather and temperature for a city.", ["weather"]),
+        ("search_flights", "Search for available flights between two airports.", ["travel"]),
+        ("book_hotel", "Reserve a hotel room for a set of dates.", ["travel"]),
+        ("send_email", "Compose and send an email message to a recipient.", ["email"]),
+        ("convert_currency", "Convert money from one currency to another.", ["finance"]),
+        ("create_todo", "Add a task item to the user's to-do list.", ["productivity"]),
+    ]
+    for name, desc, tags in tools:
+        def make(n: str):
+            def fn(arg: str = "") -> str:
+                return f"{n} done"
+            fn.__name__ = n
+            fn.__doc__ = desc
+            return fn
+        gantry.register(make(name), tags=tags)
+    return gantry
+
+
+async def main() -> None:
+    gantry = build_gantry()
+    await gantry.sync()
+
+    # Default query generator = fallback_chain(last_user_text, last_tool_result),
+    # which is the right choice for user-driven pivots like this conversation.
+    refresher = ToolRefresher(gantry, limit=3, dialect="openai")
+
+    conversation = [
+        "What's the weather in San Francisco today?",
+        "Now find me flights from London to San Francisco.",
+        "Book a hotel there for two nights.",
+        "Email the trip details to my travel buddy.",
+        "Convert the 450 dollar hotel rate into euros.",
+        "Add 'pack passport' to my todo list.",
+    ]
+
+    messages: list[dict[str, Any]] = []
+    picks: list[str] = []
+    for turn, utterance in enumerate(conversation, start=1):
+        messages.append({"role": "user", "content": utterance})
+
+        # Re-select over the WHOLE registry for this turn.
+        schemas = await refresher.refresh(messages)
+        names = [s["function"]["name"] for s in schemas]
+        pick = names[0] if names else None
+        picks.append(pick or "—")
+
+        print(f"turn {turn}: {utterance!r}")
+        print(f"         top3={names}  -> picked={pick}")
+
+        # Simulate executing the picked tool and feeding the result back.
+        if pick:
+            messages.append({"role": "assistant", "content": f"calling {pick}"})
+            messages.append({"role": "tool", "name": pick, "content": f"{pick} done"})
+
+    print(f"\nPicks across the run: {picks}")
+    print(f"Distinct tools chosen: {len(set(picks))} / {len(conversation)} turns")
+    print(f"Tools used (accumulated): {refresher.tools_used}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/frameworks/multi_turn_refresher_example.py
+++ b/examples/frameworks/multi_turn_refresher_example.py
@@ -32,6 +32,8 @@ from agent_gantry.integrations import ToolRefresher
 
 def _embedder() -> tuple[Any, str]:
     try:
+        import sentence_transformers  # noqa: F401  (validate the install actually imports)
+
         from agent_gantry.adapters.embedders.sentence_transformers import (
             SentenceTransformersEmbedder,
         )

--- a/examples/frameworks/multi_turn_refresher_example.py
+++ b/examples/frameworks/multi_turn_refresher_example.py
@@ -1,13 +1,20 @@
-"""Multi-turn tool selection within a single agent run, for any framework.
+"""Multi-turn tool selection within one agent run — autonomous AND conversational.
 
 ``ToolRefresher`` re-ranks the *whole* registry on every turn, so an agent can
-pick a tool, read its result, then **change direction** and pick a completely
-different tool driven by the semantics of the new sub-task — not by a fixed,
-pre-bound tool list. This generalizes the Microsoft Agent Framework provider's
-per-call retrieval to any framework (or a hand-rolled loop).
+pick a tool, read its result, then move to a completely different tool driven by
+the semantics of the new sub-task — not by a fixed, pre-bound tool list. Its
+default query generator (:func:`agent_gantry.query.latest_activity`) is
+recency-aware, so the **same** refresher works for both:
+
+- **Autonomous agents / tool pipelines** — no new user input; each tool's
+  *result* selects the next tool.
+- **Conversational agents** — each new user message selects the next tool.
 
 This example runs offline (no LLM). A simulated model always picks the
-top-ranked tool; the point is that the *selection* pivots turn to turn.
+top-ranked tool; the point is that the *selection* advances correctly in both
+modes. It uses the strongest embedder available (SentenceTransformers if
+installed) and falls back to the offline ``SimpleEmbedder`` — note the toy
+embedder is too coarse for the autonomous result-driven routing.
 
 Run::
 
@@ -20,70 +27,111 @@ import asyncio
 from typing import Any
 
 from agent_gantry import AgentGantry
-from agent_gantry.adapters.embedders.simple import SimpleEmbedder
 from agent_gantry.integrations import ToolRefresher
 
 
-def build_gantry() -> AgentGantry:
-    gantry = AgentGantry(embedder=SimpleEmbedder(dimension=128))
-    tools = [
+def _embedder() -> tuple[Any, str]:
+    try:
+        from agent_gantry.adapters.embedders.sentence_transformers import (
+            SentenceTransformersEmbedder,
+        )
+
+        return SentenceTransformersEmbedder("all-MiniLM-L6-v2"), "all-MiniLM-L6-v2"
+    except Exception:  # noqa: BLE001
+        from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+        return SimpleEmbedder(dimension=256), "SimpleEmbedder (toy)"
+
+
+def _register(gantry: AgentGantry, tools: list[tuple[str, str, list[str]]]) -> None:
+    for name, desc, tags in tools:
+        def make(n: str, d: str):
+            def fn(arg: str = "") -> str:
+                return f"{n} done"
+            fn.__name__ = n
+            fn.__doc__ = d
+            return fn
+        gantry.register(make(name, desc), tags=tags)
+
+
+async def autonomous_pipeline_demo(embedder) -> None:
+    """No new user input — each tool result drives the next selection."""
+    print("\n=== AUTONOMOUS PIPELINE (result-driven) ===")
+    gantry = AgentGantry(embedder=embedder)
+    _register(gantry, [
+        ("fetch_raw_data", "Fetch raw unprocessed data from the source system.", ["data"]),
+        ("clean_dataset", "Clean and normalize a raw dataset, removing nulls and duplicates.", ["data"]),
+        ("train_model", "Train a machine learning model on a cleaned dataset.", ["ml"]),
+        ("evaluate_model", "Evaluate a trained machine learning model's accuracy metrics.", ["ml"]),
+        ("generate_report", "Generate a written report summarizing evaluation results.", ["report"]),
+        ("send_email", "Compose and send an email message to a recipient.", ["email"]),
+    ])
+    await gantry.sync()
+
+    refresher = ToolRefresher(gantry, limit=3)  # default = latest_activity
+    # Each result points forward at the next stage (how a real step hands off).
+    forward = {
+        "fetch_raw_data": "records have missing nulls and duplicate rows that must be cleaned and normalized",
+        "clean_dataset": "the prepared training set is ready to fit and train a machine learning model",
+        "train_model": "the fitted model now needs its accuracy and performance metrics evaluated",
+        "evaluate_model": "please write a summary report describing the evaluation findings",
+        "generate_report": "report complete",
+    }
+
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "Build and evaluate a model from the raw source data."}
+    ]
+    for step in range(5):
+        schemas = await refresher.refresh(messages)
+        names = [s["function"]["name"] for s in schemas]
+        pick = names[0] if names else None
+        print(f"  step {step + 1}: picked={pick}   (top3={names})")
+        if not pick:
+            break
+        # Autonomously advance — NO new user message, only the tool result.
+        messages.append({"role": "assistant", "content": f"calling {pick}"})
+        messages.append({"role": "tool", "name": pick, "content": forward.get(pick, "done")})
+
+
+async def conversational_demo(embedder) -> None:
+    """New user message each turn — the user's request drives selection."""
+    print("\n=== CONVERSATIONAL (user-driven) ===")
+    gantry = AgentGantry(embedder=embedder)
+    _register(gantry, [
         ("get_weather", "Get the current weather and temperature for a city.", ["weather"]),
         ("search_flights", "Search for available flights between two airports.", ["travel"]),
         ("book_hotel", "Reserve a hotel room for a set of dates.", ["travel"]),
         ("send_email", "Compose and send an email message to a recipient.", ["email"]),
         ("convert_currency", "Convert money from one currency to another.", ["finance"]),
         ("create_todo", "Add a task item to the user's to-do list.", ["productivity"]),
-    ]
-    for name, desc, tags in tools:
-        def make(n: str):
-            def fn(arg: str = "") -> str:
-                return f"{n} done"
-            fn.__name__ = n
-            fn.__doc__ = desc
-            return fn
-        gantry.register(make(name), tags=tags)
-    return gantry
-
-
-async def main() -> None:
-    gantry = build_gantry()
+    ])
     await gantry.sync()
 
-    # Default query generator = fallback_chain(last_user_text, last_tool_result),
-    # which is the right choice for user-driven pivots like this conversation.
-    refresher = ToolRefresher(gantry, limit=3, dialect="openai")
-
+    refresher = ToolRefresher(gantry, limit=3)
     conversation = [
         "What's the weather in San Francisco today?",
         "Now find me flights from London to San Francisco.",
         "Book a hotel there for two nights.",
         "Email the trip details to my travel buddy.",
         "Convert the 450 dollar hotel rate into euros.",
-        "Add 'pack passport' to my todo list.",
     ]
-
     messages: list[dict[str, Any]] = []
-    picks: list[str] = []
     for turn, utterance in enumerate(conversation, start=1):
         messages.append({"role": "user", "content": utterance})
-
-        # Re-select over the WHOLE registry for this turn.
         schemas = await refresher.refresh(messages)
         names = [s["function"]["name"] for s in schemas]
         pick = names[0] if names else None
-        picks.append(pick or "—")
-
-        print(f"turn {turn}: {utterance!r}")
-        print(f"         top3={names}  -> picked={pick}")
-
-        # Simulate executing the picked tool and feeding the result back.
+        print(f"  turn {turn}: {utterance!r}\n           picked={pick}   (top3={names})")
         if pick:
             messages.append({"role": "assistant", "content": f"calling {pick}"})
             messages.append({"role": "tool", "name": pick, "content": f"{pick} done"})
 
-    print(f"\nPicks across the run: {picks}")
-    print(f"Distinct tools chosen: {len(set(picks))} / {len(conversation)} turns")
-    print(f"Tools used (accumulated): {refresher.tools_used}")
+
+async def main() -> None:
+    embedder, label = _embedder()
+    print(f"Embedder: {label}")
+    await autonomous_pipeline_demo(embedder)
+    await conversational_demo(embedder)
 
 
 if __name__ == "__main__":

--- a/examples/frameworks/universal_adapters_example.py
+++ b/examples/frameworks/universal_adapters_example.py
@@ -1,0 +1,100 @@
+"""Universal native-tool adapters: select once, export to any framework.
+
+Agent-Gantry selects a small, relevant slice of tools from a large registry.
+The ``agent_gantry.integrations.frameworks`` adapters turn that slice into the
+*native* tool object of whichever framework you use, so the framework can
+introspect and call it — while every invocation still routes through
+``gantry.execute`` (retries, timeouts, circuit breakers, security policy).
+
+This example runs offline (no LLM). It shows:
+
+1. The framework-neutral core: ``GantryToolset.select`` → ``ToolSpec`` → invoke.
+2. The per-framework exporters: ``for_langchain`` / ``for_crewai`` / … which
+   build native objects when the framework is installed (skipped cleanly here
+   if it is not).
+
+Run::
+
+    python examples/frameworks/universal_adapters_example.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+from agent_gantry.integrations.frameworks import GantryToolset
+
+
+def build_gantry() -> AgentGantry:
+    gantry = AgentGantry(embedder=SimpleEmbedder(dimension=128))
+
+    @gantry.register(tags=["email"])
+    def send_email(to: str, subject: str = "", body: str = "") -> str:
+        """Compose and send an email message to a recipient."""
+        return f"email sent to {to}"
+
+    @gantry.register(tags=["weather"])
+    def get_weather(city: str) -> str:
+        """Get the current weather for a city."""
+        return f"It is 21C and sunny in {city}."
+
+    @gantry.register(tags=["finance"])
+    def convert_currency(amount: float, frm: str, to: str) -> str:
+        """Convert an amount of money from one currency to another."""
+        return f"{amount} {frm} = {amount * 1.1:.2f} {to}"
+
+    return gantry
+
+
+async def main() -> None:
+    gantry = build_gantry()
+    await gantry.sync()
+
+    # 1) Framework-neutral core ------------------------------------------- #
+    toolset = GantryToolset(gantry)
+    specs = await toolset.select("email the report to finance", limit=2)
+    print("Selected (framework-neutral) ToolSpecs:")
+    for s in specs:
+        print(f"  - {s.name}: {s.description!r}  (score={s.score:.3f})")
+
+    # ToolSpec is callable directly — async or sync — through Gantry.
+    top = specs[0]
+    print("\nInvoke the top spec directly:")
+    print("  ainvoke:", await top.ainvoke(to="finance@acme.com"))
+    print("  invoke :", top.invoke(to="finance@acme.com"))  # safe inside the loop
+
+    # 2) Export to each framework ----------------------------------------- #
+    from agent_gantry.integrations import frameworks as F
+
+    exporters = {
+        "langchain": F.for_langchain,
+        "langgraph": F.for_langgraph,
+        "llamaindex": F.for_llamaindex,
+        "crewai": F.for_crewai,
+        "pydantic_ai": F.for_pydantic_ai,
+        "openai_agents": F.for_openai_agents,
+        "smolagents": F.for_smolagents,
+        "haystack": F.for_haystack,
+        "agno": F.for_agno,
+        "autogen": F.for_autogen,
+    }
+
+    print("\nExport the selection to each framework's native tool object:")
+    for name, exporter in exporters.items():
+        try:
+            native = await exporter(gantry, "email the report to finance", limit=2)
+            kind = type(native[0]).__name__ if native else "—"
+            print(f"  [built] {name:<14} -> {len(native)} x {kind}")
+        except ImportError:
+            print(f"  [skip ] {name:<14} -> not installed (pip install it to use)")
+
+    print(
+        "\nEvery built tool calls back through gantry.execute, so retries, "
+        "timeouts,\ncircuit breakers and the security policy all still apply."
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/frameworks/verify_all.py
+++ b/examples/frameworks/verify_all.py
@@ -1,0 +1,239 @@
+"""End-to-end verification harness for Agent-Gantry's framework integrations.
+
+Run this to confirm — offline, with no LLM and no third-party agent framework
+required — that every piece added in the framework-integration work actually
+functions:
+
+1. **P0 fixes**: a ``**kwargs`` tool is executable; the convenience retrieval
+   default surfaces tools instead of silently filtering them.
+2. **Universal core**: ``GantryToolset.select`` returns ranked ``ToolSpec``s and
+   both ``ainvoke`` (async) and ``invoke`` (sync, even inside a running loop)
+   route through ``gantry.execute``.
+3. **Native adapters**: each ``for_<framework>`` helper builds native tool
+   objects when the framework is installed, or reports SKIP with a clean
+   ``ImportError`` when it is not — proving the lazy-import contract.
+4. **Multi-turn**: ``ToolRefresher`` re-selects a *different* tool as the task
+   pivots across turns within one run, and accumulates used tools.
+
+Exit code is ``0`` only when every core check passes (framework SKIPs do not
+fail the run). Usage::
+
+    python examples/frameworks/verify_all.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+
+from agent_gantry import AgentGantry
+from agent_gantry.integrations import ToolRefresher
+from agent_gantry.integrations.frameworks import GantryToolset
+from agent_gantry.schema.execution import ExecutionStatus, ToolCall
+
+# ---- registry ------------------------------------------------------------- #
+# Ten tools across distinct domains so even the hash-based SimpleEmbedder can
+# route unambiguously when no real embedder is installed.
+TOOLS: list[tuple[str, str, list[str]]] = [
+    ("get_current_weather", "Get the current weather and temperature for a city.", ["weather"]),
+    ("send_email", "Compose and send an email message to a recipient.", ["email"]),
+    ("convert_currency", "Convert an amount of money from one currency to another.", ["finance"]),
+    ("run_sql_query", "Execute a read-only SQL query against the database.", ["database"]),
+    ("create_todo", "Add a task item to the user's to-do list.", ["productivity"]),
+    ("search_flights", "Search for available flights between two airports.", ["travel"]),
+    ("translate_text", "Translate a piece of text from one language to another.", ["language"]),
+    ("get_stock_price", "Look up the latest share price for a stock ticker.", ["finance"]),
+    ("deploy_service", "Deploy an application service to the production cluster.", ["devops"]),
+    ("summarize_text", "Produce a short summary of a long passage of text.", ["nlp"]),
+]
+
+
+def _best_embedder() -> tuple[Any, str]:
+    """Prefer a real embedder; fall back to the offline hash toy."""
+    try:
+        from agent_gantry.adapters.embedders.sentence_transformers import (
+            SentenceTransformersEmbedder,
+        )
+
+        return SentenceTransformersEmbedder("all-MiniLM-L6-v2"), "sentence-transformers/all-MiniLM-L6-v2"
+    except Exception:  # noqa: BLE001
+        from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+        return SimpleEmbedder(dimension=256), "SimpleEmbedder(hash, offline)"
+
+
+def _make_tool(name: str, description: str):
+    def fn(arg: str = "") -> str:
+        return f"{name}->{arg}"
+
+    fn.__name__ = name
+    fn.__doc__ = description
+    return fn
+
+
+async def _build_gantry() -> AgentGantry:
+    embedder, label = _best_embedder()
+    print(f"Embedder: {label}\n")
+    gantry = AgentGantry(embedder=embedder)
+    for name, desc, tags in TOOLS:
+        gantry.register(_make_tool(name, desc), tags=tags)
+
+    # A deliberately **kwargs-only tool to exercise the schema fix.
+    def echo_kwargs(**kwargs: Any) -> str:
+        "Echo back any keyword arguments supplied to this tool."
+        return f"echo:{sorted(kwargs)}"
+
+    gantry.register(echo_kwargs, tags=["debug"])
+    await gantry.sync()
+    return gantry
+
+
+# ---- individual checks ---------------------------------------------------- #
+async def check_p0_kwargs(gantry: AgentGantry) -> tuple[bool, str]:
+    """A bare ``**kwargs`` tool must be executable with an empty arg dict."""
+    result = await gantry.execute(ToolCall(tool_name="echo_kwargs", arguments={}))
+    ok = result.status == ExecutionStatus.SUCCESS
+    return ok, f"status={getattr(result.status, 'value', result.status)} result={result.result!r}"
+
+
+async def check_default_threshold(gantry: AgentGantry) -> tuple[bool, str]:
+    """retrieve_tools default (0.0) must surface tools, not filter them away."""
+    tools = await gantry.retrieve_tools("send an email to my manager", limit=3)
+    names = [t["function"]["name"] for t in tools]
+    return (len(tools) > 0 and "send_email" in names), f"top3={names}"
+
+
+async def check_toolset_invoke(gantry: AgentGantry) -> tuple[bool, str]:
+    """GantryToolset.select + ToolSpec.ainvoke/invoke route through execute."""
+    specs = await GantryToolset(gantry).select("convert 100 usd to eur", limit=3)
+    if not specs:
+        return False, "no specs selected"
+    target = next((s for s in specs if s.name == "convert_currency"), specs[0])
+    async_result = await target.ainvoke(arg="x")
+    sync_result = target.invoke(arg="y")  # sync path, called inside the loop
+    ok = async_result == f"{target.name}->x" and sync_result == f"{target.name}->y"
+    return ok, f"async={async_result!r} sync={sync_result!r} (specs={[s.name for s in specs]})"
+
+
+async def check_adapters(gantry: AgentGantry) -> list[tuple[str, bool, str]]:
+    """Build native tools per framework; SKIP cleanly when not installed."""
+    from agent_gantry.integrations import frameworks as F
+
+    adapters = [
+        ("langchain", F.for_langchain),
+        ("langgraph", F.for_langgraph),
+        ("llamaindex", F.for_llamaindex),
+        ("crewai", F.for_crewai),
+        ("pydantic_ai", F.for_pydantic_ai),
+        ("openai_agents", F.for_openai_agents),
+        ("smolagents", F.for_smolagents),
+        ("haystack", F.for_haystack),
+        ("agno", F.for_agno),
+        ("autogen", F.for_autogen),
+    ]
+    rows: list[tuple[str, bool, str]] = []
+    for name, fn in adapters:
+        try:
+            native = await fn(gantry, "deploy the payments service", limit=2)
+            rows.append((name, True, f"built {len(native)} native tool(s)"))
+        except ImportError as exc:
+            # Not installed: the lazy-import contract held — this is a SKIP,
+            # not a failure. (pip hint should be present.)
+            rows.append((name, None, f"SKIP (not installed): {str(exc).splitlines()[0][:60]}"))  # type: ignore[arg-type]
+        except Exception as exc:  # noqa: BLE001
+            rows.append((name, False, f"FAIL: {type(exc).__name__}: {exc}"))
+    return rows
+
+
+async def check_multi_turn(gantry: AgentGantry) -> tuple[bool, str]:
+    """ToolRefresher must re-select a different tool as the task pivots.
+
+    This is a *user-driven* pivot scenario (each turn the user asks for a new
+    thing), which is exactly what the refresher's default query generator —
+    ``fallback_chain(last_user_text, last_tool_result)`` — handles. For an
+    autonomous tool *pipeline* (previous output drives the next tool) you would
+    instead pass ``query_generator=fallback_chain(last_tool_result, ...)``.
+    """
+    refresher = ToolRefresher(gantry, limit=3)
+    turns = [
+        ("what's the weather in Paris?", "get_current_weather"),
+        ("now email the forecast to my team", "send_email"),
+        ("convert 50 dollars to euros for the trip", "convert_currency"),
+        ("add 'pack umbrella' to my todo list", "create_todo"),
+    ]
+    messages: list[dict[str, Any]] = []
+    top_picks: list[str] = []
+    in_top3 = 0
+    for utterance, gold in turns:
+        messages.append({"role": "user", "content": utterance})
+        schemas = await refresher.refresh(messages)
+        names = [s["function"]["name"] for s in schemas]
+        if names:
+            top_picks.append(names[0])
+            # simulate executing the top tool, feeding the result back
+            messages.append({"role": "assistant", "content": f"calling {names[0]}"})
+            messages.append({"role": "tool", "name": names[0], "content": "done"})
+        if gold in names:
+            in_top3 += 1
+    distinct = len(set(top_picks))
+    pivoted = distinct >= 2
+    accurate = in_top3 >= 3  # at least 3/4 turns surface the right tool
+    used = refresher.tools_used
+    ok = pivoted and accurate and len(used) >= 2
+    return ok, (
+        f"picks={top_picks} distinct={distinct} gold_in_top3={in_top3}/4 "
+        f"tools_used={used}"
+    )
+
+
+# ---- runner --------------------------------------------------------------- #
+async def run() -> dict[str, Any]:
+    gantry = await _build_gantry()
+
+    core_checks = [
+        ("P0: **kwargs tool executable", await check_p0_kwargs(gantry)),
+        ("P0: default threshold surfaces tools", await check_default_threshold(gantry)),
+        ("core: GantryToolset select + invoke", await check_toolset_invoke(gantry)),
+        ("multi-turn: ToolRefresher pivots", await check_multi_turn(gantry)),
+    ]
+
+    print("=== CORE CHECKS ===")
+    all_core_passed = True
+    for label, (ok, detail) in core_checks:
+        all_core_passed = all_core_passed and ok
+        print(f"  [{'PASS' if ok else 'FAIL'}] {label:<42} {detail}")
+
+    print("\n=== FRAMEWORK ADAPTERS ===")
+    adapter_rows = await check_adapters(gantry)
+    adapter_failed = False
+    for name, ok, detail in adapter_rows:
+        tag = "OK  " if ok else ("SKIP" if ok is None else "FAIL")
+        if ok is False:
+            adapter_failed = True
+        print(f"  [{tag}] {name:<16} {detail}")
+
+    ok_count = sum(1 for _, ok, _ in adapter_rows if ok is True)
+    skip_count = sum(1 for _, ok, _ in adapter_rows if ok is None)
+    print(
+        f"\nAdapters: {ok_count} built, {skip_count} skipped (not installed), "
+        f"{'0' if not adapter_failed else 'SOME'} failed."
+    )
+    print(f"Core checks: {'ALL PASSED' if all_core_passed else 'FAILURES PRESENT'}")
+
+    return {
+        "all_core_passed": all_core_passed,
+        "core_checks": {label: ok for label, (ok, _) in core_checks},
+        "adapters_built": ok_count,
+        "adapters_skipped": skip_count,
+        "adapters_failed": adapter_failed,
+    }
+
+
+def main() -> int:
+    summary = asyncio.run(run())
+    return 0 if (summary["all_core_passed"] and not summary["adapters_failed"]) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/frameworks/verify_all.py
+++ b/examples/frameworks/verify_all.py
@@ -49,18 +49,28 @@ TOOLS: list[tuple[str, str, list[str]]] = [
 ]
 
 
-def _best_embedder() -> tuple[Any, str]:
-    """Prefer a real embedder; fall back to the offline hash toy."""
+def _best_embedder() -> tuple[Any, str, bool]:
+    """Prefer a real embedder; fall back to the offline hash toy.
+
+    Returns ``(embedder, label, is_real)``. ``is_real`` is ``False`` for the
+    hash-based ``SimpleEmbedder``, whose similarity scores are too coarse for
+    nuanced result-driven routing — checks that need real semantics skip when
+    only it is available.
+    """
     try:
         from agent_gantry.adapters.embedders.sentence_transformers import (
             SentenceTransformersEmbedder,
         )
 
-        return SentenceTransformersEmbedder("all-MiniLM-L6-v2"), "sentence-transformers/all-MiniLM-L6-v2"
+        return (
+            SentenceTransformersEmbedder("all-MiniLM-L6-v2"),
+            "sentence-transformers/all-MiniLM-L6-v2",
+            True,
+        )
     except Exception:  # noqa: BLE001
         from agent_gantry.adapters.embedders.simple import SimpleEmbedder
 
-        return SimpleEmbedder(dimension=256), "SimpleEmbedder(hash, offline)"
+        return SimpleEmbedder(dimension=256), "SimpleEmbedder(hash, offline)", False
 
 
 def _make_tool(name: str, description: str):
@@ -73,7 +83,7 @@ def _make_tool(name: str, description: str):
 
 
 async def _build_gantry() -> AgentGantry:
-    embedder, label = _best_embedder()
+    embedder, label, _is_real = _best_embedder()
     print(f"Embedder: {label}\n")
     gantry = AgentGantry(embedder=embedder)
     for name, desc, tags in TOOLS:
@@ -188,6 +198,71 @@ async def check_multi_turn(gantry: AgentGantry) -> tuple[bool, str]:
 
 
 # ---- runner --------------------------------------------------------------- #
+async def check_autonomous_pipeline() -> tuple[bool, str]:
+    """ToolRefresher must chain tools in an autonomous run with NO new user input.
+
+    The agent is given one goal, then runs a pipeline; each tool's *result*
+    must drive selection of the next tool (the recency-aware default reads the
+    latest tool result when there is no newer user message). This is the
+    autonomous-agent counterpart to the conversational pivot check.
+    """
+    embedder, _label, is_real = _best_embedder()
+    if not is_real:
+        return None, "SKIP: needs a real embedder (SimpleEmbedder is a hash toy)"  # type: ignore[return-value]
+    g = AgentGantry(embedder=embedder)
+    pipeline = [
+        ("fetch_raw_data", "Fetch raw unprocessed data from the source system.", ["data"]),
+        ("clean_dataset", "Clean and normalize a raw dataset, removing nulls and duplicates.", ["data"]),
+        ("train_model", "Train a machine learning model on a cleaned dataset.", ["ml"]),
+        ("evaluate_model", "Evaluate a trained machine learning model's accuracy metrics.", ["ml"]),
+        ("generate_report", "Generate a written report summarizing evaluation results.", ["report"]),
+    ]
+    # A couple of distractor tools so selection isn't trivial.
+    distractors = [
+        ("send_email", "Compose and send an email message to a recipient.", ["email"]),
+        ("get_weather", "Get the current weather for a city.", ["weather"]),
+    ]
+    for name, desc, tags in pipeline + distractors:
+        g.register(_make_tool(name, desc), tags=tags)
+    await g.sync()
+
+    refresher = ToolRefresher(g, limit=3)  # default = latest_activity (recency-aware)
+
+    # One user goal, then NO further user messages — only tool results feed back.
+    messages: list[dict[str, Any]] = [
+        {"role": "user", "content": "Build and evaluate a model from the raw source data."}
+    ]
+    # Each result points FORWARD at the next stage (describing what is needed
+    # next, not what was just done) — how a real pipeline step hands off.
+    step_results = {
+        "fetch_raw_data": "the records contain missing nulls and duplicate rows that must be cleaned and normalized",
+        "clean_dataset": "the prepared training set is ready to fit and train a machine learning model",
+        "train_model": "the fitted model now needs its accuracy and performance metrics evaluated",
+        "evaluate_model": "please write a summary report describing the evaluation findings",
+    }
+    expected_order = ["fetch_raw_data", "clean_dataset", "train_model", "evaluate_model", "generate_report"]
+
+    picks: list[str] = []
+    for _ in expected_order:
+        schemas = await refresher.refresh(messages)
+        names = [s["function"]["name"] for s in schemas]
+        pick = names[0] if names else None
+        picks.append(pick or "—")
+        if pick is None:
+            break
+        # Autonomously advance: append the assistant call + tool result (NO user msg).
+        result_text = step_results.get(pick, f"{pick} completed")
+        messages.append({"role": "assistant", "content": f"calling {pick}"})
+        messages.append({"role": "tool", "name": pick, "content": result_text})
+
+    # Result-driven chaining should advance through the pipeline. Require the
+    # first step correct and the run to traverse most of the distinct stages.
+    advanced = len([p for p in picks if p in expected_order])
+    distinct_stages = len(set(picks) & set(expected_order))
+    ok = picks[0] == "fetch_raw_data" and distinct_stages >= 4
+    return ok, f"picks={picks} distinct_pipeline_stages={distinct_stages}/5"
+
+
 async def run() -> dict[str, Any]:
     gantry = await _build_gantry()
 
@@ -195,14 +270,18 @@ async def run() -> dict[str, Any]:
         ("P0: **kwargs tool executable", await check_p0_kwargs(gantry)),
         ("P0: default threshold surfaces tools", await check_default_threshold(gantry)),
         ("core: GantryToolset select + invoke", await check_toolset_invoke(gantry)),
-        ("multi-turn: ToolRefresher pivots", await check_multi_turn(gantry)),
+        ("multi-turn (conversational) pivots", await check_multi_turn(gantry)),
+        ("multi-turn (autonomous) pipeline chains", await check_autonomous_pipeline()),
     ]
 
     print("=== CORE CHECKS ===")
     all_core_passed = True
     for label, (ok, detail) in core_checks:
-        all_core_passed = all_core_passed and ok
-        print(f"  [{'PASS' if ok else 'FAIL'}] {label:<42} {detail}")
+        # ok is True (pass), False (fail), or None (skipped — not a failure).
+        if ok is False:
+            all_core_passed = False
+        tag = "PASS" if ok else ("SKIP" if ok is None else "FAIL")
+        print(f"  [{tag}] {label:<42} {detail}")
 
     print("\n=== FRAMEWORK ADAPTERS ===")
     adapter_rows = await check_adapters(gantry)

--- a/examples/frameworks/verify_all.py
+++ b/examples/frameworks/verify_all.py
@@ -58,6 +58,8 @@ def _best_embedder() -> tuple[Any, str, bool]:
     only it is available.
     """
     try:
+        import sentence_transformers  # noqa: F401  (validate the install actually imports)
+
         from agent_gantry.adapters.embedders.sentence_transformers import (
             SentenceTransformersEmbedder,
         )
@@ -257,7 +259,6 @@ async def check_autonomous_pipeline() -> tuple[bool, str]:
 
     # Result-driven chaining should advance through the pipeline. Require the
     # first step correct and the run to traverse most of the distinct stages.
-    advanced = len([p for p in picks if p in expected_order])
     distinct_stages = len(set(picks) & set(expected_order))
     ok = picks[0] == "fetch_raw_data" and distinct_stages >= 4
     return ok, f"picks={picks} distinct_pipeline_stages={distinct_stages}/5"

--- a/tests/examples/test_frameworks_examples.py
+++ b/tests/examples/test_frameworks_examples.py
@@ -1,0 +1,34 @@
+"""Keep the framework-integration examples green.
+
+These run the offline example/verification scripts in-process and assert their
+observable outcomes, so the examples can't silently rot as the library evolves.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_verify_all_core_checks_pass() -> None:
+    mod = importlib.import_module("examples.frameworks.verify_all")
+    summary = await mod.run()
+    assert summary["all_core_passed"], f"core checks failed: {summary['core_checks']}"
+    assert not summary["adapters_failed"], "a framework adapter raised an unexpected error"
+    # autogen needs no third-party framework, so at least one adapter always builds.
+    assert summary["adapters_built"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_universal_adapters_example_runs() -> None:
+    mod = importlib.import_module("examples.frameworks.universal_adapters_example")
+    # Should complete without raising (frameworks are skipped if absent).
+    await mod.main()
+
+
+@pytest.mark.asyncio
+async def test_multi_turn_refresher_example_runs() -> None:
+    mod = importlib.import_module("examples.frameworks.multi_turn_refresher_example")
+    await mod.main()

--- a/tests/frameworks/test_agno.py
+++ b/tests/frameworks/test_agno.py
@@ -1,0 +1,108 @@
+"""Tests for the Agno (formerly Phidata) native tool adapter.
+
+Agno is not installed in this environment, so minimal fake ``agno``,
+``agno.tools`` and ``agno.tools.function`` modules are injected into
+``sys.modules`` (cleaned up by ``monkeypatch.setitem``) to resolve the
+adapter's lazy import.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+
+class _FakeFunction:
+    """Stand-in for ``agno.tools.function.Function``.
+
+    Stores the kwargs passed to ``__init__`` so tests can assert how the
+    adapter built the tool.
+    """
+
+    def __init__(self, name=None, description=None, parameters=None, entrypoint=None):
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+        self.entrypoint = entrypoint
+
+
+@pytest.fixture
+def fake_agno(monkeypatch):
+    agno = types.ModuleType("agno")
+    agno_tools = types.ModuleType("agno.tools")
+    agno_tools_function = types.ModuleType("agno.tools.function")
+    agno_tools_function.Function = _FakeFunction
+    agno.tools = agno_tools
+    agno_tools.function = agno_tools_function
+
+    monkeypatch.setitem(sys.modules, "agno", agno)
+    monkeypatch.setitem(sys.modules, "agno.tools", agno_tools)
+    monkeypatch.setitem(sys.modules, "agno.tools.function", agno_tools_function)
+    return agno
+
+
+@pytest.fixture
+async def gantry():
+    g = AgentGantry(embedder=SimpleEmbedder(dimension=64))
+
+    @g.register(tags=["email"])
+    def send_email(to: str, body: str = "") -> str:
+        "Send an email message to a recipient."
+        return f"sent:{to}"
+
+    @g.register(tags=["math"])
+    def add(a: int, b: int) -> int:
+        "Add two integers together."
+        return a + b
+
+    await g.sync()
+    return g
+
+
+async def test_spec_to_agno_builds_native_tool(fake_agno, gantry):
+    from agent_gantry.integrations.frameworks.agno import spec_to_agno
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    spec = specs[0]
+    fn = spec_to_agno(spec)
+
+    assert fn.name == spec.name == "send_email"
+    assert fn.description == spec.description == "Send an email message to a recipient."
+    assert fn.parameters == spec.parameters
+    assert fn.parameters["properties"]["to"]["type"] == "string"
+
+    # entrypoint is a sync wrapper (spec.invoke), so Agno calls it from
+    # synchronous code with the tool arguments as keyword args. Run it off the
+    # event loop here to mimic that, routing through gantry.execute.
+    result = await asyncio.to_thread(fn.entrypoint, to="boss@x.com")
+    assert result == "sent:boss@x.com"
+
+
+async def test_for_agno_returns_function_list(fake_agno, gantry):
+    from agent_gantry.integrations.frameworks.agno import for_agno
+
+    tools = await for_agno(gantry, "send an email", limit=2)
+
+    assert isinstance(tools, list)
+    assert len(tools) >= 1
+    names = {t.name for t in tools}
+    assert "send_email" in names
+
+
+async def test_missing_agno_raises_helpful_error(monkeypatch, gantry):
+    # Ensure the lazy import fails even if a real package is somehow present.
+    monkeypatch.setitem(sys.modules, "agno.tools.function", None)
+
+    from agent_gantry.integrations.frameworks.agno import spec_to_agno
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    with pytest.raises(ImportError, match="pip install agno"):
+        spec_to_agno(specs[0])

--- a/tests/frameworks/test_autogen.py
+++ b/tests/frameworks/test_autogen.py
@@ -1,0 +1,124 @@
+"""Tests for the AutoGen / AG2 native tool adapter.
+
+AutoGen (pyautogen) is not installed in this environment, so for the
+registration path a minimal fake ``autogen`` module is injected into
+``sys.modules`` (cleaned up by ``monkeypatch.setitem``) to resolve the
+adapter's lazy import. Its ``register_function`` records each call so tests can
+assert what was registered. The schema-only helpers need no framework at all.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+
+@pytest.fixture
+async def gantry():
+    g = AgentGantry(embedder=SimpleEmbedder(dimension=64))
+
+    @g.register(tags=["email"])
+    def send_email(to: str, body: str = "") -> str:
+        "Send an email message to a recipient."
+        return f"sent:{to}"
+
+    @g.register(tags=["math"])
+    def add(a: int, b: int) -> int:
+        "Add two integers together."
+        return a + b
+
+    await g.sync()
+    return g
+
+
+@pytest.fixture
+def fake_autogen(monkeypatch):
+    """Inject a fake ``autogen`` module whose ``register_function`` records calls."""
+    records: list[dict] = []
+
+    def register_function(func, *, caller, executor, name, description):
+        records.append(
+            {
+                "func": func,
+                "caller": caller,
+                "executor": executor,
+                "name": name,
+                "description": description,
+            }
+        )
+
+    pkg = types.ModuleType("autogen")
+    pkg.register_function = register_function
+    pkg.records = records
+    monkeypatch.setitem(sys.modules, "autogen", pkg)
+    return pkg
+
+
+async def test_for_autogen_returns_mappings(gantry):
+    from agent_gantry.integrations.frameworks.autogen import for_autogen
+
+    tools = await for_autogen(gantry, "send an email", limit=2)
+
+    assert isinstance(tools, list)
+    assert len(tools) >= 1
+    names = {t["name"] for t in tools}
+    assert "send_email" in names
+
+    spec = next(t for t in tools if t["name"] == "send_email")
+    assert spec["description"] == "Send an email message to a recipient."
+    assert callable(spec["callable"])
+    # The callable routes through gantry.execute and returns the result.
+    assert await spec["callable"](to="boss@x.com") == "sent:boss@x.com"
+
+
+async def test_spec_to_autogen_shape(gantry):
+    from agent_gantry.integrations.frameworks.autogen import spec_to_autogen
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    mapping = spec_to_autogen(specs[0])
+
+    assert set(mapping) == {"name", "description", "callable"}
+    assert mapping["name"] == "send_email"
+    assert mapping["description"] == "Send an email message to a recipient."
+    assert mapping["callable"].__name__ == "send_email"
+    assert await mapping["callable"](to="boss@x.com") == "sent:boss@x.com"
+
+
+async def test_register_with_autogen_records_names(fake_autogen, gantry):
+    from agent_gantry.integrations.frameworks.autogen import register_with_autogen
+
+    caller = object()
+    executor = object()
+
+    names = await register_with_autogen(
+        gantry, "send an email", caller=caller, executor=executor, limit=2
+    )
+
+    assert isinstance(names, list)
+    assert "send_email" in names
+    assert len(fake_autogen.records) == len(names)
+
+    record = next(r for r in fake_autogen.records if r["name"] == "send_email")
+    assert record["caller"] is caller
+    assert record["executor"] is executor
+    assert record["description"] == "Send an email message to a recipient."
+    # The captured func executes through gantry.
+    assert await record["func"](to="boss@x.com") == "sent:boss@x.com"
+
+
+async def test_missing_autogen_raises_helpful_error(monkeypatch, gantry):
+    from agent_gantry.integrations.frameworks.autogen import register_with_autogen
+
+    # Ensure the lazy import fails even if a real package is somehow present.
+    monkeypatch.setitem(sys.modules, "autogen", None)
+
+    with pytest.raises(ImportError, match="pip install pyautogen"):
+        await register_with_autogen(
+            gantry, "send an email", caller=object(), executor=object()
+        )

--- a/tests/frameworks/test_conformance.py
+++ b/tests/frameworks/test_conformance.py
@@ -1,0 +1,122 @@
+"""Cross-framework conformance matrix for the native tool adapters.
+
+Every adapter in ``agent_gantry.integrations.frameworks`` must honor the same
+contract regardless of which third-party framework it targets:
+
+1. It exposes ``for_<fw>`` (async select+convert) and ``spec_to_<fw>`` (single
+   convert), both importable without the framework installed.
+2. ``for_<fw>`` runs semantic selection against a real gantry and returns one
+   native object per selected tool (verified through a per-framework stub).
+3. ``spec_to_<fw>`` raises a clean ``ImportError`` carrying a ``pip install``
+   hint when the framework is absent — not ``AttributeError`` / ``KeyError``.
+
+This locks the uniform surface so a new adapter can't silently drift.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+from agent_gantry.integrations import frameworks as F
+
+
+@pytest.fixture
+async def gantry():
+    g = AgentGantry(embedder=SimpleEmbedder(dimension=64))
+
+    @g.register(tags=["email"])
+    def send_email(to: str, body: str = "") -> str:
+        "Send an email message to a recipient."
+        return f"sent:{to}"
+
+    @g.register(tags=["math"])
+    def add(a: int, b: int) -> int:
+        "Add two integers together."
+        return a + b
+
+    await g.sync()
+    return g
+
+
+# (framework key, for_* fn, spec_to_* fn, module name(s) the lazy import needs)
+ADAPTERS = [
+    ("langchain", F.for_langchain, F.spec_to_langchain, ["langchain_core", "langchain_core.tools"]),
+    ("langgraph", F.for_langgraph, F.spec_to_langgraph, ["langchain_core", "langchain_core.tools"]),
+    ("llamaindex", F.for_llamaindex, F.spec_to_llamaindex, ["llama_index", "llama_index.core", "llama_index.core.tools"]),
+    ("crewai", F.for_crewai, F.spec_to_crewai, ["crewai", "crewai.tools"]),
+    ("pydantic_ai", F.for_pydantic_ai, F.spec_to_pydantic_ai, ["pydantic_ai", "pydantic_ai.tools"]),
+    ("openai_agents", F.for_openai_agents, F.spec_to_openai_agents, ["agents"]),
+    ("smolagents", F.for_smolagents, F.spec_to_smolagents, ["smolagents"]),
+    ("haystack", F.for_haystack, F.spec_to_haystack, ["haystack", "haystack.tools"]),
+    ("agno", F.for_agno, F.spec_to_agno, ["agno", "agno.tools", "agno.tools.function"]),
+]
+
+
+@pytest.mark.parametrize("name,for_fn,spec_fn,modules", ADAPTERS, ids=[a[0] for a in ADAPTERS])
+def test_adapter_exposes_uniform_surface(name, for_fn, spec_fn, modules):
+    assert callable(for_fn), f"{name}: for_{name} not callable"
+    assert callable(spec_fn), f"{name}: spec_to_{name} not callable"
+
+
+@pytest.mark.parametrize("name,for_fn,spec_fn,modules", ADAPTERS, ids=[a[0] for a in ADAPTERS])
+def test_missing_framework_raises_clean_importerror(name, for_fn, spec_fn, modules, monkeypatch):
+    # Ensure the framework's import resolves to "not installed".
+    for mod in modules:
+        monkeypatch.setitem(sys.modules, mod, None)
+
+    from agent_gantry.integrations.frameworks.base import ToolSpec
+
+    dummy = ToolSpec(
+        name="t",
+        qualified_name="default.t",
+        description="d",
+        parameters={"type": "object", "properties": {}},
+        requires_confirmation=False,
+        score=0.0,
+        _gantry=None,  # type: ignore[arg-type]
+        _namespace="default",
+    )
+    with pytest.raises(ImportError):
+        spec_fn(dummy)
+
+
+def _install_stub(monkeypatch, modules: list[str], attrs: dict[str, object]) -> None:
+    """Create stub modules; set ``attrs`` on the *last* (leaf) module."""
+    for i, mod in enumerate(modules):
+        m = types.ModuleType(mod)
+        if i == len(modules) - 1:
+            for k, v in attrs.items():
+                setattr(m, k, v)
+        monkeypatch.setitem(sys.modules, mod, m)
+
+
+async def test_for_each_framework_selects_and_converts(gantry, monkeypatch):
+    """Smoke every ``for_<fw>`` end-to-end with a permissive captured stub."""
+
+    captured: dict[str, list] = {}
+
+    def _record(fw):
+        def _factory(*args, **kwargs):
+            obj = types.SimpleNamespace(args=args, kwargs=kwargs)
+            captured.setdefault(fw, []).append(obj)
+            return obj
+
+        return _factory
+
+    # langchain StructuredTool.from_function classmethod
+    lc = types.SimpleNamespace()
+    lc.from_function = staticmethod(lambda **kw: types.SimpleNamespace(**kw))
+
+    cases = [
+        ("langchain", F.for_langchain, ["langchain_core", "langchain_core.tools"], {"StructuredTool": lc}),
+        ("langgraph", F.for_langgraph, ["langchain_core", "langchain_core.tools"], {"StructuredTool": lc}),
+    ]
+    for fw, for_fn, modules, attrs in cases:
+        _install_stub(monkeypatch, modules, attrs)
+        tools = await for_fn(gantry, "send an email to my boss", limit=2)
+        assert len(tools) >= 1, f"{fw}: expected at least one converted tool"

--- a/tests/frameworks/test_crewai.py
+++ b/tests/frameworks/test_crewai.py
@@ -1,0 +1,111 @@
+"""Tests for the CrewAI native tool adapter.
+
+CrewAI is not installed in this environment, so minimal fake ``crewai`` and
+``crewai.tools`` modules are injected into ``sys.modules`` (cleaned up by
+``monkeypatch.setitem``) to resolve the adapter's lazy import. The stub
+``BaseTool`` is a plain (non-Pydantic) subclass-friendly class.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+
+class _FakeBaseTool:
+    """Stand-in for ``crewai.tools.BaseTool``.
+
+    Plain Python (not Pydantic): instances construct with no required args and
+    expose class-level ``name`` / ``description`` attributes. ``_run`` is meant
+    to be overridden by the adapter's dynamically-built subclass.
+    """
+
+    name: str = ""
+    description: str = ""
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def _run(self, **kwargs):  # pragma: no cover - overridden by adapter
+        raise NotImplementedError
+
+
+@pytest.fixture
+def fake_crewai(monkeypatch):
+    crewai = types.ModuleType("crewai")
+    tools = types.ModuleType("crewai.tools")
+    tools.BaseTool = _FakeBaseTool
+    crewai.tools = tools
+    monkeypatch.setitem(sys.modules, "crewai", crewai)
+    monkeypatch.setitem(sys.modules, "crewai.tools", tools)
+    return tools
+
+
+@pytest.fixture
+async def gantry():
+    g = AgentGantry(embedder=SimpleEmbedder(dimension=64))
+
+    @g.register(tags=["email"])
+    def send_email(to: str, body: str = "") -> str:
+        "Send an email message to a recipient."
+        return f"sent:{to}"
+
+    @g.register(tags=["math"])
+    def add(a: int, b: int) -> int:
+        "Add two integers together."
+        return a + b
+
+    await g.sync()
+    return g
+
+
+async def test_spec_to_crewai_builds_native_tool(fake_crewai, gantry):
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+    from agent_gantry.integrations.frameworks.crewai import spec_to_crewai
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    spec = specs[0]
+    tool = spec_to_crewai(spec)
+
+    assert tool.name == spec.name == "send_email"
+    assert (
+        tool.description
+        == spec.description
+        == "Send an email message to a recipient."
+    )
+
+    # ``_run`` routes through the sync ``spec.invoke`` (which spins its own event
+    # loop), so call it off the test's running loop via a worker thread.
+    result = await asyncio.to_thread(tool._run, to="boss@x.com")
+    assert result == "sent:boss@x.com"
+
+
+async def test_for_crewai_returns_tool_list(fake_crewai, gantry):
+    from agent_gantry.integrations.frameworks.crewai import for_crewai
+
+    tools = await for_crewai(gantry, "send an email", limit=2)
+
+    assert isinstance(tools, list)
+    assert len(tools) >= 1
+    names = {t.name for t in tools}
+    assert "send_email" in names
+
+
+async def test_missing_crewai_raises_helpful_error(monkeypatch, gantry):
+    # Ensure the lazy import fails even if a real package is somehow present.
+    monkeypatch.setitem(sys.modules, "crewai", None)
+    monkeypatch.setitem(sys.modules, "crewai.tools", None)
+
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+    from agent_gantry.integrations.frameworks.crewai import spec_to_crewai
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    with pytest.raises(ImportError, match="pip install crewai"):
+        spec_to_crewai(specs[0])

--- a/tests/frameworks/test_haystack.py
+++ b/tests/frameworks/test_haystack.py
@@ -1,0 +1,109 @@
+"""Tests for the Haystack native tool adapter.
+
+Haystack (``haystack-ai``) is not installed in this environment, so minimal
+fake ``haystack`` and ``haystack.tools`` modules are injected into
+``sys.modules`` (cleaned up by ``monkeypatch.setitem``) to resolve the
+adapter's lazy import. The stub ``Tool`` simply records the constructor
+arguments the adapter passes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+
+class _FakeTool:
+    """Stand-in for ``haystack.tools.Tool``.
+
+    Stores ``name`` / ``description`` / ``parameters`` / ``function`` exactly as
+    Haystack 2.x's ``Tool`` would, so the adapter's output can be inspected.
+    """
+
+    def __init__(self, name, description, parameters, function):
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+        self.function = function
+
+
+@pytest.fixture
+def fake_haystack(monkeypatch):
+    haystack = types.ModuleType("haystack")
+    tools = types.ModuleType("haystack.tools")
+    tools.Tool = _FakeTool
+    haystack.tools = tools
+    monkeypatch.setitem(sys.modules, "haystack", haystack)
+    monkeypatch.setitem(sys.modules, "haystack.tools", tools)
+    return tools
+
+
+@pytest.fixture
+async def gantry():
+    g = AgentGantry(embedder=SimpleEmbedder(dimension=64))
+
+    @g.register(tags=["email"])
+    def send_email(to: str, body: str = "") -> str:
+        "Send an email message to a recipient."
+        return f"sent:{to}"
+
+    @g.register(tags=["math"])
+    def add(a: int, b: int) -> int:
+        "Add two integers together."
+        return a + b
+
+    await g.sync()
+    return g
+
+
+async def test_spec_to_haystack_builds_native_tool(fake_haystack, gantry):
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+    from agent_gantry.integrations.frameworks.haystack import spec_to_haystack
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    spec = specs[0]
+    tool = spec_to_haystack(spec)
+
+    assert tool.name == spec.name == "send_email"
+    assert (
+        tool.description
+        == spec.description
+        == "Send an email message to a recipient."
+    )
+    assert tool.parameters == spec.parameters
+    assert isinstance(tool.parameters, dict)
+
+    # ``function`` routes through the sync ``spec.invoke`` (which spins its own
+    # event loop), so call it off the test's running loop via a worker thread.
+    result = await asyncio.to_thread(tool.function, to="boss@x.com")
+    assert result == "sent:boss@x.com"
+
+
+async def test_for_haystack_returns_tool_list(fake_haystack, gantry):
+    from agent_gantry.integrations.frameworks.haystack import for_haystack
+
+    tools = await for_haystack(gantry, "send an email", limit=2)
+
+    assert isinstance(tools, list)
+    assert len(tools) >= 1
+    names = {t.name for t in tools}
+    assert "send_email" in names
+
+
+async def test_missing_haystack_raises_helpful_error(monkeypatch, gantry):
+    # Ensure the lazy import fails even if a real package is somehow present.
+    monkeypatch.setitem(sys.modules, "haystack", None)
+    monkeypatch.setitem(sys.modules, "haystack.tools", None)
+
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+    from agent_gantry.integrations.frameworks.haystack import spec_to_haystack
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    with pytest.raises(ImportError, match="pip install haystack-ai"):
+        spec_to_haystack(specs[0])

--- a/tests/frameworks/test_langchain.py
+++ b/tests/frameworks/test_langchain.py
@@ -94,7 +94,11 @@ async def test_for_langchain_returns_tool_list(fake_langchain, gantry):
 
 async def test_missing_langchain_raises_helpful_error(monkeypatch, gantry):
     # Ensure the lazy import fails even if a real package is somehow present.
+    # Null BOTH the parent package and the submodule the adapter imports —
+    # nulling only the parent doesn't force failure when `langchain_core.tools`
+    # is already cached in sys.modules (e.g. langchain-core is installed).
     monkeypatch.setitem(sys.modules, "langchain_core", None)
+    monkeypatch.setitem(sys.modules, "langchain_core.tools", None)
 
     from agent_gantry.integrations.frameworks.base import GantryToolset
     from agent_gantry.integrations.frameworks.langchain import spec_to_langchain

--- a/tests/frameworks/test_langchain.py
+++ b/tests/frameworks/test_langchain.py
@@ -1,0 +1,104 @@
+"""Tests for the LangChain native tool adapter.
+
+LangChain is not installed in this environment, so a minimal fake
+``langchain_core.tools`` module is injected into ``sys.modules`` (cleaned up by
+``monkeypatch.setitem``) to resolve the adapter's lazy import.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+
+class _FakeStructuredTool:
+    """Stand-in for ``langchain_core.tools.StructuredTool``.
+
+    Stores the kwargs passed to ``from_function`` on the instance so tests can
+    assert how the adapter built the tool.
+    """
+
+    def __init__(self, **kwargs):
+        self.func = kwargs.get("func")
+        self.coroutine = kwargs.get("coroutine")
+        self.name = kwargs.get("name")
+        self.description = kwargs.get("description")
+        self.args_schema = kwargs.get("args_schema")
+
+    @classmethod
+    def from_function(cls, **kwargs):
+        return cls(**kwargs)
+
+
+@pytest.fixture
+def fake_langchain(monkeypatch):
+    core = types.ModuleType("langchain_core")
+    tools = types.ModuleType("langchain_core.tools")
+    tools.StructuredTool = _FakeStructuredTool
+    core.tools = tools
+    monkeypatch.setitem(sys.modules, "langchain_core", core)
+    monkeypatch.setitem(sys.modules, "langchain_core.tools", tools)
+    return tools
+
+
+@pytest.fixture
+async def gantry():
+    g = AgentGantry(embedder=SimpleEmbedder(dimension=64))
+
+    @g.register(tags=["email"])
+    def send_email(to: str, body: str = "") -> str:
+        "Send an email message to a recipient."
+        return f"sent:{to}"
+
+    @g.register(tags=["math"])
+    def add(a: int, b: int) -> int:
+        "Add two integers together."
+        return a + b
+
+    await g.sync()
+    return g
+
+
+async def test_spec_to_langchain_builds_native_tool(fake_langchain, gantry):
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+    from agent_gantry.integrations.frameworks.langchain import spec_to_langchain
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    spec = specs[0]
+    tool = spec_to_langchain(spec)
+
+    assert tool.name == spec.name == "send_email"
+    assert tool.description == spec.description == "Send an email message to a recipient."
+    assert tool.args_schema == spec.parameters
+    assert tool.args_schema["properties"]["to"]["type"] == "string"
+
+    # The captured coroutine routes through gantry.execute and returns the result.
+    assert await tool.coroutine(to="boss@x.com") == "sent:boss@x.com"
+
+
+async def test_for_langchain_returns_tool_list(fake_langchain, gantry):
+    from agent_gantry.integrations.frameworks.langchain import for_langchain
+
+    tools = await for_langchain(gantry, "send an email", limit=2)
+
+    assert isinstance(tools, list)
+    assert len(tools) >= 1
+    names = {t.name for t in tools}
+    assert "send_email" in names
+
+
+async def test_missing_langchain_raises_helpful_error(monkeypatch, gantry):
+    # Ensure the lazy import fails even if a real package is somehow present.
+    monkeypatch.setitem(sys.modules, "langchain_core", None)
+
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+    from agent_gantry.integrations.frameworks.langchain import spec_to_langchain
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    with pytest.raises(ImportError, match="pip install langchain-core"):
+        spec_to_langchain(specs[0])

--- a/tests/frameworks/test_langgraph.py
+++ b/tests/frameworks/test_langgraph.py
@@ -1,0 +1,90 @@
+"""Tests for the LangGraph native tool adapter.
+
+LangGraph consumes LangChain ``BaseTool`` objects, so the adapter reuses the
+LangChain wrappers. As with the LangChain tests, a fake ``langchain_core.tools``
+module is injected so the lazy import resolves without the real package.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+
+class _FakeStructuredTool:
+    def __init__(self, **kwargs):
+        self.func = kwargs.get("func")
+        self.coroutine = kwargs.get("coroutine")
+        self.name = kwargs.get("name")
+        self.description = kwargs.get("description")
+        self.args_schema = kwargs.get("args_schema")
+
+    @classmethod
+    def from_function(cls, **kwargs):
+        return cls(**kwargs)
+
+
+@pytest.fixture
+def fake_langchain(monkeypatch):
+    core = types.ModuleType("langchain_core")
+    tools = types.ModuleType("langchain_core.tools")
+    tools.StructuredTool = _FakeStructuredTool
+    core.tools = tools
+    monkeypatch.setitem(sys.modules, "langchain_core", core)
+    monkeypatch.setitem(sys.modules, "langchain_core.tools", tools)
+    return tools
+
+
+@pytest.fixture
+async def gantry():
+    g = AgentGantry(embedder=SimpleEmbedder(dimension=64))
+
+    @g.register(tags=["email"])
+    def send_email(to: str, body: str = "") -> str:
+        "Send an email message to a recipient."
+        return f"sent:{to}"
+
+    @g.register(tags=["math"])
+    def add(a: int, b: int) -> int:
+        "Add two integers together."
+        return a + b
+
+    await g.sync()
+    return g
+
+
+def test_spec_to_langgraph_is_langchain_wrapper():
+    from agent_gantry.integrations.frameworks.langchain import spec_to_langchain
+    from agent_gantry.integrations.frameworks.langgraph import spec_to_langgraph
+
+    assert spec_to_langgraph is spec_to_langchain
+
+
+async def test_spec_to_langgraph_builds_native_tool(fake_langchain, gantry):
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+    from agent_gantry.integrations.frameworks.langgraph import spec_to_langgraph
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    spec = specs[0]
+    tool = spec_to_langgraph(spec)
+
+    assert tool.name == spec.name == "send_email"
+    assert tool.description == spec.description
+    assert tool.args_schema == spec.parameters
+
+    assert await tool.coroutine(to="boss@x.com") == "sent:boss@x.com"
+
+
+async def test_for_langgraph_returns_tool_list(fake_langchain, gantry):
+    from agent_gantry.integrations.frameworks.langgraph import for_langgraph
+
+    tools = await for_langgraph(gantry, "send an email", limit=2)
+
+    assert isinstance(tools, list)
+    assert len(tools) >= 1
+    assert "send_email" in {t.name for t in tools}

--- a/tests/frameworks/test_llamaindex.py
+++ b/tests/frameworks/test_llamaindex.py
@@ -1,0 +1,134 @@
+"""Tests for the LlamaIndex framework adapter.
+
+LlamaIndex is not installed in the test environment, so a minimal fake
+``llama_index.core.tools`` module is injected into ``sys.modules``. The fake
+``FunctionTool`` simply records the kwargs passed to ``from_defaults`` so we can
+assert the adapter wired name/description/callables correctly.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+from agent_gantry.integrations.frameworks.llamaindex import (
+    for_llamaindex,
+    spec_to_llamaindex,
+)
+
+
+@pytest.fixture
+async def gantry() -> AgentGantry:
+    g = AgentGantry(embedder=SimpleEmbedder(dimension=64))
+
+    @g.register(tags=["email"])
+    def send_email(to: str, body: str = "") -> str:
+        "Send an email message to a recipient."
+        return f"sent:{to}"
+
+    @g.register(tags=["math"])
+    def add(a: int, b: int) -> int:
+        "Add two integers together."
+        return a + b
+
+    await g.sync()
+    return g
+
+
+@pytest.fixture
+def fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> type:
+    """Inject a fake ``llama_index.core.tools`` module exposing FunctionTool."""
+
+    class FunctionTool:
+        def __init__(self, **kwargs: object) -> None:
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+        @classmethod
+        def from_defaults(cls, **kwargs: object) -> "FunctionTool":
+            return cls(**kwargs)
+
+    pkg = types.ModuleType("llama_index")
+    core = types.ModuleType("llama_index.core")
+    tools = types.ModuleType("llama_index.core.tools")
+    tools.FunctionTool = FunctionTool
+    core.tools = tools
+    pkg.core = core
+
+    monkeypatch.setitem(sys.modules, "llama_index", pkg)
+    monkeypatch.setitem(sys.modules, "llama_index.core", core)
+    monkeypatch.setitem(sys.modules, "llama_index.core.tools", tools)
+
+    return FunctionTool
+
+
+async def _first_spec(gantry: AgentGantry):
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+
+    specs = await GantryToolset(gantry).select("send an email", limit=5)
+    by_name = {s.name: s for s in specs}
+    assert "send_email" in by_name, f"send_email not selected: {list(by_name)}"
+    return by_name["send_email"]
+
+
+async def test_spec_to_llamaindex_captures_metadata(
+    gantry: AgentGantry, fake_llama_index: type
+) -> None:
+    spec = await _first_spec(gantry)
+    tool = spec_to_llamaindex(spec)
+
+    assert tool.name == "send_email"
+    assert tool.description == "Send an email message to a recipient."
+    assert callable(tool.fn)
+    assert callable(tool.async_fn)
+
+
+async def test_spec_to_llamaindex_async_fn_executes(
+    gantry: AgentGantry, fake_llama_index: type
+) -> None:
+    spec = await _first_spec(gantry)
+    tool = spec_to_llamaindex(spec)
+
+    result = await tool.async_fn(to="boss@x.com")
+    assert result == "sent:boss@x.com"
+
+
+async def test_for_llamaindex_maps_all_specs(
+    gantry: AgentGantry, fake_llama_index: type
+) -> None:
+    tools = await for_llamaindex(gantry, "send an email", limit=5)
+
+    assert len(tools) >= 1
+    names = {t.name for t in tools}
+    assert "send_email" in names
+    for t in tools:
+        assert callable(t.fn)
+        assert callable(t.async_fn)
+
+
+def test_spec_to_llamaindex_missing_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the fake module installed, a helpful ImportError is raised."""
+    for mod in ("llama_index", "llama_index.core", "llama_index.core.tools"):
+        monkeypatch.setitem(sys.modules, mod, None)
+
+    class _DummySpec:
+        name = "x"
+        description = "d"
+
+        def invoke(self, **kwargs: object) -> object:  # pragma: no cover
+            return None
+
+        def callable_for_signature(self):  # pragma: no cover
+            async def _fn(**kwargs: object) -> object:
+                return None
+
+            return _fn
+
+    with pytest.raises(ImportError, match="pip install llama-index-core"):
+        spec_to_llamaindex(_DummySpec())

--- a/tests/frameworks/test_openai_agents.py
+++ b/tests/frameworks/test_openai_agents.py
@@ -1,0 +1,106 @@
+"""Tests for the OpenAI Agents SDK native tool adapter.
+
+The OpenAI Agents SDK is not installed in this environment, so a minimal fake
+``agents`` module is injected into ``sys.modules`` (cleaned up by
+``monkeypatch.setitem``) to resolve the adapter's lazy import.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+
+class _FakeFunctionTool:
+    """Stand-in for ``agents.FunctionTool``.
+
+    Stores the kwargs passed to ``__init__`` so tests can assert how the
+    adapter built the tool.
+    """
+
+    def __init__(self, name=None, description=None, params_json_schema=None, on_invoke_tool=None):
+        self.name = name
+        self.description = description
+        self.params_json_schema = params_json_schema
+        self.on_invoke_tool = on_invoke_tool
+
+
+@pytest.fixture
+def fake_agents(monkeypatch):
+    agents = types.ModuleType("agents")
+    agents.FunctionTool = _FakeFunctionTool
+    monkeypatch.setitem(sys.modules, "agents", agents)
+    return agents
+
+
+@pytest.fixture
+async def gantry():
+    g = AgentGantry(embedder=SimpleEmbedder(dimension=64))
+
+    @g.register(tags=["email"])
+    def send_email(to: str, body: str = "") -> str:
+        "Send an email message to a recipient."
+        return f"sent:{to}"
+
+    @g.register(tags=["math"])
+    def add(a: int, b: int) -> int:
+        "Add two integers together."
+        return a + b
+
+    await g.sync()
+    return g
+
+
+async def test_spec_to_openai_agents_builds_native_tool(fake_agents, gantry):
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+    from agent_gantry.integrations.frameworks.openai_agents import spec_to_openai_agents
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    spec = specs[0]
+    tool = spec_to_openai_agents(spec)
+
+    assert tool.name == spec.name == "send_email"
+    assert tool.description == spec.description == "Send an email message to a recipient."
+
+    # Strict tools must declare additionalProperties: False.
+    assert tool.params_json_schema["additionalProperties"] is False
+    assert tool.params_json_schema["properties"]["to"]["type"] == "string"
+
+    # on_invoke_tool parses a JSON string and routes through gantry.execute.
+    result = await tool.on_invoke_tool(None, '{"to": "boss@x.com"}')
+    assert isinstance(result, str)
+    assert "sent:boss@x.com" in result
+
+    # on_invoke_tool also accepts an already-parsed dict of arguments.
+    result_dict = await tool.on_invoke_tool(None, {"to": "boss@x.com"})
+    assert isinstance(result_dict, str)
+    assert "sent:boss@x.com" in result_dict
+
+
+async def test_for_openai_agents_returns_tool_list(fake_agents, gantry):
+    from agent_gantry.integrations.frameworks.openai_agents import for_openai_agents
+
+    tools = await for_openai_agents(gantry, "send an email", limit=2)
+
+    assert isinstance(tools, list)
+    assert len(tools) >= 1
+    names = {t.name for t in tools}
+    assert "send_email" in names
+    assert all(t.params_json_schema["additionalProperties"] is False for t in tools)
+
+
+async def test_missing_openai_agents_raises_helpful_error(monkeypatch, gantry):
+    # Ensure the lazy import fails even if a real package is somehow present.
+    monkeypatch.setitem(sys.modules, "agents", None)
+
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+    from agent_gantry.integrations.frameworks.openai_agents import spec_to_openai_agents
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    with pytest.raises(ImportError, match="pip install openai-agents"):
+        spec_to_openai_agents(specs[0])

--- a/tests/frameworks/test_pydantic_ai.py
+++ b/tests/frameworks/test_pydantic_ai.py
@@ -1,0 +1,147 @@
+"""Tests for the Pydantic AI native tool adapter.
+
+Pydantic AI is not installed in this environment, so minimal fake ``pydantic_ai``
+and ``pydantic_ai.tools`` modules are injected into ``sys.modules`` (cleaned up
+by ``monkeypatch.setitem``) to resolve the adapter's lazy import. Two stub
+``Tool`` variants are used: one exposing ``from_schema`` (the preferred path) and
+one without it (the fallback path).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+
+class _FakeToolFromSchema:
+    """Stand-in for ``pydantic_ai.tools.Tool`` with a ``from_schema`` builder.
+
+    Stores the kwargs passed to ``from_schema`` on the instance so tests can
+    assert how the adapter built the tool.
+    """
+
+    def __init__(self, **kwargs):
+        self.function = kwargs.get("function")
+        self.name = kwargs.get("name")
+        self.description = kwargs.get("description")
+        self.json_schema = kwargs.get("json_schema")
+
+    @classmethod
+    def from_schema(cls, **kwargs):
+        return cls(**kwargs)
+
+
+class _FakeToolNoSchema:
+    """Stand-in for an older ``Tool`` without ``from_schema``.
+
+    Only supports the function-based constructor used by the fallback path.
+    """
+
+    def __init__(self, function, *, name=None, description=None, takes_ctx=False):
+        self.function = function
+        self.name = name
+        self.description = description
+        self.takes_ctx = takes_ctx
+
+
+def _inject_pydantic_ai(monkeypatch, tool_cls):
+    pkg = types.ModuleType("pydantic_ai")
+    tools = types.ModuleType("pydantic_ai.tools")
+    tools.Tool = tool_cls
+    pkg.tools = tools
+    monkeypatch.setitem(sys.modules, "pydantic_ai", pkg)
+    monkeypatch.setitem(sys.modules, "pydantic_ai.tools", tools)
+    return tools
+
+
+@pytest.fixture
+def fake_pydantic_ai(monkeypatch):
+    return _inject_pydantic_ai(monkeypatch, _FakeToolFromSchema)
+
+
+@pytest.fixture
+def fake_pydantic_ai_no_schema(monkeypatch):
+    return _inject_pydantic_ai(monkeypatch, _FakeToolNoSchema)
+
+
+@pytest.fixture
+async def gantry():
+    g = AgentGantry(embedder=SimpleEmbedder(dimension=64))
+
+    @g.register(tags=["email"])
+    def send_email(to: str, body: str = "") -> str:
+        "Send an email message to a recipient."
+        return f"sent:{to}"
+
+    @g.register(tags=["math"])
+    def add(a: int, b: int) -> int:
+        "Add two integers together."
+        return a + b
+
+    await g.sync()
+    return g
+
+
+async def test_spec_to_pydantic_ai_uses_from_schema(fake_pydantic_ai, gantry):
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+    from agent_gantry.integrations.frameworks.pydantic_ai import spec_to_pydantic_ai
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    spec = specs[0]
+    tool = spec_to_pydantic_ai(spec)
+
+    assert isinstance(tool, _FakeToolFromSchema)
+    assert tool.name == spec.name == "send_email"
+    assert tool.description == spec.description == "Send an email message to a recipient."
+    assert tool.json_schema == spec.parameters
+    assert tool.json_schema["properties"]["to"]["type"] == "string"
+
+    # The captured function routes through gantry.execute and returns the result.
+    assert await tool.function(to="boss@x.com") == "sent:boss@x.com"
+
+
+async def test_spec_to_pydantic_ai_falls_back_without_from_schema(
+    fake_pydantic_ai_no_schema, gantry
+):
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+    from agent_gantry.integrations.frameworks.pydantic_ai import spec_to_pydantic_ai
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    spec = specs[0]
+    tool = spec_to_pydantic_ai(spec)
+
+    assert isinstance(tool, _FakeToolNoSchema)
+    assert tool.name == spec.name == "send_email"
+    assert tool.description == spec.description == "Send an email message to a recipient."
+    assert tool.takes_ctx is False
+
+    assert await tool.function(to="boss@x.com") == "sent:boss@x.com"
+
+
+async def test_for_pydantic_ai_returns_tool_list(fake_pydantic_ai, gantry):
+    from agent_gantry.integrations.frameworks.pydantic_ai import for_pydantic_ai
+
+    tools = await for_pydantic_ai(gantry, "send an email", limit=2)
+
+    assert isinstance(tools, list)
+    assert len(tools) >= 1
+    names = {t.name for t in tools}
+    assert "send_email" in names
+
+
+async def test_missing_pydantic_ai_raises_helpful_error(monkeypatch, gantry):
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+    from agent_gantry.integrations.frameworks.pydantic_ai import spec_to_pydantic_ai
+
+    # Ensure the lazy import fails even if a real package is somehow present.
+    monkeypatch.setitem(sys.modules, "pydantic_ai", None)
+    monkeypatch.setitem(sys.modules, "pydantic_ai.tools", None)
+
+    specs = await GantryToolset(gantry).select("send an email", limit=1)
+    with pytest.raises(ImportError, match="pip install pydantic-ai"):
+        spec_to_pydantic_ai(specs[0])

--- a/tests/frameworks/test_smolagents.py
+++ b/tests/frameworks/test_smolagents.py
@@ -1,0 +1,143 @@
+"""Tests for the smolagents framework adapter.
+
+Smolagents is not installed in the test environment, so a minimal fake
+``smolagents`` module is injected into ``sys.modules``. The fake ``Tool`` base
+class provides the ``__init__`` (setting ``is_initialized``) that the adapter's
+dynamically built subclass relies on, letting us assert the adapter wired
+name / description / inputs / output_type / forward correctly.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+from agent_gantry.integrations.frameworks.smolagents import (
+    for_smolagents,
+    spec_to_smolagents,
+)
+
+
+@pytest.fixture
+async def gantry() -> AgentGantry:
+    g = AgentGantry(embedder=SimpleEmbedder(dimension=64))
+
+    @g.register(tags=["email"])
+    def send_email(to: str, body: str = "") -> str:
+        "Send an email message to a recipient."
+        return f"sent:{to}"
+
+    @g.register(tags=["math"])
+    def add(a: int, b: int) -> int:
+        "Add two integers together."
+        return a + b
+
+    await g.sync()
+    return g
+
+
+@pytest.fixture
+def fake_smolagents(monkeypatch: pytest.MonkeyPatch) -> type:
+    """Inject a fake ``smolagents`` module exposing a minimal ``Tool`` base."""
+
+    class Tool:
+        def __init__(self) -> None:
+            self.is_initialized = True
+
+    module = types.ModuleType("smolagents")
+    module.Tool = Tool
+    monkeypatch.setitem(sys.modules, "smolagents", module)
+    return Tool
+
+
+async def _first_spec(gantry: AgentGantry):
+    from agent_gantry.integrations.frameworks.base import GantryToolset
+
+    specs = await GantryToolset(gantry).select("send an email", limit=5)
+    by_name = {s.name: s for s in specs}
+    assert "send_email" in by_name, f"send_email not selected: {list(by_name)}"
+    return by_name["send_email"]
+
+
+async def test_spec_to_smolagents_captures_metadata(
+    gantry: AgentGantry, fake_smolagents: type
+) -> None:
+    spec = await _first_spec(gantry)
+    tool = spec_to_smolagents(spec)
+
+    assert tool.name == "send_email"
+    assert tool.description == "Send an email message to a recipient."
+    assert tool.output_type == "string"
+    assert tool.is_initialized is True
+
+
+async def test_spec_to_smolagents_inputs_shape(
+    gantry: AgentGantry, fake_smolagents: type
+) -> None:
+    spec = await _first_spec(gantry)
+    tool = spec_to_smolagents(spec)
+
+    assert isinstance(tool.inputs, dict)
+    assert tool.inputs, "inputs should not be empty"
+    for value in tool.inputs.values():
+        assert "type" in value
+        assert "description" in value
+    assert "to" in tool.inputs
+
+
+def test_spec_to_smolagents_forward_executes(fake_smolagents: type) -> None:
+    # ``forward`` routes through the synchronous ``ToolSpec.invoke``, which must
+    # run outside a live event loop — so this test is intentionally non-async and
+    # builds its own gantry rather than using the async ``gantry`` fixture.
+    import asyncio
+
+    async def _build_spec():
+        g = AgentGantry(embedder=SimpleEmbedder(dimension=64))
+
+        @g.register(tags=["email"])
+        def send_email(to: str, body: str = "") -> str:
+            "Send an email message to a recipient."
+            return f"sent:{to}"
+
+        await g.sync()
+        return await _first_spec(g)
+
+    spec = asyncio.run(_build_spec())
+    tool = spec_to_smolagents(spec)
+
+    assert tool.forward(to="boss@x.com") == "sent:boss@x.com"
+
+
+async def test_for_smolagents_maps_all_specs(
+    gantry: AgentGantry, fake_smolagents: type
+) -> None:
+    tools = await for_smolagents(gantry, "send an email", limit=5)
+
+    assert len(tools) >= 1
+    names = {t.name for t in tools}
+    assert "send_email" in names
+    for t in tools:
+        assert t.output_type == "string"
+        assert isinstance(t.inputs, dict)
+
+
+def test_spec_to_smolagents_missing_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the fake module installed, a helpful ImportError is raised."""
+    monkeypatch.setitem(sys.modules, "smolagents", None)
+
+    class _DummySpec:
+        name = "x"
+        description = "d"
+        parameters = {"type": "object", "properties": {}}
+
+        def invoke(self, **kwargs: object) -> object:  # pragma: no cover
+            return None
+
+    with pytest.raises(ImportError, match="pip install smolagents"):
+        spec_to_smolagents(_DummySpec())

--- a/tests/test_query_strategies.py
+++ b/tests/test_query_strategies.py
@@ -547,3 +547,61 @@ async def test_cached_embedder_persists_across_instances(tmp_path):
     assert v3 == [v1[0]]
     assert second.hits == 1 and second.misses == 0
     second.close()
+
+
+# ---------------------------------------------------------------------------
+# latest_activity: recency-aware generator that serves both autonomous and
+# conversational agents (the ToolRefresher default).
+# ---------------------------------------------------------------------------
+
+
+def test_latest_activity_prefers_newest_user_message():
+    """Conversational: the most recent user message drives the query."""
+    from agent_gantry.query import latest_activity
+
+    messages = [
+        {"role": "user", "content": "what's the weather?"},
+        {"role": "assistant", "content": "calling get_weather"},
+        {"role": "tool", "name": "get_weather", "content": "sunny 21C"},
+        {"role": "user", "content": "now send an email to my boss"},
+    ]
+    assert latest_activity(messages) == "now send an email to my boss"
+
+
+def test_latest_activity_uses_tool_result_when_it_is_newest():
+    """Autonomous: with no newer user message, the latest tool result drives it."""
+    from agent_gantry.query import latest_activity
+
+    messages = [
+        {"role": "user", "content": "build a model from the data"},
+        {"role": "assistant", "content": "calling clean_dataset"},
+        {"role": "tool", "name": "clean_dataset", "content": "dataset ready to train a model"},
+    ]
+    # Returns the tool result content (not the older user message).
+    assert latest_activity(messages) == "dataset ready to train a model"
+
+
+def test_latest_activity_skips_empty_assistant_tool_call_stub():
+    """An empty assistant tool-call stub must not blank out the query."""
+    from agent_gantry.query import latest_activity
+
+    messages = [
+        {"role": "user", "content": "summarize this article"},
+        {"role": "assistant", "content": ""},  # tool-call stub, no text
+    ]
+    assert latest_activity(messages) == "summarize this article"
+
+
+def test_latest_activity_truncates_long_tool_result():
+    from agent_gantry.query import latest_activity
+
+    long_result = "x" * 2000
+    messages = [{"role": "tool", "name": "t", "content": long_result}]
+    assert len(latest_activity(messages, max_chars=100)) == 100
+
+
+def test_latest_activity_empty_history():
+    from agent_gantry.query import latest_activity
+
+    assert latest_activity([]) == ""
+    assert latest_activity(None) == ""

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -1,0 +1,163 @@
+"""Tests for the framework-agnostic multi-turn :class:`ToolRefresher`.
+
+These use a *real* gantry with the hash-based :class:`SimpleEmbedder` and five
+tools across clearly distinct domains, then simulate a single agent run as a
+growing list of message dicts whose user intent pivots across turns
+(weather -> email -> currency). The refresher should track those pivots and
+surface a different, on-topic top tool each turn.
+
+SimpleEmbedder is a toy hash-based embedder, so we keep tool descriptions
+unambiguously distinct and assert the expected tool is *within* the returned
+top-k (limit=3) rather than insisting it is strictly rank 1.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_gantry import AgentGantry
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+from agent_gantry.integrations.frameworks.base import ToolSpec
+from agent_gantry.integrations.refresh import ToolRefresher
+
+
+@pytest.fixture
+async def gantry():
+    g = AgentGantry(embedder=SimpleEmbedder(dimension=128))
+
+    @g.register(tags=["weather"])
+    def get_weather(city: str) -> str:
+        "Get the current weather forecast and temperature for a city."
+        return f"weather:{city}"
+
+    @g.register(tags=["email"])
+    def send_email(to: str, body: str = "") -> str:
+        "Send an email message to a recipient mailbox address."
+        return f"email:{to}"
+
+    @g.register(tags=["currency"])
+    def convert_currency(amount: float, source: str, target: str) -> str:
+        "Convert a money amount between currencies using exchange rates."
+        return f"currency:{amount}{source}->{target}"
+
+    @g.register(tags=["todo"])
+    def add_todo(task: str) -> str:
+        "Add a task item to the personal todo list reminder."
+        return f"todo:{task}"
+
+    @g.register(tags=["sql"])
+    def run_sql_query(query: str) -> str:
+        "Execute a SQL database query and return matching table rows."
+        return f"sql:{query}"
+
+    await g.sync()
+    return g
+
+
+def _names(schemas: list[dict]) -> set[str]:
+    """Pull tool names out of OpenAI-dialect schema dicts."""
+    out: set[str] = set()
+    for s in schemas:
+        fn = s.get("function", s)
+        name = fn.get("name") if isinstance(fn, dict) else None
+        if name:
+            out.add(name)
+    return out
+
+
+async def test_refresh_pivots_with_changing_intent(gantry):
+    """As the conversation pivots, refresh() surfaces the matching tool."""
+    refresher = ToolRefresher(gantry, limit=3, dialect="openai")
+
+    # Turn 1: weather.
+    messages = [
+        {"role": "user", "content": "What is the weather forecast in Paris today?"}
+    ]
+    turn1 = await refresher.refresh(messages)
+    assert "get_weather" in _names(turn1)
+
+    # Turn 2: pivot to sending an email.
+    messages += [
+        {"role": "assistant", "content": "It is sunny in Paris."},
+        {"role": "user", "content": "Now send an email message to my boss."},
+    ]
+    turn2 = await refresher.refresh(messages)
+    assert "send_email" in _names(turn2)
+
+    # Turn 3: pivot to currency conversion.
+    messages += [
+        {"role": "assistant", "content": "Email sent."},
+        {
+            "role": "user",
+            "content": "Convert 100 dollars to euros using the exchange rate.",
+        },
+    ]
+    turn3 = await refresher.refresh(messages)
+    assert "convert_currency" in _names(turn3)
+
+    # The selection genuinely changed across turns (direction-changing).
+    assert _names(turn1) != _names(turn2)
+    assert _names(turn2) != _names(turn3)
+
+
+async def test_tools_used_accumulates_across_turns(gantry):
+    """tools_used accumulates as tool-role messages are appended."""
+    refresher = ToolRefresher(gantry, limit=3, track_used=True)
+
+    messages = [{"role": "user", "content": "What is the weather in Paris?"}]
+    await refresher.refresh(messages)
+    assert refresher.tools_used == []
+
+    # Append a tool-role result for the weather tool.
+    messages += [
+        {"role": "tool", "name": "get_weather", "content": "sunny, 21C"},
+        {"role": "user", "content": "Now send an email to my boss."},
+    ]
+    await refresher.refresh(messages)
+    assert refresher.tools_used == ["get_weather"]
+
+    # Append another tool result for the email tool.
+    messages += [
+        {"role": "tool", "name": "send_email", "content": "delivered"},
+        {"role": "user", "content": "Convert 100 dollars to euros."},
+    ]
+    await refresher.refresh(messages)
+    assert refresher.tools_used == ["get_weather", "send_email"]
+
+
+async def test_track_used_disabled_keeps_empty(gantry):
+    """With track_used=False, tools_used stays empty despite tool messages."""
+    refresher = ToolRefresher(gantry, limit=3, track_used=False)
+    messages = [
+        {"role": "user", "content": "What is the weather in Paris?"},
+        {"role": "tool", "name": "get_weather", "content": "sunny"},
+    ]
+    await refresher.refresh(messages)
+    assert refresher.tools_used == []
+
+
+async def test_refresh_returns_dialect_schemas(gantry):
+    """refresh() returns a list of dialect schema dicts."""
+    refresher = ToolRefresher(gantry, limit=3, dialect="openai")
+    messages = [{"role": "user", "content": "Run a SQL database query for rows."}]
+    schemas = await refresher.refresh(messages)
+
+    assert isinstance(schemas, list)
+    assert schemas
+    assert all(isinstance(s, dict) for s in schemas)
+    assert "run_sql_query" in _names(schemas)
+
+
+async def test_refresh_specs_returns_toolspecs(gantry):
+    """refresh_specs() returns ToolSpec objects and sets last_selection."""
+    refresher = ToolRefresher(gantry, limit=3)
+    messages = [{"role": "user", "content": "Add a task to my todo list reminder."}]
+    specs = await refresher.refresh_specs(messages)
+
+    assert isinstance(specs, list)
+    assert specs
+    assert all(isinstance(s, ToolSpec) for s in specs)
+    assert "add_todo" in {s.name for s in specs}
+
+    # last_selection mirrors the most recent specs.
+    assert {s.name for s in refresher.last_selection} == {s.name for s in specs}


### PR DESCRIPTION
- memory store: replace per-tool pure-Python cosine loop with a cached,
  L2-normalized NumPy matrix scored in a single matmul; ~36x faster at 50
  tools and ~59x at 1000 (numpy already a core dep, behavior-preserving)
- add benchmarks/benchmark_tool_selection.py: top-3-of-50 quality
  (top1 0.889, hit@3 1.0, MRR 0.94, ~93% token savings on MiniLM)
- add benchmarks/benchmark_multi_turn.py: direction-changing tool
  selection within one agent run (7 distinct tools, pivots every turn)
- add benchmarks/benchmark_memory_store.py + benchmarks/README.md
- add docs/REVIEW_AGENT_FRAMEWORKS_2026-06-14.md: framework status,
  gaps, perf findings, and the score_threshold=0.5 / **kwargs traps

https://claude.ai/code/session_01QFWSo7EE2kivy7kWArLGLX