### PR TITLE
🎨 Palette: Cleanup tabindex on blur after smooth scroll

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -96,3 +96,7 @@
 ## 2026-05-32 - [Skip to Content Focus Targets]
 **Learning:** Adding a "Skip to main content" link at the top of the document is a best practice for accessibility, but it only partially works if the target element (usually `<main id="main-content">`) is not programmatically focusable. When clicked or activated via keyboard, the browser scrolls to the target, but keyboard focus stays on the skip link itself, causing the user to start tabbing through the very navigation they were trying to bypass.
 **Action:** When creating skip links, always ensure the target element has `tabindex="-1"`. This allows the browser to shift programmatic focus to the content area so subsequent `Tab` keystrokes continue from the main content.
+
+## 2026-05-33 - [Cleanup Tabindex on Smooth Scroll Blur]
+**Learning:** When intercepting anchor clicks with `e.preventDefault()` to apply programmatic smooth scrolling, manually moving focus to the target element (`target.focus()`) requires temporarily setting `tabindex="-1"`. If this attribute is not removed when the element loses focus, it permanently alters the element's focusability state, which can negatively impact accessibility and standard tab ordering for interactive elements.
+**Action:** When temporarily adding `tabindex="-1"` to manage focus during smooth scrolling, always attach a `blur` event listener to the target element (using `{ once: true }`) that calls `removeAttribute("tabindex")` to clean up the DOM state.

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -118,6 +118,10 @@
           // Update focus for accessibility
           target.setAttribute("tabindex", "-1");
           target.focus({ preventScroll: true });
+
+          target.addEventListener("blur", function () {
+            target.removeAttribute("tabindex");
+          }, { once: true });
         }
       });
     });


### PR DESCRIPTION
💡 What: Added a 'blur' event listener to target elements during smooth scrolling to remove the temporarily added 'tabindex="-1"' attribute.
🎯 Why: To prevent permanently altering the focusability state of target elements, ensuring the DOM stays clean and standard tab ordering is preserved for interactive elements after focus is moved away.
📸 Before/After: N/A (non-visual change)
♿ Accessibility: Ensures interactive elements that were targets of smooth scrolling don't get stuck with a negative tabindex, preventing potential focus issues for keyboard users.

---
*PR created automatically by Jules for task [8765097861903712940](https://jules.google.com/task/8765097861903712940) started by @CodeHalwell*