### PR TITLE
v0.6.0: Refresh skill docs and add --claude install flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Bundled Claude Skill refreshed for v0.5.0** (`agent_gantry/skills/agent-gantry/SKILL.md`):
+  rewrote the framework integration guidance around the native `for_<framework>`
+  adapters and clean per-framework import namespaces (`from agent_gantry.langchain
+  import for_langchain`), added the five frameworks introduced in 0.5.0 (Pydantic AI,
+  OpenAI Agents SDK, Smolagents, Haystack, Agno), documented the deep per-turn "live"
+  providers and the `ToolRefresher` multi-turn API, and corrected the stale
+  `fetch_framework_tools` examples (the previous `framework="langchain"/"autogen"/
+  "llamaindex"` names were never valid and now point at the schema-only adapter's real
+  name set). Frontmatter still follows the Anthropic Agent Skills format
+  (`name`/`description` only). Skill trigger description expanded to the new frameworks.
+
+### Added
+
+- **`agent-gantry install-skill --claude`** installs the bundled skill straight into
+  `~/.claude/skills` so Claude Code discovers it with no further wiring (previously the
+  command only supported `--target <dir>`).
+
 ## [0.5.0] - 2026-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-15
+
 ### Changed
 
-- **Bundled Claude Skill refreshed for v0.5.0** (`agent_gantry/skills/agent-gantry/SKILL.md`):
+- **Bundled Claude Skill refreshed for the v0.5.0+ API surface** (`agent_gantry/skills/agent-gantry/SKILL.md`):
   rewrote the framework integration guidance around the native `for_<framework>`
   adapters and clean per-framework import namespaces (`from agent_gantry.langchain
   import for_langchain`), added the five frameworks introduced in 0.5.0 (Pydantic AI,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   name set). Frontmatter still follows the Anthropic Agent Skills format
   (`name`/`description` only). Skill trigger description expanded to the new frameworks.
 
+- **Install/usage instructions now lead with uv** (with pip kept as an explicit
+  fallback) across the bundled skill, `README.md`, and the `skill_path()` error hint —
+  `uv add "agent-gantry[...]"` for dependencies and `uv run agent-gantry ...` for the CLI.
+
 ### Added
 
 - **`agent-gantry install-skill --claude`** installs the bundled skill straight into

--- a/README.md
+++ b/README.md
@@ -18,14 +18,20 @@ Agent-Gantry is a Python library and service for intelligent, secure tool orches
 
 ## Installation
 
+Agent-Gantry uses **uv** as its package manager, with `pip` as a supported fallback.
+
 ```bash
+uv add agent-gantry          # in a uv project
+# or, ad-hoc / outside a project:
+uv pip install agent-gantry
+# fallback without uv:
 pip install agent-gantry
 ```
 
 For development:
 
 ```bash
-pip install agent-gantry[dev]
+uv add "agent-gantry[dev]"   # fallback: pip install "agent-gantry[dev]"
 ```
 
 ### Optional: install the bundled Claude Skill
@@ -33,8 +39,9 @@ pip install agent-gantry[dev]
 Agent-Gantry ships a Claude Skill — a self-contained reference following the [Anthropic Agent Skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview) format that an agent can read to learn the library — bundled inside the wheel. Install it with one command:
 
 ```bash
-agent-gantry install-skill --claude        # → ~/.claude/skills (Claude Code finds it automatically)
-agent-gantry install-skill --target ./skills   # → a project-local skills/ dir
+uv run agent-gantry install-skill --claude        # → ~/.claude/skills (Claude Code finds it automatically)
+uv run agent-gantry install-skill --target ./skills   # → a project-local skills/ dir
+# fallback without uv: drop the `uv run` prefix once agent-gantry is on PATH
 ```
 
 `--claude` drops `agent-gantry/` into Claude's personal skills directory so Claude Code discovers it with no further wiring. `--target` drops a `skills/agent-gantry/` directory wherever you point it — wire that into an AF agent via `SkillsProvider(skill_paths=["./skills"])`. To use the bundled copy in place without copying:
@@ -48,39 +55,39 @@ The skill covers every integration (Microsoft Agent Framework, plus native adapt
 
 ### LLM Provider SDKs
 
-Install with specific LLM provider support:
+Install with specific LLM provider support (uv shown; swap `uv add` for `pip install` as a fallback):
 
 ```bash
 # All LLM providers
-pip install agent-gantry[llm-providers]
+uv add "agent-gantry[llm-providers]"
 
 # Individual providers
-pip install agent-gantry[openai]        # OpenAI, Azure OpenAI, OpenRouter
-pip install agent-gantry[anthropic]     # Anthropic (Claude)
-pip install agent-gantry[google-genai]  # Google GenAI
-pip install agent-gantry[google-vertexai]  # Google Vertex AI
-pip install agent-gantry[mistral]       # Mistral AI
-pip install agent-gantry[groq]          # Groq
+uv add "agent-gantry[openai]"        # OpenAI, Azure OpenAI, OpenRouter
+uv add "agent-gantry[anthropic]"     # Anthropic (Claude)
+uv add "agent-gantry[google-genai]"  # Google GenAI
+uv add "agent-gantry[google-vertexai]"  # Google Vertex AI
+uv add "agent-gantry[mistral]"       # Mistral AI
+uv add "agent-gantry[groq]"          # Groq
 
 # Everything
-pip install agent-gantry[all]
+uv add "agent-gantry[all]"
 ```
 
 See [docs/llm_sdk_compatibility.md](docs/llm_sdk_compatibility.md) for detailed provider documentation.
 
 ### Optional components
 
-- **Vector stores**: `pip install agent-gantry[vector-stores]` (Qdrant/Chroma stubs)
-- **Local persistence (LanceDB)**: `pip install agent-gantry[lancedb]`
-- **Local embeddings (Nomic Matryoshka)**: `pip install agent-gantry[nomic]`
-- **Agent framework integrations**: `pip install agent-gantry[agent-frameworks]` (LangChain, AutoGen, CrewAI, LlamaIndex, Semantic Kernel, etc.)
-- **Example extras**: `pip install agent-gantry[example-tools]` for optional libraries used by the example scripts
-- **Protocols**: `pip install agent-gantry[mcp]` and `pip install agent-gantry[a2a]`
+- **Vector stores**: `uv add "agent-gantry[vector-stores]"` (Qdrant/Chroma stubs)
+- **Local persistence (LanceDB)**: `uv add "agent-gantry[lancedb]"`
+- **Local embeddings (Nomic Matryoshka)**: `uv add "agent-gantry[nomic]"`
+- **Agent framework integrations**: `uv add "agent-gantry[agent-frameworks]"` (LangChain, AutoGen, CrewAI, LlamaIndex, Semantic Kernel, etc.)
+- **Example extras**: `uv add "agent-gantry[example-tools]"` for optional libraries used by the example scripts
+- **Protocols**: `uv add "agent-gantry[mcp]"` and `uv add "agent-gantry[a2a]"`
 
 Combine as needed, e.g.:
 
 ```bash
-pip install agent-gantry[lancedb,nomic,mcp,a2a]
+uv add "agent-gantry[lancedb,nomic,mcp,a2a]"   # fallback: pip install "agent-gantry[lancedb,nomic,mcp,a2a]"
 ```
 
 ## Quick Start: The "Plug and Play" Experience
@@ -303,8 +310,8 @@ decision = await provider.dry_run_retrieve("the user's actual query")
 For registry-level mistakes — descriptions that name other tools, near-duplicate tools, overly generic tags — run the linter:
 
 ```bash
-agent-gantry lint
-agent-gantry sim factorial fibonacci   # cosine similarity between two tools
+uv run agent-gantry lint
+uv run agent-gantry sim factorial fibonacci   # cosine similarity between two tools
 ```
 
 ### Robust score thresholds for long queries
@@ -623,7 +630,7 @@ tools = await gantry.retrieve_tools("read my config.yaml")
 > server metadata, `sync_mcp_servers()` / `retrieve_mcp_servers()` run real semantic search over
 > registered servers, and `discover_tools_from_server()` connects on demand and registers the
 > discovered tools into the registry so `retrieve_tools()` finds them. Requires the `mcp` extra
-> (`pip install agent-gantry[mcp]`). See the dynamic MCP selection docs for details.
+> (`uv add "agent-gantry[mcp]"`, or `pip install "agent-gantry[mcp]"`). See the dynamic MCP selection docs for details.
 
 **Benefits:**
 - 🎯 **Semantic Routing**: Automatically finds relevant servers based on query context
@@ -751,15 +758,15 @@ See `examples/a2a_integration_demo.py` for a complete demonstration.
 
 ## CLI
 
-A lightweight CLI ships with the package for quick inspection and diagnostics:
+A lightweight CLI ships with the package for quick inspection and diagnostics. Inside a uv project, prefix with `uv run`; drop the prefix when `agent-gantry` is already on `PATH`:
 
 ```bash
-agent-gantry list                              # list registered tools
-agent-gantry search "refund an order" --limit 3
-agent-gantry lint                              # detect tool-description authoring mistakes
-agent-gantry sim factorial fibonacci           # cosine similarity between two tools
-agent-gantry sync --dry-run                    # which tools would (re-)embed and why
-agent-gantry install-skill --claude            # install the bundled Claude Skill into ~/.claude/skills
+uv run agent-gantry list                              # list registered tools
+uv run agent-gantry search "refund an order" --limit 3
+uv run agent-gantry lint                              # detect tool-description authoring mistakes
+uv run agent-gantry sim factorial fibonacci           # cosine similarity between two tools
+uv run agent-gantry sync --dry-run                    # which tools would (re-)embed and why
+uv run agent-gantry install-skill --claude            # install the bundled Claude Skill into ~/.claude/skills
 ```
 
 `lint` flags three patterns that silently degrade routing quality: tool descriptions that name *other* registered tools (the embedding pulls them toward the wrong queries), pairs of tools with >0.85 cosine similarity (probably should be merged or differentiated), and tags that appear on more than half the registry (low discriminative value). Exit code is `1` when any issues are flagged, `0` when the registry is clean — so it drops into any CI runner that respects exit codes.

--- a/README.md
+++ b/README.md
@@ -30,20 +30,21 @@ pip install agent-gantry[dev]
 
 ### Optional: install the bundled Claude Skill
 
-Agent-Gantry ships a Claude Skill — a self-contained reference an agent can read to learn the library — bundled inside the wheel. Install it next to your other skills with one command:
+Agent-Gantry ships a Claude Skill — a self-contained reference following the [Anthropic Agent Skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview) format that an agent can read to learn the library — bundled inside the wheel. Install it with one command:
 
 ```bash
-agent-gantry install-skill --target ./skills
+agent-gantry install-skill --claude        # → ~/.claude/skills (Claude Code finds it automatically)
+agent-gantry install-skill --target ./skills   # → a project-local skills/ dir
 ```
 
-This drops a `skills/agent-gantry/` directory in your project. Wire it into an AF agent via `SkillsProvider(skill_paths=["./skills"])` or point Claude Code at it directly. To use the bundled copy without copying:
+`--claude` drops `agent-gantry/` into Claude's personal skills directory so Claude Code discovers it with no further wiring. `--target` drops a `skills/agent-gantry/` directory wherever you point it — wire that into an AF agent via `SkillsProvider(skill_paths=["./skills"])`. To use the bundled copy in place without copying:
 
 ```python
 from agent_gantry.skills import skill_path
 print(skill_path())  # /…/site-packages/agent_gantry/skills/agent-gantry
 ```
 
-The skill covers each integration (Microsoft Agent Framework, LangChain, AutoGen, CrewAI, LlamaIndex, Semantic Kernel, Google ADK, plain SDK use), the new introspection APIs, and a debugging playbook.
+The skill covers every integration (Microsoft Agent Framework, plus native adapters for LangChain, LangGraph, LlamaIndex, CrewAI, Pydantic AI, OpenAI Agents SDK, Smolagents, Haystack, Agno, AutoGen, Semantic Kernel, Google ADK, and plain SDK use), the `ToolRefresher` multi-turn API, the introspection APIs, and a debugging playbook.
 
 ### LLM Provider SDKs
 
@@ -758,7 +759,7 @@ agent-gantry search "refund an order" --limit 3
 agent-gantry lint                              # detect tool-description authoring mistakes
 agent-gantry sim factorial fibonacci           # cosine similarity between two tools
 agent-gantry sync --dry-run                    # which tools would (re-)embed and why
-agent-gantry install-skill --target ./skills   # install the bundled Claude Skill
+agent-gantry install-skill --claude            # install the bundled Claude Skill into ~/.claude/skills
 ```
 
 `lint` flags three patterns that silently degrade routing quality: tool descriptions that name *other* registered tools (the embedding pulls them toward the wrong queries), pairs of tools with >0.85 cosine similarity (probably should be merged or differentiated), and tags that appear on more than half the registry (low discriminative value). Exit code is `1` when any issues are flagged, `0` when the registry is clean — so it drops into any CI runner that respects exit codes.

--- a/agent_gantry/__init__.py
+++ b/agent_gantry/__init__.py
@@ -52,7 +52,7 @@ def disable_af_instrumentation() -> bool:
     return _impl()
 
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __all__ = [
     "AgentGantry",
     "GantryContextProvider",

--- a/agent_gantry/cli/main.py
+++ b/agent_gantry/cli/main.py
@@ -91,12 +91,13 @@ def main(argv: list[str] | None = None) -> int:
         "install-skill",
         help="Install the bundled Agent-Gantry Claude Skill into a target directory",
     )
-    skill_parser.add_argument(
+    skill_dest = skill_parser.add_mutually_exclusive_group()
+    skill_dest.add_argument(
         "--target",
         default="./skills",
-        help="Destination directory (default: ./skills). Ignored when --claude is set.",
+        help="Destination directory (default: ./skills).",
     )
-    skill_parser.add_argument(
+    skill_dest.add_argument(
         "--claude",
         action="store_true",
         help="Install into Claude's personal skills directory (~/.claude/skills) "

--- a/agent_gantry/cli/main.py
+++ b/agent_gantry/cli/main.py
@@ -11,6 +11,11 @@ import sys
 from agent_gantry import AgentGantry
 from agent_gantry.schema.query import ConversationContext, ToolQuery
 
+# Default skill install target, and Claude Code's personal skills directory
+# (searched at startup). install_to() expands the leading ~ via Path.expanduser().
+_DEFAULT_SKILL_TARGET = "./skills"
+_CLAUDE_SKILLS_DIR = "~/.claude/skills"
+
 
 def _load_demo_tools(gantry: AgentGantry) -> None:
     """Register a small set of demo tools for CLI usage."""
@@ -94,13 +99,14 @@ def main(argv: list[str] | None = None) -> int:
     skill_dest = skill_parser.add_mutually_exclusive_group()
     skill_dest.add_argument(
         "--target",
-        default="./skills",
-        help="Destination directory (default: ./skills). Mutually exclusive with --claude.",
+        default=None,
+        help=f"Destination directory (default: {_DEFAULT_SKILL_TARGET}). "
+        "Mutually exclusive with --claude.",
     )
     skill_dest.add_argument(
         "--claude",
         action="store_true",
-        help="Install into Claude's personal skills directory (~/.claude/skills) "
+        help=f"Install into Claude's personal skills directory ({_CLAUDE_SKILLS_DIR}) "
         "so Claude Code discovers it automatically.",
     )
     skill_parser.add_argument(
@@ -183,10 +189,7 @@ def main(argv: list[str] | None = None) -> int:
             except FileNotFoundError as exc:
                 print(f"error: {exc}", file=sys.stderr)
                 return 2
-        # --target keeps its "./skills" default even when --claude is set
-        # (argparse always applies defaults), so branch on --claude explicitly.
-        # install_to() expands the leading ~ via Path.expanduser().
-        target = "~/.claude/skills" if args.claude else args.target
+        target = _CLAUDE_SKILLS_DIR if args.claude else (args.target or _DEFAULT_SKILL_TARGET)
         try:
             dst = install_to(target, overwrite=args.overwrite)
         except FileExistsError as exc:

--- a/agent_gantry/cli/main.py
+++ b/agent_gantry/cli/main.py
@@ -183,6 +183,9 @@ def main(argv: list[str] | None = None) -> int:
             except FileNotFoundError as exc:
                 print(f"error: {exc}", file=sys.stderr)
                 return 2
+        # --target keeps its "./skills" default even when --claude is set
+        # (argparse always applies defaults), so branch on --claude explicitly.
+        # install_to() expands the leading ~ via Path.expanduser().
         target = "~/.claude/skills" if args.claude else args.target
         try:
             dst = install_to(target, overwrite=args.overwrite)

--- a/agent_gantry/cli/main.py
+++ b/agent_gantry/cli/main.py
@@ -94,12 +94,18 @@ def main(argv: list[str] | None = None) -> int:
     skill_parser.add_argument(
         "--target",
         default="./skills",
-        help="Destination directory (default: ./skills).",
+        help="Destination directory (default: ./skills). Ignored when --claude is set.",
+    )
+    skill_parser.add_argument(
+        "--claude",
+        action="store_true",
+        help="Install into Claude's personal skills directory (~/.claude/skills) "
+        "so Claude Code discovers it automatically.",
     )
     skill_parser.add_argument(
         "--overwrite",
         action="store_true",
-        help="Replace an existing agent-gantry directory in --target.",
+        help="Replace an existing agent-gantry directory in the target.",
     )
     skill_parser.add_argument(
         "--print-path",
@@ -176,8 +182,9 @@ def main(argv: list[str] | None = None) -> int:
             except FileNotFoundError as exc:
                 print(f"error: {exc}", file=sys.stderr)
                 return 2
+        target = "~/.claude/skills" if args.claude else args.target
         try:
-            dst = install_to(args.target, overwrite=args.overwrite)
+            dst = install_to(target, overwrite=args.overwrite)
         except FileExistsError as exc:
             print(f"error: {exc}", file=sys.stderr)
             print("  Re-run with --overwrite to replace.", file=sys.stderr)

--- a/agent_gantry/cli/main.py
+++ b/agent_gantry/cli/main.py
@@ -95,7 +95,7 @@ def main(argv: list[str] | None = None) -> int:
     skill_dest.add_argument(
         "--target",
         default="./skills",
-        help="Destination directory (default: ./skills).",
+        help="Destination directory (default: ./skills). Mutually exclusive with --claude.",
     )
     skill_dest.add_argument(
         "--claude",

--- a/agent_gantry/skills/__init__.py
+++ b/agent_gantry/skills/__init__.py
@@ -49,7 +49,8 @@ def skill_path() -> Path:
             f"Agent-Gantry skill directory not found at {path!s}. "
             "This usually means the package was installed from a source "
             "tree that doesn't include skills/. Reinstall via "
-            "'pip install agent-gantry' to get the bundled skill."
+            "'uv add agent-gantry' (or 'pip install agent-gantry') to get "
+            "the bundled skill."
         )
     return path
 

--- a/agent_gantry/skills/agent-gantry/SKILL.md
+++ b/agent_gantry/skills/agent-gantry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-gantry
-description: Use this skill when the user is writing or debugging code that uses the `agent-gantry` Python library (semantic tool routing for LLM agents). Triggers on `import agent_gantry`, mentions of `AgentGantry`, `GantryContextProvider`, `GantryToolBridge`, `gantry.register`, `with_semantic_tools`, tool retrieval / surfacing problems with Microsoft Agent Framework, LangChain, AutoGen, CrewAI, LlamaIndex, Semantic Kernel, Google ADK, A2A, or MCP. Use proactively when the code imports `agent_gantry` even if the user did not explicitly invoke the skill.
+description: Use this skill when the user is writing or debugging code that uses the `agent-gantry` Python library (semantic tool routing for LLM agents). Triggers on `import agent_gantry`, mentions of `AgentGantry`, `GantryContextProvider`, `GantryToolBridge`, `gantry.register`, `with_semantic_tools`, `for_langchain`/`for_crewai`/other `for_<framework>` adapters, `ToolRefresher`, or tool retrieval / surfacing problems with Microsoft Agent Framework, LangChain, LangGraph, AutoGen, CrewAI, LlamaIndex, Pydantic AI, OpenAI Agents SDK, Smolagents, Haystack, Agno, Semantic Kernel, Google ADK, A2A, or MCP. Use proactively when the code imports `agent_gantry` even if the user did not explicitly invoke the skill.
 ---
 
 # Agent-Gantry
@@ -14,16 +14,30 @@ This skill is the canonical reference for using the library. Read the section th
 | User's framework | API to use | Section |
 |---|---|---|
 | Microsoft Agent Framework (AF 1.x) | `GantryContextProvider` (dynamic, per-turn or per-call) or `GantryToolBridge` (static) | [Microsoft Agent Framework](#microsoft-agent-framework) |
-| LangChain / LangGraph | `fetch_framework_tools(..., framework="langchain")` then pass to `bind_tools` | [LangChain](#langchain--langgraph) |
-| AutoGen | `fetch_framework_tools(..., framework="autogen")` | [AutoGen](#autogen) |
-| CrewAI | `fetch_framework_tools(..., framework="crewai")` | [CrewAI](#crewai) |
-| LlamaIndex | `fetch_framework_tools(..., framework="llamaindex")` | [LlamaIndex](#llamaindex) |
-| Semantic Kernel | `fetch_framework_tools(..., framework="semantic_kernel")` | [Semantic Kernel](#semantic-kernel) |
-| Google ADK | `fetch_framework_tools(..., framework="google_adk")` | [Google ADK](#google-adk) |
+| LangChain | `for_langchain(gantry, query, limit=...)` → `bind_tools` | [Native framework adapters](#native-framework-adapters) |
+| LangGraph | `for_langgraph(...)` (static) or `create_gantry_react_agent(...)` (live) | [Native framework adapters](#native-framework-adapters) |
+| LlamaIndex | `for_llamaindex(...)` (static) or `gantry_function_agent(...)` (live) | [Native framework adapters](#native-framework-adapters) |
+| CrewAI | `for_crewai(...)` | [Native framework adapters](#native-framework-adapters) |
+| Pydantic AI | `for_pydantic_ai(...)` (static) or `gantry_toolset(...)` (live) | [Native framework adapters](#native-framework-adapters) |
+| OpenAI Agents SDK | `for_openai_agents(...)` (static) or `run_with_gantry(...)` (live) | [Native framework adapters](#native-framework-adapters) |
+| Smolagents | `for_smolagents(...)` | [Native framework adapters](#native-framework-adapters) |
+| Haystack | `for_haystack(...)` | [Native framework adapters](#native-framework-adapters) |
+| Agno | `for_agno(...)` | [Native framework adapters](#native-framework-adapters) |
+| AutoGen / AG2 | `for_autogen(...)` / `register_with_autogen(...)` (static) or `gantry_workbench(...)` (live) | [Native framework adapters](#native-framework-adapters) |
+| Semantic Kernel | `for_semantic_kernel(...)` / `gantry_plugin(...)` | [Native framework adapters](#native-framework-adapters) |
+| Google ADK | `for_google_adk(...)` (static) or `gantry_adk_agent(...)` (live) | [Native framework adapters](#native-framework-adapters) |
+| Any framework, re-select every turn | `ToolRefresher(gantry).refresh(messages)` | [Multi-turn re-selection](#multi-turn-re-selection-toolrefresher) |
 | Plain OpenAI / Anthropic / Gemini SDK | `@with_semantic_tools(dialect=...)` decorator | [LLM-SDK direct](#llm-sdk-direct) |
 | MCP server (expose Gantry as MCP) | `gantry.serve_mcp(mode="dynamic")` | [MCP](#mcp) |
 | A2A (expose Gantry as an A2A agent) | `gantry.serve_a2a(...)` | [A2A](#a2a) |
 | CLI inspection / linting | `agent-gantry lint / sim / sync --dry-run` | [CLI](#cli) |
+
+> **Native adapters vs. `fetch_framework_tools`.** As of v0.5.0 the per-framework
+> `for_<fw>()` helpers return the framework's **native tool objects** (e.g. a
+> LangChain `StructuredTool`, a CrewAI `BaseTool`), with execution routed through
+> `gantry.execute` (retries, timeouts, circuit breakers, security policy). Prefer
+> these. `fetch_framework_tools` still exists but only emits OpenAI-shape JSON
+> schemas and supports a smaller name set — see [its note](#schema-only-adapter-fetch_framework_tools).
 
 ## Core concepts (read first)
 
@@ -31,7 +45,9 @@ This skill is the canonical reference for using the library. Read the section th
 
 2. **`await gantry.sync()` embeds every tool.** Fingerprint-based change detection means only modified tools re-embed on subsequent calls. With paid embedders, wrap the embedder in `CachedEmbedder` to persist across cold starts.
 
-3. **`gantry.retrieve(...)` returns a `RetrievalResult`.** That's the universal API. The high-level integrations (`GantryContextProvider`, `GantryToolBridge`, `fetch_framework_tools`, `@with_semantic_tools`) are thin wrappers around it that emit framework-specific schema shapes.
+3. **`gantry.retrieve(...)` returns a `RetrievalResult`.** That's the universal API. The high-level integrations (`GantryContextProvider`, `GantryToolBridge`, the `for_<fw>` native adapters, `ToolRefresher`, `@with_semantic_tools`) are thin wrappers around it that emit framework-specific shapes.
+
+   Every native adapter is `for_<fw>(gantry, query, *, limit=3, **select_kwargs)` and shares the same selection knobs (`score_threshold`, `namespaces`, `tools_already_used`). Import it from the clean per-framework namespace — `from agent_gantry.langchain import for_langchain`. Importing `agent_gantry` never pulls in any third-party framework; the import is lazy and raises a `pip install ...` hint only when you call the adapter.
 
 4. **`score_threshold` is opt-in filtering.** Default is `0.0` (no filtering). Use `score_threshold="relative:0.8"` for length-robust filtering — that keeps anything within 80% of the top score. Fixed absolute cutoffs degrade badly on long, instruction-style queries because the embedding gets diluted.
 
@@ -197,90 +213,98 @@ agent = Agent(
 )
 ```
 
-## LangChain / LangGraph
+## Native framework adapters
+
+For LangChain, LangGraph, LlamaIndex, CrewAI, Pydantic AI, OpenAI Agents SDK, Smolagents, Haystack, Agno, AutoGen/AG2, Semantic Kernel, and Google ADK, use the native `for_<fw>` adapter. It selects the top-K relevant tools and returns the framework's **native tool objects**, with every call still routed through `gantry.execute`.
 
 ```python
-from langchain_openai import ChatOpenAI
 from agent_gantry import AgentGantry
-from agent_gantry.integrations import fetch_framework_tools
+from agent_gantry.langchain import for_langchain     # clean per-framework namespace
 
 gantry = AgentGantry()
 # ... register tools, await gantry.sync() ...
 
-tools = await fetch_framework_tools(
-    gantry, "search the web for X", framework="langchain", limit=5
-)
-
-llm = ChatOpenAI(model="gpt-5.5").bind_tools(tools)
-response = await llm.ainvoke("...")
+tools = await for_langchain(gantry, "email the quarterly report to finance", limit=3)
+# hand `tools` straight to a LangChain agent / ChatModel.bind_tools(tools)
 ```
 
-LangGraph: build the tools the same way, then add them to the graph's `ToolNode` or pass to `create_react_agent(llm, tools)`.
+Every adapter has the identical signature `for_<fw>(gantry, query, *, limit=3, **select_kwargs)` and the same per-framework namespace (`agent_gantry.<framework>`):
 
-## AutoGen
+| Framework | Static adapter | Native object | Namespace import |
+|---|---|---|---|
+| LangChain | `for_langchain` | `StructuredTool` | `from agent_gantry.langchain import for_langchain` |
+| LangGraph | `for_langgraph` | LangChain `StructuredTool` | `from agent_gantry.langgraph import for_langgraph` |
+| LlamaIndex | `for_llamaindex` | `FunctionTool` | `from agent_gantry.llamaindex import for_llamaindex` |
+| CrewAI | `for_crewai` | `crewai.tools.BaseTool` | `from agent_gantry.crewai import for_crewai` |
+| Pydantic AI | `for_pydantic_ai` | `pydantic_ai.tools.Tool` | `from agent_gantry.pydantic_ai import for_pydantic_ai` |
+| OpenAI Agents SDK | `for_openai_agents` | `agents.FunctionTool` | `from agent_gantry.openai_agents import for_openai_agents` |
+| Smolagents | `for_smolagents` | `smolagents.Tool` | `from agent_gantry.smolagents import for_smolagents` |
+| Haystack | `for_haystack` | `haystack.tools.Tool` | `from agent_gantry.haystack import for_haystack` |
+| Agno | `for_agno` | `agno.tools.function.Function` | `from agent_gantry.agno import for_agno` |
+| AutoGen / AG2 | `for_autogen`, `register_with_autogen` | callables + `register_function` | `from agent_gantry.autogen import for_autogen` |
+| Semantic Kernel | `for_semantic_kernel`, `gantry_plugin` | `@kernel_function` `KernelFunction` | `from agent_gantry.semantic_kernel import for_semantic_kernel` |
+| Google ADK | `for_google_adk` | `google.adk.tools.FunctionTool` | `from agent_gantry.google_adk import for_google_adk` |
+
+Need one conversion at a time (you already hold the selected specs)? Use `spec_to_<fw>(spec)` with specs from `GantryToolset(gantry).select(query, limit=...)`.
 
 ```python
-from autogen_agentchat.agents import AssistantAgent
-from autogen_ext.models.openai import OpenAIChatCompletionClient
-from agent_gantry.integrations import fetch_framework_tools
+from agent_gantry.integrations.frameworks import GantryToolset, spec_to_crewai
 
-tools = await fetch_framework_tools(
-    gantry, "math operations", framework="autogen", limit=3
-)
-
-agent = AssistantAgent(
-    name="assistant",
-    model_client=OpenAIChatCompletionClient(model="gpt-5.5"),
-    tools=tools,
-)
+specs = await GantryToolset(gantry).select("research and writing", limit=4)
+crew_tools = [spec_to_crewai(s) for s in specs]
 ```
 
-## CrewAI
+### Deep per-turn "live" providers
+
+The `for_<fw>` helpers are *static* — select once, hand over a fixed list. The **live** providers hook each framework's own per-turn lifecycle so Gantry re-selects tools on **every turn**, matching `GantryContextProvider` depth for Microsoft Agent Framework. Import them lazily from the per-framework namespace.
 
 ```python
-from crewai import Agent, Task, Crew
-from agent_gantry.integrations import fetch_framework_tools
-
-tools = await fetch_framework_tools(
-    gantry, "research and writing", framework="crewai", limit=4
-)
-
-researcher = Agent(
-    role="Researcher",
-    goal="Find accurate information",
-    backstory="...",
-    tools=tools,
-)
+from agent_gantry.llamaindex import gantry_function_agent
+agent = gantry_function_agent(gantry, llm)   # re-selects tools each step
 ```
 
-## LlamaIndex
+| Framework | Live entry point | Native hook |
+|---|---|---|
+| LlamaIndex | `gantry_tool_retriever` / `gantry_function_agent` | `FunctionAgent(tool_retriever=…)` |
+| Pydantic AI | `gantry_toolset` | `AbstractToolset.get_tools()` |
+| AutoGen | `gantry_workbench` | `Workbench.list_tools()` |
+| Google ADK | `gantry_before_model_callback` / `gantry_adk_agent` | `Agent(before_model_callback=…)` |
+| LangGraph | `create_gantry_react_agent` / `acreate_gantry_react_agent` | dynamic `model` callable (re-binds tools per turn) |
+| Semantic Kernel | `GantryFunctionProvider` / `refresh_kernel_tools` | per-invocation plugin refresh |
+| OpenAI Agents SDK | `run_with_gantry` / `GantryAgentSession` / `gantry_run_hooks` | `RunHooks.on_llm_start` + per-run refresh |
+
+Frameworks whose tool list is **fixed at agent construction** (CrewAI, Agno, Haystack, Smolagents) can't re-advertise tools mid-run; their live wrappers (`GantryLiveCrewAgent`, `GantryLiveAgnoAgent`, `gantry_haystack_tools`, `GantryLiveSmolAgent`, all under `agent_gantry.integrations.frameworks`) re-select and rebuild the agent on each top-level call.
+
+## Multi-turn re-selection (ToolRefresher)
+
+`ToolRefresher` generalizes the per-call retrieval pattern to **any** framework without a native live hook: re-rank the whole registry on every turn so the agent can pivot tools as the task changes.
 
 ```python
-from llama_index.llms.openai import OpenAI
-from agent_gantry.integrations import fetch_framework_tools
+from agent_gantry.integrations import ToolRefresher
 
-tools = await fetch_framework_tools(
-    gantry, "data retrieval", framework="llamaindex", limit=3
-)
-# LlamaIndex consumes OpenAI-shape tool schemas directly.
+refresher = ToolRefresher(gantry, limit=3, dialect="openai")
+
+# Each turn, pass the running message list. Selection is recomputed fresh and
+# tools already used are deprioritized so the agent keeps moving forward.
+tools = await refresher.refresh(messages)        # dialect schemas
+specs = await refresher.refresh_specs(messages)  # ToolSpec objects
 ```
 
-## Semantic Kernel
+The default query generator (`agent_gantry.query.latest_activity`) is **recency-aware**, so one refresher serves both styles with no config:
+
+- **Autonomous agents / tool pipelines** — newest message is a tool result, so that result's *content* selects the next tool (`fetch → clean → train → evaluate → report`).
+- **Conversational agents** — newest message is the user's, so their new request drives selection (`weather → flights → hotel → email`).
+
+Force one behaviour with `query_generator=last_user_text` or `last_tool_result`.
+
+## Schema-only adapter (`fetch_framework_tools`)
+
+The legacy adapter returns OpenAI-shape JSON schemas (not native objects) and supports a smaller, hyphen/underscore-sensitive name set: `"langgraph"`, `"semantic-kernel"`, `"crew_ai"`, `"google_adk"`, `"strands"`, `"agent_framework"`. Prefer `for_<fw>` for the frameworks listed above; reach for this only when you want raw schemas (e.g. a framework that just wants OpenAI tool dicts).
 
 ```python
 from agent_gantry.integrations import fetch_framework_tools
 
-tools = await fetch_framework_tools(
-    gantry, "translate documents", framework="semantic_kernel", limit=3
-)
-```
-
-## Google ADK
-
-```python
-from agent_gantry.integrations import fetch_framework_tools
-
-tools = await fetch_framework_tools(
+schemas = await fetch_framework_tools(
     gantry, "code execution", framework="google_adk", limit=3
 )
 ```
@@ -364,6 +388,7 @@ agent-gantry search "refund order" --limit 3   # semantic search
 agent-gantry lint                              # detect tool-description authoring mistakes
 agent-gantry sim toolA toolB                   # cosine similarity between two tools
 agent-gantry sync --dry-run                    # which tools would (re-)embed and why
+agent-gantry install-skill --claude            # install THIS skill into ~/.claude/skills
 ```
 
 `lint` flags three patterns that silently degrade routing quality:
@@ -496,8 +521,9 @@ Cache is keyed by `(embedder_id, sha256(text))` — different models / dimension
 | `fallback_chain(*gens)` | Try each in order until one returns non-empty |
 | `keyword_focused` | Long instructional queries dilute the signal |
 | `truncated(gen, max_chars=200)` | Cap the query length, defaults to keeping the tail |
+| `latest_activity` (default for `ToolRefresher`) | Recency-aware: picks user text *or* last tool result, whichever is newest |
 
-Default for `query_strategy="per_call"` is `fallback_chain(last_tool_result, last_user_text)` — it adapts as the agent reasons.
+Default for `query_strategy="per_call"` is `fallback_chain(last_tool_result, last_user_text)` — it adapts as the agent reasons. `ToolRefresher` defaults to `latest_activity`, which serves autonomous and conversational agents alike.
 
 ## API reference quick-card
 
@@ -520,12 +546,23 @@ from agent_gantry.integrations import (
     GantryApprovalMiddleware,
     GantryObservabilityMiddleware,
     GantryToolChoiceMiddleware,   # round-by-round tool_choice modulation
-    fetch_framework_tools,        # multi-framework adapter (OpenAI-shape)
+    ToolRefresher,                # framework-agnostic multi-turn re-selection
+    fetch_framework_tools,        # legacy schema-only adapter (OpenAI-shape)
 )
+from agent_gantry.integrations.frameworks import (
+    GantryToolset,                # selection core behind every for_<fw>
+    ToolSpec,                     # framework-neutral tool handle (.ainvoke/.invoke)
+    spec_from_tool,
+    for_langchain, for_langgraph, for_llamaindex, for_crewai,
+    for_pydantic_ai, for_openai_agents, for_smolagents, for_haystack,
+    for_agno, for_autogen, for_semantic_kernel, for_google_adk,
+    # ...and matching spec_to_<fw> converters.
+)
+# Or the clean per-framework namespace: from agent_gantry.langchain import for_langchain
 from agent_gantry.query import (
     last_user_text, last_assistant_text, last_tool_result,
     concatenate_recent, fallback_chain,
-    keyword_focused, truncated,
+    keyword_focused, truncated, latest_activity,
 )
 from agent_gantry.adapters.embedders.cached import CachedEmbedder
 from agent_gantry.utils.registry_linter import (

--- a/agent_gantry/skills/agent-gantry/SKILL.md
+++ b/agent_gantry/skills/agent-gantry/SKILL.md
@@ -55,16 +55,20 @@ This skill is the canonical reference for using the library. Read the section th
 
 ## Installing
 
+This project uses **uv** as its package manager; `pip` works as a fallback. Inside a uv project use `uv add`; for an ad-hoc environment use `uv pip install`.
+
 ```bash
-pip install agent-gantry                # core
-pip install "agent-gantry[nomic]"       # local embeddings (recommended)
-pip install "agent-gantry[openai]"      # OpenAI/Azure embeddings + custom OpenAI-compatible base_url
-pip install "agent-gantry[agent-frameworks]"  # Microsoft AF, LangChain, AutoGen, CrewAI, LlamaIndex, Semantic Kernel, Google ADK
-pip install "agent-gantry[lancedb]"     # disk-persistent vector store
-pip install "agent-gantry[mcp]"         # MCP client/server
-pip install "agent-gantry[a2a]"         # A2A agent
-pip install "agent-gantry[all]"         # everything
+uv add agent-gantry                     # core (in a uv project)
+uv add "agent-gantry[nomic]"            # local embeddings (recommended)
+uv add "agent-gantry[openai]"           # OpenAI/Azure embeddings + custom OpenAI-compatible base_url
+uv add "agent-gantry[agent-frameworks]" # Microsoft AF, LangChain, AutoGen, CrewAI, LlamaIndex, Semantic Kernel, Google ADK
+uv add "agent-gantry[lancedb]"          # disk-persistent vector store
+uv add "agent-gantry[mcp]"              # MCP client/server
+uv add "agent-gantry[a2a]"              # A2A agent
+uv add "agent-gantry[all]"              # everything
 ```
+
+Not in a uv project? Swap `uv add` for `uv pip install`. No uv at all? Fall back to `pip install "agent-gantry[...]"` — the extras are identical.
 
 The `[nomic]` extra is the recommended default for getting started — local, free, and accurate enough for production. `SimpleEmbedder` (the fallback when no embedder extra is installed) is hash-based and only useful for tests.
 
@@ -380,15 +384,15 @@ Skills exposed: `tool_discovery` (semantic search) and `tool_execution` (run a t
 
 ## CLI
 
-The `agent-gantry` command ships with the package:
+The `agent-gantry` command ships with the package. Inside a uv project, prefix with `uv run` (e.g. `uv run agent-gantry list`); the bare `agent-gantry` form works when the package is on `PATH` (pip install or an activated venv).
 
 ```bash
-agent-gantry list                              # list registered demo tools
-agent-gantry search "refund order" --limit 3   # semantic search
-agent-gantry lint                              # detect tool-description authoring mistakes
-agent-gantry sim toolA toolB                   # cosine similarity between two tools
-agent-gantry sync --dry-run                    # which tools would (re-)embed and why
-agent-gantry install-skill --claude            # install THIS skill into ~/.claude/skills
+uv run agent-gantry list                              # list registered demo tools
+uv run agent-gantry search "refund order" --limit 3   # semantic search
+uv run agent-gantry lint                              # detect tool-description authoring mistakes
+uv run agent-gantry sim toolA toolB                   # cosine similarity between two tools
+uv run agent-gantry sync --dry-run                    # which tools would (re-)embed and why
+uv run agent-gantry install-skill --claude            # install THIS skill into ~/.claude/skills
 ```
 
 `lint` flags three patterns that silently degrade routing quality:

--- a/agent_gantry/skills/agent-gantry/SKILL.md
+++ b/agent_gantry/skills/agent-gantry/SKILL.md
@@ -249,6 +249,8 @@ Every adapter has the identical signature `for_<fw>(gantry, query, *, limit=3, *
 | Semantic Kernel | `for_semantic_kernel`, `gantry_plugin` | `@kernel_function` `KernelFunction` | `from agent_gantry.semantic_kernel import for_semantic_kernel` |
 | Google ADK | `for_google_adk` | `google.adk.tools.FunctionTool` | `from agent_gantry.google_adk import for_google_adk` |
 
+The secondary symbols in the *Static adapter* column import from the same namespace, e.g. `from agent_gantry.semantic_kernel import for_semantic_kernel, gantry_plugin` and `from agent_gantry.autogen import for_autogen, register_with_autogen`.
+
 Need one conversion at a time (you already hold the selected specs)? Use `spec_to_<fw>(spec)` with specs from `GantryToolset(gantry).select(query, limit=...)`.
 
 ```python

--- a/agent_gantry/skills/agent-gantry/references/cookbook.md
+++ b/agent_gantry/skills/agent-gantry/references/cookbook.md
@@ -43,6 +43,36 @@ agent = Agent(
 )
 ```
 
+## Recipe 1b: Native adapters + multi-turn re-selection (any framework)
+
+Goal: route a large registry into a non-AF framework (LangChain, CrewAI, Pydantic AI, …) and re-select tools every turn — without hand-rolling schema plumbing.
+
+Static slice (select once, native tool objects):
+
+```python
+from agent_gantry.langchain import for_langchain   # clean per-framework namespace
+
+tools = await for_langchain(gantry, "email the quarterly report", limit=3)
+llm = ChatOpenAI(model="gpt-5.5").bind_tools(tools)   # native StructuredTools
+```
+
+Multi-turn (re-rank the whole registry each turn, deprioritising tools already used):
+
+```python
+from agent_gantry.integrations import ToolRefresher
+
+refresher = ToolRefresher(gantry, limit=3, dialect="openai")
+
+messages = [...]                      # the running conversation / tool-result log
+while not done:
+    tools = await refresher.refresh(messages)     # fresh selection this turn
+    # ...call the model with `tools`, append its output to `messages`...
+```
+
+The default `latest_activity` query generator is recency-aware: a tool result drives the next selection in an autonomous pipeline (`fetch → clean → train → report`), while a new user message drives it in a chat agent (`weather → flights → hotel`). Pin one with `query_generator=last_user_text` or `last_tool_result`.
+
+For frameworks with a native per-turn hook (LlamaIndex, Pydantic AI, AutoGen, Google ADK, LangGraph, Semantic Kernel, OpenAI Agents SDK), prefer the deep **live** provider instead of `ToolRefresher` — e.g. `from agent_gantry.llamaindex import gantry_function_agent`.
+
 ## Recipe 2: Pipe a custom embedding endpoint (Requesty / OpenRouter / vLLM)
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-gantry"
-version = "0.5.0"
+version = "0.6.0"
 description = "Universal Tool Orchestration Platform - Intelligent, secure tool orchestration for LLM-based agent systems"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_bundled_skill.py
+++ b/tests/test_bundled_skill.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 from agent_gantry.cli.main import main
 from agent_gantry.skills import install_to, skill_path
@@ -22,15 +23,15 @@ _DESCRIPTION_MAX = 1024
 
 
 def _read_frontmatter(skill_md: Path) -> dict[str, str]:
-    """Parse the simple ``name``/``description`` YAML frontmatter from SKILL.md."""
+    """Parse the ``name``/``description`` YAML frontmatter from SKILL.md."""
     text = skill_md.read_text(encoding="utf-8")
     assert text.startswith("---"), "SKILL.md must open with a YAML frontmatter block"
     _, frontmatter, _body = text.split("---", 2)
-    name = re.search(r"^name:\s*(.+)$", frontmatter, re.MULTILINE)
-    description = re.search(r"^description:\s*(.+)", frontmatter, re.MULTILINE | re.DOTALL)
-    assert name is not None, "frontmatter is missing required 'name'"
-    assert description is not None, "frontmatter is missing required 'description'"
-    return {"name": name.group(1).strip(), "description": description.group(1).strip()}
+    data = yaml.safe_load(frontmatter)
+    assert isinstance(data, dict), "frontmatter must be a YAML mapping"
+    assert "name" in data, "frontmatter is missing required 'name'"
+    assert "description" in data, "frontmatter is missing required 'description'"
+    return {"name": str(data["name"]).strip(), "description": str(data["description"]).strip()}
 
 
 def test_skill_path_resolves_to_bundled_skill() -> None:
@@ -76,6 +77,34 @@ def test_cli_install_skill_command(tmp_path: Path, capsys: pytest.CaptureFixture
     assert exit_code == 0
     assert (target / "agent-gantry" / "SKILL.md").is_file()
     assert "Installed Agent-Gantry skill" in capsys.readouterr().out
+
+
+def test_cli_install_skill_claude_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--claude` installs into ~/.claude/skills, expanding ~ via expanduser()."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    # Path.expanduser() reads HOME on POSIX and USERPROFILE on Windows.
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+
+    exit_code = main(["install-skill", "--claude"])
+    assert exit_code == 0
+    assert (fake_home / ".claude" / "skills" / "agent-gantry" / "SKILL.md").is_file()
+    # No literal "~" directory leaked into the cwd.
+    assert not Path("~").exists()
+    assert "Installed Agent-Gantry skill" in capsys.readouterr().out
+
+
+def test_cli_install_skill_rejects_target_and_claude_together(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--target and --claude are mutually exclusive (argparse exits with code 2)."""
+    with pytest.raises(SystemExit) as exc:
+        main(["install-skill", "--target", "./x", "--claude"])
+    assert exc.value.code == 2
+    assert "not allowed with" in capsys.readouterr().err
 
 
 def test_cli_install_skill_print_path(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_bundled_skill.py
+++ b/tests/test_bundled_skill.py
@@ -97,6 +97,23 @@ def test_cli_install_skill_claude_flag(
     assert "Installed Agent-Gantry skill" in capsys.readouterr().out
 
 
+def test_cli_install_skill_claude_overwrite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second --claude install with --overwrite replaces the existing copy."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+
+    assert main(["install-skill", "--claude"]) == 0
+    # Without --overwrite the second install must refuse (non-zero exit).
+    assert main(["install-skill", "--claude"]) == 2
+    # With --overwrite it succeeds and the skill is still present.
+    assert main(["install-skill", "--claude", "--overwrite"]) == 0
+    assert (fake_home / ".claude" / "skills" / "agent-gantry" / "SKILL.md").is_file()
+
+
 def test_cli_install_skill_rejects_target_and_claude_together(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_bundled_skill.py
+++ b/tests/test_bundled_skill.py
@@ -81,6 +81,15 @@ def test_cli_install_skill_command(tmp_path: Path, capsys: pytest.CaptureFixture
     assert "Installed Agent-Gantry skill" in capsys.readouterr().out
 
 
+def test_cli_install_skill_default_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With neither --target nor --claude, the default ./skills target is used."""
+    monkeypatch.chdir(tmp_path)
+    assert main(["install-skill"]) == 0
+    assert (tmp_path / "skills" / "agent-gantry" / "SKILL.md").is_file()
+
+
 def test_cli_install_skill_claude_flag(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_bundled_skill.py
+++ b/tests/test_bundled_skill.py
@@ -26,7 +26,9 @@ def _read_frontmatter(skill_md: Path) -> dict[str, str]:
     """Parse the ``name``/``description`` YAML frontmatter from SKILL.md."""
     text = skill_md.read_text(encoding="utf-8")
     assert text.startswith("---"), "SKILL.md must open with a YAML frontmatter block"
-    _, frontmatter, _body = text.split("---", 2)
+    # Split only on lines that are exactly "---" so a literal "---" inside the
+    # description can never carve up the frontmatter incorrectly.
+    _, frontmatter, _body = re.split(r"^---\s*$", text, maxsplit=2, flags=re.MULTILINE)
     data = yaml.safe_load(frontmatter)
     assert isinstance(data, dict), "frontmatter must be a YAML mapping"
     assert "name" in data, "frontmatter is missing required 'name'"
@@ -120,8 +122,11 @@ def test_cli_install_skill_rejects_target_and_claude_together(
     """--target and --claude are mutually exclusive (argparse exits with code 2)."""
     with pytest.raises(SystemExit) as exc:
         main(["install-skill", "--target", "./x", "--claude"])
+    # Exit code 2 is argparse's documented "usage error" contract; the exact
+    # wording of the conflict message is an internal detail, so assert only that
+    # the offending option is named in stderr rather than pinning the phrasing.
     assert exc.value.code == 2
-    assert "not allowed with" in capsys.readouterr().err
+    assert "--claude" in capsys.readouterr().err
 
 
 def test_cli_install_skill_print_path(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_bundled_skill.py
+++ b/tests/test_bundled_skill.py
@@ -1,0 +1,86 @@
+"""
+Guard tests for the bundled Agent-Gantry Claude Skill.
+
+These keep the skill release-safe: it must ship inside the package, expose a
+resolvable path, install via the CLI, and carry valid Anthropic Agent Skills
+frontmatter (`name` + `description` within the documented limits).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from agent_gantry.cli.main import main
+from agent_gantry.skills import install_to, skill_path
+
+# Anthropic Agent Skills frontmatter limits.
+_NAME_MAX = 64
+_DESCRIPTION_MAX = 1024
+
+
+def _read_frontmatter(skill_md: Path) -> dict[str, str]:
+    """Parse the simple ``name``/``description`` YAML frontmatter from SKILL.md."""
+    text = skill_md.read_text(encoding="utf-8")
+    assert text.startswith("---"), "SKILL.md must open with a YAML frontmatter block"
+    _, frontmatter, _body = text.split("---", 2)
+    name = re.search(r"^name:\s*(.+)$", frontmatter, re.MULTILINE)
+    description = re.search(r"^description:\s*(.+)", frontmatter, re.MULTILINE | re.DOTALL)
+    assert name is not None, "frontmatter is missing required 'name'"
+    assert description is not None, "frontmatter is missing required 'description'"
+    return {"name": name.group(1).strip(), "description": description.group(1).strip()}
+
+
+def test_skill_path_resolves_to_bundled_skill() -> None:
+    """The skill ships inside the package and exposes SKILL.md + references/."""
+    path = skill_path()
+    assert path.is_dir()
+    assert (path / "SKILL.md").is_file()
+    assert (path / "references" / "cookbook.md").is_file()
+
+
+def test_skill_frontmatter_is_anthropic_compliant() -> None:
+    """name/description exist, are non-empty, and stay within Anthropic limits."""
+    fm = _read_frontmatter(skill_path() / "SKILL.md")
+
+    assert fm["name"] == "agent-gantry"
+    assert re.fullmatch(r"[a-z0-9-]+", fm["name"]), "name must be lowercase/hyphenated"
+    assert 0 < len(fm["name"]) <= _NAME_MAX
+
+    assert fm["description"], "description must be non-empty"
+    assert len(fm["description"]) <= _DESCRIPTION_MAX
+
+
+def test_install_to_copies_the_skill(tmp_path: Path) -> None:
+    """install_to() vendors the skill (incl. references/) into a target dir."""
+    dst = install_to(tmp_path / "skills")
+    assert dst == (tmp_path / "skills" / "agent-gantry").resolve()
+    assert (dst / "SKILL.md").is_file()
+    assert (dst / "references" / "cookbook.md").is_file()
+
+    # Default is non-destructive: a second call without overwrite must refuse.
+    with pytest.raises(FileExistsError):
+        install_to(tmp_path / "skills")
+
+    # ...and overwrite=True replaces it cleanly.
+    again = install_to(tmp_path / "skills", overwrite=True)
+    assert again.is_dir()
+
+
+def test_cli_install_skill_command(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`agent-gantry install-skill --target ...` copies the skill and reports it."""
+    target = tmp_path / "vendored"
+    exit_code = main(["install-skill", "--target", str(target)])
+    assert exit_code == 0
+    assert (target / "agent-gantry" / "SKILL.md").is_file()
+    assert "Installed Agent-Gantry skill" in capsys.readouterr().out
+
+
+def test_cli_install_skill_print_path(capsys: pytest.CaptureFixture[str]) -> None:
+    """`--print-path` prints the bundled skill location without copying."""
+    exit_code = main(["install-skill", "--print-path"])
+    assert exit_code == 0
+    printed = capsys.readouterr().out.strip()
+    assert printed == str(skill_path())

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "agent-gantry"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Summary

This release updates the bundled Claude Skill documentation to reflect the v0.5.0+ API surface, adds a `--claude` flag to install the skill directly into Claude's personal skills directory, and updates installation instructions across the project to lead with `uv` as the package manager.

## Key Changes

- **Bundled Claude Skill (`SKILL.md`) refreshed**:
  - Rewrote framework integration guidance around native `for_` adapters and clean per-framework import namespaces
  - Added five new frameworks introduced in v0.5.0: Pydantic AI, OpenAI Agents SDK, Smolagents, Haystack, Agno
  - Documented deep per-turn "live" providers and the `ToolRefresher` multi-turn re-selection API
  - Corrected stale `fetch_framework_tools` examples and clarified it as a schema-only legacy adapter
  - Expanded trigger description in frontmatter to cover all new frameworks
  - Added new cookbook recipe (1b) demonstrating native adapters with multi-turn re-selection

- **CLI skill installation enhancements**:
  - Added `--claude` flag to `agent-gantry install-skill` to install directly into `~/.claude/skills`
  - `--target` and `--claude` are a mutually exclusive argparse group (passing both is a parse-time error, not a silent override)
  - Updated `skill_path()` error message to recommend `uv add` over `pip install`

- **Installation instructions updated across the project**:
  - `README.md`, `SKILL.md`, and CLI help now lead with `uv add` / `uv run` commands
  - Kept `pip install` as an explicit fallback for users without `uv`
  - Added guidance on using `uv run` prefix for CLI commands in uv projects

- **Test coverage added**:
  - New `tests/test_bundled_skill.py` with guards for skill release safety:
    - Validates skill path resolution and bundled file structure
    - Checks Anthropic Agent Skills frontmatter compliance (name/description limits)
    - Tests `install_to()`, the CLI `install-skill` command, the `--claude` install path, `--claude` + `--overwrite`, and the `--target`/`--claude` mutual exclusion

- **Version bumped to 0.6.0** in `__init__.py` and `pyproject.toml`

## Implementation Details

- `install_to()` already expands `~` via `Path(target).expanduser().resolve()` (`agent_gantry/skills/__init__.py`), so `--claude` passing `"~/.claude/skills"` resolves to the user's home; the `--claude` test exercises this end to end with a monkeypatched `HOME`/`USERPROFILE`
- Skill frontmatter parsing in tests uses `yaml.safe_load` (PyYAML is already a core dependency) — robust against future frontmatter fields
- All installation examples now show `uv add` first, with `pip install` as a documented fallback
- The skill's trigger description in frontmatter was expanded to include all supported frameworks without exceeding the 1024-character Anthropic limit

https://claude.ai/code/session_014TChd8Ge1PExFdRqKQfNNb