### PR TITLE
Add per-framework basic/advanced guides and remove Pages deployment from docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,25 +50,3 @@ jobs:
 
       - name: Build Astro site
         run: npm run build
-
-      - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-
-  deploy:
-    name: Deploy to GitHub Pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy Astro site
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/src/pages/docs/frameworks.astro
+++ b/src/pages/docs/frameworks.astro
@@ -1,5 +1,37 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
 import ProviderMatrix from '../../components/ProviderMatrix';
+const guides = [
+  ['LangChain', '/Agent-Gantry/docs/frameworks/langchain/'],
+  ['LangGraph', '/Agent-Gantry/docs/frameworks/langgraph/'],
+  ['LlamaIndex', '/Agent-Gantry/docs/frameworks/llamaindex/'],
+  ['CrewAI', '/Agent-Gantry/docs/frameworks/crewai/'],
+  ['AutoGen', '/Agent-Gantry/docs/frameworks/autogen/'],
+  ['Semantic Kernel', '/Agent-Gantry/docs/frameworks/semantic-kernel/'],
+  ['Google ADK', '/Agent-Gantry/docs/frameworks/google-adk/'],
+  ['Pydantic AI', '/Agent-Gantry/docs/frameworks/pydantic-ai/'],
+  ['OpenAI Agents SDK', '/Agent-Gantry/docs/frameworks/openai-agents/'],
+  ['Smolagents', '/Agent-Gantry/docs/frameworks/smolagents/'],
+  ['Haystack', '/Agent-Gantry/docs/frameworks/haystack/'],
+  ['Agno', '/Agent-Gantry/docs/frameworks/agno/'],
+];
 ---
-<DocsLayout title="Frameworks | Agent-Gantry"><h1>Framework integrations</h1><p class="lead">Agent-Gantry is designed to be the shared tool layer below many agent frameworks.</p><ProviderMatrix /><h2>Microsoft Agent Framework</h2><p>Use Gantry context providers and tool bridges to surface only relevant tools during a run. For Agent Framework 1.6+ concurrent workflows, call <code>disable_af_instrumentation()</code> before agent construction if upstream ContextVar instrumentation conflicts with parallel runs.</p><h2>Native adapters</h2><p>Adapters and examples exist for LangChain, LangGraph, LlamaIndex, CrewAI, AutoGen, Semantic Kernel, Google ADK, Pydantic AI, OpenAI Agents SDK, Smolagents, Haystack, and Agno. Use isolated environments when upstream dependency constraints conflict.</p></DocsLayout>
+<DocsLayout title="Frameworks | Agent-Gantry">
+  <h1>Framework integrations</h1>
+  <p class="lead">Agent-Gantry is designed to be the shared tool layer below many agent frameworks. These guides show how to expose the same trusted tool registry, retrieval strategy, and LLM routing policy from basic prototypes through production-grade agent systems.</p>
+  <ProviderMatrix />
+
+  <h2>Framework-by-framework guides</h2>
+  <p>Each guide is organized as a two-page learning path in one place: a <strong>basic page</strong> for setup, registration, and a first tool call, followed by an <strong>advanced page</strong> for dynamic tool selection, LLM calls, observability, and deployment patterns.</p>
+  <div class="grid">
+    {guides.map(([name, href]) => <a class="card guide-card" href={href}><h3>{name}</h3><p>Basic usage, advanced orchestration, and LLM-call guidance.</p></a>)}
+  </div>
+
+  <h2>Recommended integration model</h2>
+  <div class="step"><h3>Start with the shared registry</h3><p>Register Python callables once in Agent-Gantry, attach metadata, and export framework-specific tool objects only at the boundary of the selected framework.</p></div>
+  <div class="step"><h3>Keep LLM calls behind adapters</h3><p>Use the framework for conversation state and agent loops, then route model calls through your provider policy so usage tracking, cost controls, and fallback rules remain consistent.</p></div>
+  <div class="step"><h3>Add advanced controls last</h3><p>Introduce semantic tool retrieval, reranking, MCP/A2A executors, and tracing after the basic path has stable tests.</p></div>
+
+  <h2>Microsoft Agent Framework</h2>
+  <p>Use Gantry context providers and tool bridges to surface only relevant tools during a run. For Agent Framework 1.6+ concurrent workflows, call <code>disable_af_instrumentation()</code> before agent construction if upstream ContextVar instrumentation conflicts with parallel runs.</p>
+</DocsLayout>

--- a/src/pages/docs/frameworks/agno/advanced.astro
+++ b/src/pages/docs/frameworks/agno/advanced.astro
@@ -1,0 +1,38 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Advanced Agno guide | Agent-Gantry">
+  <p class="eyebrow">Advanced framework guide</p>
+  <h1>Advanced Agno</h1>
+  <p class="lead">Scale Agno from static tool demos to governed agent workloads with semantic selection, explicit LLM-call policy, tracing, and deployment boundaries.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/agno/">← Basic Agno usage</a></p>
+
+  <h2>Advanced page: dynamic tool selection</h2>
+  <p>Before each Agno run, ask Gantry for a context-aware subset of tools. Combine request metadata, tenant policy, semantic similarity, and reranker results so the agent sees a concise, relevant tool surface.</p>
+  <pre><code>candidate_tools = gantry.select_tools(
+    query=user_message,
+    tags=["support"],
+    limit=8,
+)
+framework_tools = [AgnoAdapter.convert(spec) for spec in candidate_tools]
+</code></pre>
+
+  <h2>LLM calls and model policy</h2>
+  <p>Centralize LLM calls when Agno supports custom model clients; otherwise add middleware around the framework call. The policy should select the provider, enforce budget ceilings, redact sensitive fields, emit token metrics, and decide whether tool results should be summarized before returning to the model.</p>
+  <pre><code>response = llm_policy.complete(
+    framework="Agno",
+    model="primary-or-fallback-model",
+    messages=messages,
+    tools=framework_tools,
+    trace_id=trace_id,
+)
+</code></pre>
+
+  <h2>Production patterns</h2>
+  <ul>
+    <li><strong>Observability:</strong> attach trace IDs to every Agno run, LLM call, and tool execution.</li>
+    <li><strong>Safety:</strong> keep high-risk tools behind explicit allowlists, human approval, or dry-run executors.</li>
+    <li><strong>Resilience:</strong> add provider fallback for LLM calls and executor fallback for remote MCP/A2A tools.</li>
+    <li><strong>Evaluation:</strong> replay representative prompts with fixed tool snapshots before broadening dynamic retrieval.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/frameworks/agno/index.astro
+++ b/src/pages/docs/frameworks/agno/index.astro
@@ -1,0 +1,37 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Agno guide | Agent-Gantry">
+  <p class="eyebrow">Framework guide</p>
+  <h1>Agno</h1>
+  <p class="lead">Use Agent-Gantry with agent teams, knowledge, and toolkits. This page covers basic setup and the first production-friendly path; continue to the advanced page for dynamic retrieval, LLM calls, and operations.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/agno/advanced/">Advanced Agno usage →</a></p>
+
+  <h2>Basic page: register once, adapt at the edge</h2>
+  <ol>
+    <li>Create a Gantry instance near application startup.</li>
+    <li>Register deterministic Python functions with descriptions and input schemas.</li>
+    <li>Export framework-native tools for Agno immediately before constructing the agent, graph, pipeline, or crew.</li>
+    <li>Keep authorization, rate limits, and audit metadata in Gantry instead of duplicating it inside framework glue code.</li>
+  </ol>
+  <pre><code>from agent_gantry import AgentGantry
+from agent_gantry.agno import AgnoAdapter
+
+gantry = AgentGantry()
+
+def get_order_status(order_id: str) -> str:
+    """Return the current shipping status for an order."""
+    return "in_transit"
+
+gantry.register_tool(get_order_status, tags=["support", "orders"])
+adapter = AgnoAdapter(gantry)
+framework_tools = await adapter.select("check an order", limit=3)  # Native Agno adapter export.
+</code></pre>
+
+  <h2>First tool-calling loop</h2>
+  <p>Let Agno own the conversation lifecycle while Gantry owns the tool catalog. Start with a small tool set and assert that the framework receives only safe, documented functions.</p>
+  <div class="callout"><strong>Basic testing checklist:</strong> verify tool names, JSON schemas, auth metadata, and a happy-path invocation before wiring a live model.</div>
+
+  <h2>Basic LLM call guidance</h2>
+  <p>For early prototypes, use the model client already recommended by Agno. Wrap that client with a thin policy function that records model name, prompt tokens, completion tokens, tool calls, and latency. Once the integration stabilizes, move the policy into Agent-Gantry's LLM adapter layer so other frameworks share the same rules.</p>
+</DocsLayout>

--- a/src/pages/docs/frameworks/autogen/advanced.astro
+++ b/src/pages/docs/frameworks/autogen/advanced.astro
@@ -1,0 +1,38 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Advanced AutoGen guide | Agent-Gantry">
+  <p class="eyebrow">Advanced framework guide</p>
+  <h1>Advanced AutoGen</h1>
+  <p class="lead">Scale AutoGen from static tool demos to governed agent workloads with semantic selection, explicit LLM-call policy, tracing, and deployment boundaries.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/autogen/">← Basic AutoGen usage</a></p>
+
+  <h2>Advanced page: dynamic tool selection</h2>
+  <p>Before each AutoGen run, ask Gantry for a context-aware subset of tools. Combine request metadata, tenant policy, semantic similarity, and reranker results so the agent sees a concise, relevant tool surface.</p>
+  <pre><code>candidate_tools = gantry.select_tools(
+    query=user_message,
+    tags=["support"],
+    limit=8,
+)
+framework_tools = [AutoGenAdapter.convert(spec) for spec in candidate_tools]
+</code></pre>
+
+  <h2>LLM calls and model policy</h2>
+  <p>Centralize LLM calls when AutoGen supports custom model clients; otherwise add middleware around the framework call. The policy should select the provider, enforce budget ceilings, redact sensitive fields, emit token metrics, and decide whether tool results should be summarized before returning to the model.</p>
+  <pre><code>response = llm_policy.complete(
+    framework="AutoGen",
+    model="primary-or-fallback-model",
+    messages=messages,
+    tools=framework_tools,
+    trace_id=trace_id,
+)
+</code></pre>
+
+  <h2>Production patterns</h2>
+  <ul>
+    <li><strong>Observability:</strong> attach trace IDs to every AutoGen run, LLM call, and tool execution.</li>
+    <li><strong>Safety:</strong> keep high-risk tools behind explicit allowlists, human approval, or dry-run executors.</li>
+    <li><strong>Resilience:</strong> add provider fallback for LLM calls and executor fallback for remote MCP/A2A tools.</li>
+    <li><strong>Evaluation:</strong> replay representative prompts with fixed tool snapshots before broadening dynamic retrieval.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/frameworks/autogen/index.astro
+++ b/src/pages/docs/frameworks/autogen/index.astro
@@ -1,0 +1,37 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="AutoGen guide | Agent-Gantry">
+  <p class="eyebrow">Framework guide</p>
+  <h1>AutoGen</h1>
+  <p class="lead">Use Agent-Gantry with multi-agent conversations and tool executors. This page covers basic setup and the first production-friendly path; continue to the advanced page for dynamic retrieval, LLM calls, and operations.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/autogen/advanced/">Advanced AutoGen usage →</a></p>
+
+  <h2>Basic page: register once, adapt at the edge</h2>
+  <ol>
+    <li>Create a Gantry instance near application startup.</li>
+    <li>Register deterministic Python functions with descriptions and input schemas.</li>
+    <li>Export framework-native tools for AutoGen immediately before constructing the agent, graph, pipeline, or crew.</li>
+    <li>Keep authorization, rate limits, and audit metadata in Gantry instead of duplicating it inside framework glue code.</li>
+  </ol>
+  <pre><code>from agent_gantry import AgentGantry
+from agent_gantry.autogen import AutoGenAdapter
+
+gantry = AgentGantry()
+
+def get_order_status(order_id: str) -> str:
+    """Return the current shipping status for an order."""
+    return "in_transit"
+
+gantry.register_tool(get_order_status, tags=["support", "orders"])
+adapter = AutoGenAdapter(gantry)
+framework_tools = await adapter.select("check an order", limit=3)  # Native AutoGen adapter export.
+</code></pre>
+
+  <h2>First tool-calling loop</h2>
+  <p>Let AutoGen own the conversation lifecycle while Gantry owns the tool catalog. Start with a small tool set and assert that the framework receives only safe, documented functions.</p>
+  <div class="callout"><strong>Basic testing checklist:</strong> verify tool names, JSON schemas, auth metadata, and a happy-path invocation before wiring a live model.</div>
+
+  <h2>Basic LLM call guidance</h2>
+  <p>For early prototypes, use the model client already recommended by AutoGen. Wrap that client with a thin policy function that records model name, prompt tokens, completion tokens, tool calls, and latency. Once the integration stabilizes, move the policy into Agent-Gantry's LLM adapter layer so other frameworks share the same rules.</p>
+</DocsLayout>

--- a/src/pages/docs/frameworks/crewai/advanced.astro
+++ b/src/pages/docs/frameworks/crewai/advanced.astro
@@ -1,0 +1,38 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Advanced CrewAI guide | Agent-Gantry">
+  <p class="eyebrow">Advanced framework guide</p>
+  <h1>Advanced CrewAI</h1>
+  <p class="lead">Scale CrewAI from static tool demos to governed agent workloads with semantic selection, explicit LLM-call policy, tracing, and deployment boundaries.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/crewai/">← Basic CrewAI usage</a></p>
+
+  <h2>Advanced page: dynamic tool selection</h2>
+  <p>Before each CrewAI run, ask Gantry for a context-aware subset of tools. Combine request metadata, tenant policy, semantic similarity, and reranker results so the agent sees a concise, relevant tool surface.</p>
+  <pre><code>candidate_tools = gantry.select_tools(
+    query=user_message,
+    tags=["support"],
+    limit=8,
+)
+framework_tools = [CrewAIAdapter.convert(spec) for spec in candidate_tools]
+</code></pre>
+
+  <h2>LLM calls and model policy</h2>
+  <p>Centralize LLM calls when CrewAI supports custom model clients; otherwise add middleware around the framework call. The policy should select the provider, enforce budget ceilings, redact sensitive fields, emit token metrics, and decide whether tool results should be summarized before returning to the model.</p>
+  <pre><code>response = llm_policy.complete(
+    framework="CrewAI",
+    model="primary-or-fallback-model",
+    messages=messages,
+    tools=framework_tools,
+    trace_id=trace_id,
+)
+</code></pre>
+
+  <h2>Production patterns</h2>
+  <ul>
+    <li><strong>Observability:</strong> attach trace IDs to every CrewAI run, LLM call, and tool execution.</li>
+    <li><strong>Safety:</strong> keep high-risk tools behind explicit allowlists, human approval, or dry-run executors.</li>
+    <li><strong>Resilience:</strong> add provider fallback for LLM calls and executor fallback for remote MCP/A2A tools.</li>
+    <li><strong>Evaluation:</strong> replay representative prompts with fixed tool snapshots before broadening dynamic retrieval.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/frameworks/crewai/index.astro
+++ b/src/pages/docs/frameworks/crewai/index.astro
@@ -1,0 +1,37 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="CrewAI guide | Agent-Gantry">
+  <p class="eyebrow">Framework guide</p>
+  <h1>CrewAI</h1>
+  <p class="lead">Use Agent-Gantry with role-based crews and task handoffs. This page covers basic setup and the first production-friendly path; continue to the advanced page for dynamic retrieval, LLM calls, and operations.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/crewai/advanced/">Advanced CrewAI usage →</a></p>
+
+  <h2>Basic page: register once, adapt at the edge</h2>
+  <ol>
+    <li>Create a Gantry instance near application startup.</li>
+    <li>Register deterministic Python functions with descriptions and input schemas.</li>
+    <li>Export framework-native tools for CrewAI immediately before constructing the agent, graph, pipeline, or crew.</li>
+    <li>Keep authorization, rate limits, and audit metadata in Gantry instead of duplicating it inside framework glue code.</li>
+  </ol>
+  <pre><code>from agent_gantry import AgentGantry
+from agent_gantry.crewai import CrewAIAdapter
+
+gantry = AgentGantry()
+
+def get_order_status(order_id: str) -> str:
+    """Return the current shipping status for an order."""
+    return "in_transit"
+
+gantry.register_tool(get_order_status, tags=["support", "orders"])
+adapter = CrewAIAdapter(gantry)
+framework_tools = await adapter.select("check an order", limit=3)  # Native CrewAI adapter export.
+</code></pre>
+
+  <h2>First tool-calling loop</h2>
+  <p>Let CrewAI own the conversation lifecycle while Gantry owns the tool catalog. Start with a small tool set and assert that the framework receives only safe, documented functions.</p>
+  <div class="callout"><strong>Basic testing checklist:</strong> verify tool names, JSON schemas, auth metadata, and a happy-path invocation before wiring a live model.</div>
+
+  <h2>Basic LLM call guidance</h2>
+  <p>For early prototypes, use the model client already recommended by CrewAI. Wrap that client with a thin policy function that records model name, prompt tokens, completion tokens, tool calls, and latency. Once the integration stabilizes, move the policy into Agent-Gantry's LLM adapter layer so other frameworks share the same rules.</p>
+</DocsLayout>

--- a/src/pages/docs/frameworks/google-adk/advanced.astro
+++ b/src/pages/docs/frameworks/google-adk/advanced.astro
@@ -1,0 +1,38 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Advanced Google ADK guide | Agent-Gantry">
+  <p class="eyebrow">Advanced framework guide</p>
+  <h1>Advanced Google ADK</h1>
+  <p class="lead">Scale Google ADK from static tool demos to governed agent workloads with semantic selection, explicit LLM-call policy, tracing, and deployment boundaries.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/google-adk/">← Basic Google ADK usage</a></p>
+
+  <h2>Advanced page: dynamic tool selection</h2>
+  <p>Before each Google ADK run, ask Gantry for a context-aware subset of tools. Combine request metadata, tenant policy, semantic similarity, and reranker results so the agent sees a concise, relevant tool surface.</p>
+  <pre><code>candidate_tools = gantry.select_tools(
+    query=user_message,
+    tags=["support"],
+    limit=8,
+)
+framework_tools = [GoogleADKAdapter.convert(spec) for spec in candidate_tools]
+</code></pre>
+
+  <h2>LLM calls and model policy</h2>
+  <p>Centralize LLM calls when Google ADK supports custom model clients; otherwise add middleware around the framework call. The policy should select the provider, enforce budget ceilings, redact sensitive fields, emit token metrics, and decide whether tool results should be summarized before returning to the model.</p>
+  <pre><code>response = llm_policy.complete(
+    framework="Google ADK",
+    model="primary-or-fallback-model",
+    messages=messages,
+    tools=framework_tools,
+    trace_id=trace_id,
+)
+</code></pre>
+
+  <h2>Production patterns</h2>
+  <ul>
+    <li><strong>Observability:</strong> attach trace IDs to every Google ADK run, LLM call, and tool execution.</li>
+    <li><strong>Safety:</strong> keep high-risk tools behind explicit allowlists, human approval, or dry-run executors.</li>
+    <li><strong>Resilience:</strong> add provider fallback for LLM calls and executor fallback for remote MCP/A2A tools.</li>
+    <li><strong>Evaluation:</strong> replay representative prompts with fixed tool snapshots before broadening dynamic retrieval.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/frameworks/google-adk/index.astro
+++ b/src/pages/docs/frameworks/google-adk/index.astro
@@ -1,0 +1,37 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Google ADK guide | Agent-Gantry">
+  <p class="eyebrow">Framework guide</p>
+  <h1>Google ADK</h1>
+  <p class="lead">Use Agent-Gantry with Google agent runtimes and tool callbacks. This page covers basic setup and the first production-friendly path; continue to the advanced page for dynamic retrieval, LLM calls, and operations.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/google-adk/advanced/">Advanced Google ADK usage →</a></p>
+
+  <h2>Basic page: register once, adapt at the edge</h2>
+  <ol>
+    <li>Create a Gantry instance near application startup.</li>
+    <li>Register deterministic Python functions with descriptions and input schemas.</li>
+    <li>Export framework-native tools for Google ADK immediately before constructing the agent, graph, pipeline, or crew.</li>
+    <li>Keep authorization, rate limits, and audit metadata in Gantry instead of duplicating it inside framework glue code.</li>
+  </ol>
+  <pre><code>from agent_gantry import AgentGantry
+from agent_gantry.google_adk import GoogleADKAdapter
+
+gantry = AgentGantry()
+
+def get_order_status(order_id: str) -> str:
+    """Return the current shipping status for an order."""
+    return "in_transit"
+
+gantry.register_tool(get_order_status, tags=["support", "orders"])
+adapter = GoogleADKAdapter(gantry)
+framework_tools = await adapter.select("check an order", limit=3)  # Native Google ADK adapter export.
+</code></pre>
+
+  <h2>First tool-calling loop</h2>
+  <p>Let Google ADK own the conversation lifecycle while Gantry owns the tool catalog. Start with a small tool set and assert that the framework receives only safe, documented functions.</p>
+  <div class="callout"><strong>Basic testing checklist:</strong> verify tool names, JSON schemas, auth metadata, and a happy-path invocation before wiring a live model.</div>
+
+  <h2>Basic LLM call guidance</h2>
+  <p>For early prototypes, use the model client already recommended by Google ADK. Wrap that client with a thin policy function that records model name, prompt tokens, completion tokens, tool calls, and latency. Once the integration stabilizes, move the policy into Agent-Gantry's LLM adapter layer so other frameworks share the same rules.</p>
+</DocsLayout>

--- a/src/pages/docs/frameworks/haystack/advanced.astro
+++ b/src/pages/docs/frameworks/haystack/advanced.astro
@@ -1,0 +1,38 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Advanced Haystack guide | Agent-Gantry">
+  <p class="eyebrow">Advanced framework guide</p>
+  <h1>Advanced Haystack</h1>
+  <p class="lead">Scale Haystack from static tool demos to governed agent workloads with semantic selection, explicit LLM-call policy, tracing, and deployment boundaries.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/haystack/">← Basic Haystack usage</a></p>
+
+  <h2>Advanced page: dynamic tool selection</h2>
+  <p>Before each Haystack run, ask Gantry for a context-aware subset of tools. Combine request metadata, tenant policy, semantic similarity, and reranker results so the agent sees a concise, relevant tool surface.</p>
+  <pre><code>candidate_tools = gantry.select_tools(
+    query=user_message,
+    tags=["support"],
+    limit=8,
+)
+framework_tools = [HaystackAdapter.convert(spec) for spec in candidate_tools]
+</code></pre>
+
+  <h2>LLM calls and model policy</h2>
+  <p>Centralize LLM calls when Haystack supports custom model clients; otherwise add middleware around the framework call. The policy should select the provider, enforce budget ceilings, redact sensitive fields, emit token metrics, and decide whether tool results should be summarized before returning to the model.</p>
+  <pre><code>response = llm_policy.complete(
+    framework="Haystack",
+    model="primary-or-fallback-model",
+    messages=messages,
+    tools=framework_tools,
+    trace_id=trace_id,
+)
+</code></pre>
+
+  <h2>Production patterns</h2>
+  <ul>
+    <li><strong>Observability:</strong> attach trace IDs to every Haystack run, LLM call, and tool execution.</li>
+    <li><strong>Safety:</strong> keep high-risk tools behind explicit allowlists, human approval, or dry-run executors.</li>
+    <li><strong>Resilience:</strong> add provider fallback for LLM calls and executor fallback for remote MCP/A2A tools.</li>
+    <li><strong>Evaluation:</strong> replay representative prompts with fixed tool snapshots before broadening dynamic retrieval.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/frameworks/haystack/index.astro
+++ b/src/pages/docs/frameworks/haystack/index.astro
@@ -1,0 +1,37 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Haystack guide | Agent-Gantry">
+  <p class="eyebrow">Framework guide</p>
+  <h1>Haystack</h1>
+  <p class="lead">Use Agent-Gantry with pipeline components and agent tools. This page covers basic setup and the first production-friendly path; continue to the advanced page for dynamic retrieval, LLM calls, and operations.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/haystack/advanced/">Advanced Haystack usage →</a></p>
+
+  <h2>Basic page: register once, adapt at the edge</h2>
+  <ol>
+    <li>Create a Gantry instance near application startup.</li>
+    <li>Register deterministic Python functions with descriptions and input schemas.</li>
+    <li>Export framework-native tools for Haystack immediately before constructing the agent, graph, pipeline, or crew.</li>
+    <li>Keep authorization, rate limits, and audit metadata in Gantry instead of duplicating it inside framework glue code.</li>
+  </ol>
+  <pre><code>from agent_gantry import AgentGantry
+from agent_gantry.haystack import HaystackAdapter
+
+gantry = AgentGantry()
+
+def get_order_status(order_id: str) -> str:
+    """Return the current shipping status for an order."""
+    return "in_transit"
+
+gantry.register_tool(get_order_status, tags=["support", "orders"])
+adapter = HaystackAdapter(gantry)
+framework_tools = await adapter.select("check an order", limit=3)  # Native Haystack adapter export.
+</code></pre>
+
+  <h2>First tool-calling loop</h2>
+  <p>Let Haystack own the conversation lifecycle while Gantry owns the tool catalog. Start with a small tool set and assert that the framework receives only safe, documented functions.</p>
+  <div class="callout"><strong>Basic testing checklist:</strong> verify tool names, JSON schemas, auth metadata, and a happy-path invocation before wiring a live model.</div>
+
+  <h2>Basic LLM call guidance</h2>
+  <p>For early prototypes, use the model client already recommended by Haystack. Wrap that client with a thin policy function that records model name, prompt tokens, completion tokens, tool calls, and latency. Once the integration stabilizes, move the policy into Agent-Gantry's LLM adapter layer so other frameworks share the same rules.</p>
+</DocsLayout>

--- a/src/pages/docs/frameworks/langchain/advanced.astro
+++ b/src/pages/docs/frameworks/langchain/advanced.astro
@@ -1,0 +1,38 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Advanced LangChain guide | Agent-Gantry">
+  <p class="eyebrow">Advanced framework guide</p>
+  <h1>Advanced LangChain</h1>
+  <p class="lead">Scale LangChain from static tool demos to governed agent workloads with semantic selection, explicit LLM-call policy, tracing, and deployment boundaries.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/langchain/">← Basic LangChain usage</a></p>
+
+  <h2>Advanced page: dynamic tool selection</h2>
+  <p>Before each LangChain run, ask Gantry for a context-aware subset of tools. Combine request metadata, tenant policy, semantic similarity, and reranker results so the agent sees a concise, relevant tool surface.</p>
+  <pre><code>candidate_tools = gantry.select_tools(
+    query=user_message,
+    tags=["support"],
+    limit=8,
+)
+framework_tools = [LangChainAdapter.convert(spec) for spec in candidate_tools]
+</code></pre>
+
+  <h2>LLM calls and model policy</h2>
+  <p>Centralize LLM calls when LangChain supports custom model clients; otherwise add middleware around the framework call. The policy should select the provider, enforce budget ceilings, redact sensitive fields, emit token metrics, and decide whether tool results should be summarized before returning to the model.</p>
+  <pre><code>response = llm_policy.complete(
+    framework="LangChain",
+    model="primary-or-fallback-model",
+    messages=messages,
+    tools=framework_tools,
+    trace_id=trace_id,
+)
+</code></pre>
+
+  <h2>Production patterns</h2>
+  <ul>
+    <li><strong>Observability:</strong> attach trace IDs to every LangChain run, LLM call, and tool execution.</li>
+    <li><strong>Safety:</strong> keep high-risk tools behind explicit allowlists, human approval, or dry-run executors.</li>
+    <li><strong>Resilience:</strong> add provider fallback for LLM calls and executor fallback for remote MCP/A2A tools.</li>
+    <li><strong>Evaluation:</strong> replay representative prompts with fixed tool snapshots before broadening dynamic retrieval.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/frameworks/langchain/index.astro
+++ b/src/pages/docs/frameworks/langchain/index.astro
@@ -1,0 +1,37 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="LangChain guide | Agent-Gantry">
+  <p class="eyebrow">Framework guide</p>
+  <h1>LangChain</h1>
+  <p class="lead">Use Agent-Gantry with LangChain agents and LCEL chains. This page covers basic setup and the first production-friendly path; continue to the advanced page for dynamic retrieval, LLM calls, and operations.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/langchain/advanced/">Advanced LangChain usage →</a></p>
+
+  <h2>Basic page: register once, adapt at the edge</h2>
+  <ol>
+    <li>Create a Gantry instance near application startup.</li>
+    <li>Register deterministic Python functions with descriptions and input schemas.</li>
+    <li>Export framework-native tools for LangChain immediately before constructing the agent, graph, pipeline, or crew.</li>
+    <li>Keep authorization, rate limits, and audit metadata in Gantry instead of duplicating it inside framework glue code.</li>
+  </ol>
+  <pre><code>from agent_gantry import AgentGantry
+from agent_gantry.langchain import LangChainAdapter
+
+gantry = AgentGantry()
+
+def get_order_status(order_id: str) -> str:
+    """Return the current shipping status for an order."""
+    return "in_transit"
+
+gantry.register_tool(get_order_status, tags=["support", "orders"])
+adapter = LangChainAdapter(gantry)
+framework_tools = await adapter.select("check an order", limit=3)  # Native LangChain adapter export.
+</code></pre>
+
+  <h2>First tool-calling loop</h2>
+  <p>Let LangChain own the conversation lifecycle while Gantry owns the tool catalog. Start with a small tool set and assert that the framework receives only safe, documented functions.</p>
+  <div class="callout"><strong>Basic testing checklist:</strong> verify tool names, JSON schemas, auth metadata, and a happy-path invocation before wiring a live model.</div>
+
+  <h2>Basic LLM call guidance</h2>
+  <p>For early prototypes, use the model client already recommended by LangChain. Wrap that client with a thin policy function that records model name, prompt tokens, completion tokens, tool calls, and latency. Once the integration stabilizes, move the policy into Agent-Gantry's LLM adapter layer so other frameworks share the same rules.</p>
+</DocsLayout>

--- a/src/pages/docs/frameworks/langgraph/advanced.astro
+++ b/src/pages/docs/frameworks/langgraph/advanced.astro
@@ -1,0 +1,38 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Advanced LangGraph guide | Agent-Gantry">
+  <p class="eyebrow">Advanced framework guide</p>
+  <h1>Advanced LangGraph</h1>
+  <p class="lead">Scale LangGraph from static tool demos to governed agent workloads with semantic selection, explicit LLM-call policy, tracing, and deployment boundaries.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/langgraph/">← Basic LangGraph usage</a></p>
+
+  <h2>Advanced page: dynamic tool selection</h2>
+  <p>Before each LangGraph run, ask Gantry for a context-aware subset of tools. Combine request metadata, tenant policy, semantic similarity, and reranker results so the agent sees a concise, relevant tool surface.</p>
+  <pre><code>candidate_tools = gantry.select_tools(
+    query=user_message,
+    tags=["support"],
+    limit=8,
+)
+framework_tools = [LangGraphAdapter.convert(spec) for spec in candidate_tools]
+</code></pre>
+
+  <h2>LLM calls and model policy</h2>
+  <p>Centralize LLM calls when LangGraph supports custom model clients; otherwise add middleware around the framework call. The policy should select the provider, enforce budget ceilings, redact sensitive fields, emit token metrics, and decide whether tool results should be summarized before returning to the model.</p>
+  <pre><code>response = llm_policy.complete(
+    framework="LangGraph",
+    model="primary-or-fallback-model",
+    messages=messages,
+    tools=framework_tools,
+    trace_id=trace_id,
+)
+</code></pre>
+
+  <h2>Production patterns</h2>
+  <ul>
+    <li><strong>Observability:</strong> attach trace IDs to every LangGraph run, LLM call, and tool execution.</li>
+    <li><strong>Safety:</strong> keep high-risk tools behind explicit allowlists, human approval, or dry-run executors.</li>
+    <li><strong>Resilience:</strong> add provider fallback for LLM calls and executor fallback for remote MCP/A2A tools.</li>
+    <li><strong>Evaluation:</strong> replay representative prompts with fixed tool snapshots before broadening dynamic retrieval.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/frameworks/langgraph/index.astro
+++ b/src/pages/docs/frameworks/langgraph/index.astro
@@ -1,0 +1,37 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="LangGraph guide | Agent-Gantry">
+  <p class="eyebrow">Framework guide</p>
+  <h1>LangGraph</h1>
+  <p class="lead">Use Agent-Gantry with stateful graphs with conditional tool nodes. This page covers basic setup and the first production-friendly path; continue to the advanced page for dynamic retrieval, LLM calls, and operations.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/langgraph/advanced/">Advanced LangGraph usage →</a></p>
+
+  <h2>Basic page: register once, adapt at the edge</h2>
+  <ol>
+    <li>Create a Gantry instance near application startup.</li>
+    <li>Register deterministic Python functions with descriptions and input schemas.</li>
+    <li>Export framework-native tools for LangGraph immediately before constructing the agent, graph, pipeline, or crew.</li>
+    <li>Keep authorization, rate limits, and audit metadata in Gantry instead of duplicating it inside framework glue code.</li>
+  </ol>
+  <pre><code>from agent_gantry import AgentGantry
+from agent_gantry.langgraph import LangGraphAdapter
+
+gantry = AgentGantry()
+
+def get_order_status(order_id: str) -> str:
+    """Return the current shipping status for an order."""
+    return "in_transit"
+
+gantry.register_tool(get_order_status, tags=["support", "orders"])
+adapter = LangGraphAdapter(gantry)
+framework_tools = await adapter.select("check an order", limit=3)  # Native LangGraph adapter export.
+</code></pre>
+
+  <h2>First tool-calling loop</h2>
+  <p>Let LangGraph own the conversation lifecycle while Gantry owns the tool catalog. Start with a small tool set and assert that the framework receives only safe, documented functions.</p>
+  <div class="callout"><strong>Basic testing checklist:</strong> verify tool names, JSON schemas, auth metadata, and a happy-path invocation before wiring a live model.</div>
+
+  <h2>Basic LLM call guidance</h2>
+  <p>For early prototypes, use the model client already recommended by LangGraph. Wrap that client with a thin policy function that records model name, prompt tokens, completion tokens, tool calls, and latency. Once the integration stabilizes, move the policy into Agent-Gantry's LLM adapter layer so other frameworks share the same rules.</p>
+</DocsLayout>

--- a/src/pages/docs/frameworks/llamaindex/advanced.astro
+++ b/src/pages/docs/frameworks/llamaindex/advanced.astro
@@ -1,0 +1,38 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Advanced LlamaIndex guide | Agent-Gantry">
+  <p class="eyebrow">Advanced framework guide</p>
+  <h1>Advanced LlamaIndex</h1>
+  <p class="lead">Scale LlamaIndex from static tool demos to governed agent workloads with semantic selection, explicit LLM-call policy, tracing, and deployment boundaries.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/llamaindex/">← Basic LlamaIndex usage</a></p>
+
+  <h2>Advanced page: dynamic tool selection</h2>
+  <p>Before each LlamaIndex run, ask Gantry for a context-aware subset of tools. Combine request metadata, tenant policy, semantic similarity, and reranker results so the agent sees a concise, relevant tool surface.</p>
+  <pre><code>candidate_tools = gantry.select_tools(
+    query=user_message,
+    tags=["support"],
+    limit=8,
+)
+framework_tools = [LlamaIndexAdapter.convert(spec) for spec in candidate_tools]
+</code></pre>
+
+  <h2>LLM calls and model policy</h2>
+  <p>Centralize LLM calls when LlamaIndex supports custom model clients; otherwise add middleware around the framework call. The policy should select the provider, enforce budget ceilings, redact sensitive fields, emit token metrics, and decide whether tool results should be summarized before returning to the model.</p>
+  <pre><code>response = llm_policy.complete(
+    framework="LlamaIndex",
+    model="primary-or-fallback-model",
+    messages=messages,
+    tools=framework_tools,
+    trace_id=trace_id,
+)
+</code></pre>
+
+  <h2>Production patterns</h2>
+  <ul>
+    <li><strong>Observability:</strong> attach trace IDs to every LlamaIndex run, LLM call, and tool execution.</li>
+    <li><strong>Safety:</strong> keep high-risk tools behind explicit allowlists, human approval, or dry-run executors.</li>
+    <li><strong>Resilience:</strong> add provider fallback for LLM calls and executor fallback for remote MCP/A2A tools.</li>
+    <li><strong>Evaluation:</strong> replay representative prompts with fixed tool snapshots before broadening dynamic retrieval.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/frameworks/llamaindex/index.astro
+++ b/src/pages/docs/frameworks/llamaindex/index.astro
@@ -1,0 +1,37 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="LlamaIndex guide | Agent-Gantry">
+  <p class="eyebrow">Framework guide</p>
+  <h1>LlamaIndex</h1>
+  <p class="lead">Use Agent-Gantry with query engines, agents, and retrieval workflows. This page covers basic setup and the first production-friendly path; continue to the advanced page for dynamic retrieval, LLM calls, and operations.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/llamaindex/advanced/">Advanced LlamaIndex usage →</a></p>
+
+  <h2>Basic page: register once, adapt at the edge</h2>
+  <ol>
+    <li>Create a Gantry instance near application startup.</li>
+    <li>Register deterministic Python functions with descriptions and input schemas.</li>
+    <li>Export framework-native tools for LlamaIndex immediately before constructing the agent, graph, pipeline, or crew.</li>
+    <li>Keep authorization, rate limits, and audit metadata in Gantry instead of duplicating it inside framework glue code.</li>
+  </ol>
+  <pre><code>from agent_gantry import AgentGantry
+from agent_gantry.llamaindex import LlamaIndexAdapter
+
+gantry = AgentGantry()
+
+def get_order_status(order_id: str) -> str:
+    """Return the current shipping status for an order."""
+    return "in_transit"
+
+gantry.register_tool(get_order_status, tags=["support", "orders"])
+adapter = LlamaIndexAdapter(gantry)
+framework_tools = await adapter.select("check an order", limit=3)  # Native LlamaIndex adapter export.
+</code></pre>
+
+  <h2>First tool-calling loop</h2>
+  <p>Let LlamaIndex own the conversation lifecycle while Gantry owns the tool catalog. Start with a small tool set and assert that the framework receives only safe, documented functions.</p>
+  <div class="callout"><strong>Basic testing checklist:</strong> verify tool names, JSON schemas, auth metadata, and a happy-path invocation before wiring a live model.</div>
+
+  <h2>Basic LLM call guidance</h2>
+  <p>For early prototypes, use the model client already recommended by LlamaIndex. Wrap that client with a thin policy function that records model name, prompt tokens, completion tokens, tool calls, and latency. Once the integration stabilizes, move the policy into Agent-Gantry's LLM adapter layer so other frameworks share the same rules.</p>
+</DocsLayout>

--- a/src/pages/docs/frameworks/openai-agents/advanced.astro
+++ b/src/pages/docs/frameworks/openai-agents/advanced.astro
@@ -1,0 +1,38 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Advanced OpenAI Agents SDK guide | Agent-Gantry">
+  <p class="eyebrow">Advanced framework guide</p>
+  <h1>Advanced OpenAI Agents SDK</h1>
+  <p class="lead">Scale OpenAI Agents SDK from static tool demos to governed agent workloads with semantic selection, explicit LLM-call policy, tracing, and deployment boundaries.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/openai-agents/">← Basic OpenAI Agents SDK usage</a></p>
+
+  <h2>Advanced page: dynamic tool selection</h2>
+  <p>Before each OpenAI Agents SDK run, ask Gantry for a context-aware subset of tools. Combine request metadata, tenant policy, semantic similarity, and reranker results so the agent sees a concise, relevant tool surface.</p>
+  <pre><code>candidate_tools = gantry.select_tools(
+    query=user_message,
+    tags=["support"],
+    limit=8,
+)
+framework_tools = [OpenAIAgentsAdapter.convert(spec) for spec in candidate_tools]
+</code></pre>
+
+  <h2>LLM calls and model policy</h2>
+  <p>Centralize LLM calls when OpenAI Agents SDK supports custom model clients; otherwise add middleware around the framework call. The policy should select the provider, enforce budget ceilings, redact sensitive fields, emit token metrics, and decide whether tool results should be summarized before returning to the model.</p>
+  <pre><code>response = llm_policy.complete(
+    framework="OpenAI Agents SDK",
+    model="primary-or-fallback-model",
+    messages=messages,
+    tools=framework_tools,
+    trace_id=trace_id,
+)
+</code></pre>
+
+  <h2>Production patterns</h2>
+  <ul>
+    <li><strong>Observability:</strong> attach trace IDs to every OpenAI Agents SDK run, LLM call, and tool execution.</li>
+    <li><strong>Safety:</strong> keep high-risk tools behind explicit allowlists, human approval, or dry-run executors.</li>
+    <li><strong>Resilience:</strong> add provider fallback for LLM calls and executor fallback for remote MCP/A2A tools.</li>
+    <li><strong>Evaluation:</strong> replay representative prompts with fixed tool snapshots before broadening dynamic retrieval.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/frameworks/openai-agents/index.astro
+++ b/src/pages/docs/frameworks/openai-agents/index.astro
@@ -1,0 +1,37 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="OpenAI Agents SDK guide | Agent-Gantry">
+  <p class="eyebrow">Framework guide</p>
+  <h1>OpenAI Agents SDK</h1>
+  <p class="lead">Use Agent-Gantry with handoffs, hosted tools, and function tools. This page covers basic setup and the first production-friendly path; continue to the advanced page for dynamic retrieval, LLM calls, and operations.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/openai-agents/advanced/">Advanced OpenAI Agents SDK usage →</a></p>
+
+  <h2>Basic page: register once, adapt at the edge</h2>
+  <ol>
+    <li>Create a Gantry instance near application startup.</li>
+    <li>Register deterministic Python functions with descriptions and input schemas.</li>
+    <li>Export framework-native tools for OpenAI Agents SDK immediately before constructing the agent, graph, pipeline, or crew.</li>
+    <li>Keep authorization, rate limits, and audit metadata in Gantry instead of duplicating it inside framework glue code.</li>
+  </ol>
+  <pre><code>from agent_gantry import AgentGantry
+from agent_gantry.openai_agents import OpenAIAgentsAdapter
+
+gantry = AgentGantry()
+
+def get_order_status(order_id: str) -> str:
+    """Return the current shipping status for an order."""
+    return "in_transit"
+
+gantry.register_tool(get_order_status, tags=["support", "orders"])
+adapter = OpenAIAgentsAdapter(gantry)
+framework_tools = await adapter.select("check an order", limit=3)  # Native OpenAI Agents SDK adapter export.
+</code></pre>
+
+  <h2>First tool-calling loop</h2>
+  <p>Let OpenAI Agents SDK own the conversation lifecycle while Gantry owns the tool catalog. Start with a small tool set and assert that the framework receives only safe, documented functions.</p>
+  <div class="callout"><strong>Basic testing checklist:</strong> verify tool names, JSON schemas, auth metadata, and a happy-path invocation before wiring a live model.</div>
+
+  <h2>Basic LLM call guidance</h2>
+  <p>For early prototypes, use the model client already recommended by OpenAI Agents SDK. Wrap that client with a thin policy function that records model name, prompt tokens, completion tokens, tool calls, and latency. Once the integration stabilizes, move the policy into Agent-Gantry's LLM adapter layer so other frameworks share the same rules.</p>
+</DocsLayout>

--- a/src/pages/docs/frameworks/pydantic-ai/advanced.astro
+++ b/src/pages/docs/frameworks/pydantic-ai/advanced.astro
@@ -1,0 +1,38 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Advanced Pydantic AI guide | Agent-Gantry">
+  <p class="eyebrow">Advanced framework guide</p>
+  <h1>Advanced Pydantic AI</h1>
+  <p class="lead">Scale Pydantic AI from static tool demos to governed agent workloads with semantic selection, explicit LLM-call policy, tracing, and deployment boundaries.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/pydantic-ai/">← Basic Pydantic AI usage</a></p>
+
+  <h2>Advanced page: dynamic tool selection</h2>
+  <p>Before each Pydantic AI run, ask Gantry for a context-aware subset of tools. Combine request metadata, tenant policy, semantic similarity, and reranker results so the agent sees a concise, relevant tool surface.</p>
+  <pre><code>candidate_tools = gantry.select_tools(
+    query=user_message,
+    tags=["support"],
+    limit=8,
+)
+framework_tools = [PydanticAIAdapter.convert(spec) for spec in candidate_tools]
+</code></pre>
+
+  <h2>LLM calls and model policy</h2>
+  <p>Centralize LLM calls when Pydantic AI supports custom model clients; otherwise add middleware around the framework call. The policy should select the provider, enforce budget ceilings, redact sensitive fields, emit token metrics, and decide whether tool results should be summarized before returning to the model.</p>
+  <pre><code>response = llm_policy.complete(
+    framework="Pydantic AI",
+    model="primary-or-fallback-model",
+    messages=messages,
+    tools=framework_tools,
+    trace_id=trace_id,
+)
+</code></pre>
+
+  <h2>Production patterns</h2>
+  <ul>
+    <li><strong>Observability:</strong> attach trace IDs to every Pydantic AI run, LLM call, and tool execution.</li>
+    <li><strong>Safety:</strong> keep high-risk tools behind explicit allowlists, human approval, or dry-run executors.</li>
+    <li><strong>Resilience:</strong> add provider fallback for LLM calls and executor fallback for remote MCP/A2A tools.</li>
+    <li><strong>Evaluation:</strong> replay representative prompts with fixed tool snapshots before broadening dynamic retrieval.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/frameworks/pydantic-ai/index.astro
+++ b/src/pages/docs/frameworks/pydantic-ai/index.astro
@@ -1,0 +1,37 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Pydantic AI guide | Agent-Gantry">
+  <p class="eyebrow">Framework guide</p>
+  <h1>Pydantic AI</h1>
+  <p class="lead">Use Agent-Gantry with typed agents with validated dependencies. This page covers basic setup and the first production-friendly path; continue to the advanced page for dynamic retrieval, LLM calls, and operations.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/pydantic-ai/advanced/">Advanced Pydantic AI usage →</a></p>
+
+  <h2>Basic page: register once, adapt at the edge</h2>
+  <ol>
+    <li>Create a Gantry instance near application startup.</li>
+    <li>Register deterministic Python functions with descriptions and input schemas.</li>
+    <li>Export framework-native tools for Pydantic AI immediately before constructing the agent, graph, pipeline, or crew.</li>
+    <li>Keep authorization, rate limits, and audit metadata in Gantry instead of duplicating it inside framework glue code.</li>
+  </ol>
+  <pre><code>from agent_gantry import AgentGantry
+from agent_gantry.pydantic_ai import PydanticAIAdapter
+
+gantry = AgentGantry()
+
+def get_order_status(order_id: str) -> str:
+    """Return the current shipping status for an order."""
+    return "in_transit"
+
+gantry.register_tool(get_order_status, tags=["support", "orders"])
+adapter = PydanticAIAdapter(gantry)
+framework_tools = await adapter.select("check an order", limit=3)  # Native Pydantic AI adapter export.
+</code></pre>
+
+  <h2>First tool-calling loop</h2>
+  <p>Let Pydantic AI own the conversation lifecycle while Gantry owns the tool catalog. Start with a small tool set and assert that the framework receives only safe, documented functions.</p>
+  <div class="callout"><strong>Basic testing checklist:</strong> verify tool names, JSON schemas, auth metadata, and a happy-path invocation before wiring a live model.</div>
+
+  <h2>Basic LLM call guidance</h2>
+  <p>For early prototypes, use the model client already recommended by Pydantic AI. Wrap that client with a thin policy function that records model name, prompt tokens, completion tokens, tool calls, and latency. Once the integration stabilizes, move the policy into Agent-Gantry's LLM adapter layer so other frameworks share the same rules.</p>
+</DocsLayout>

--- a/src/pages/docs/frameworks/semantic-kernel/advanced.astro
+++ b/src/pages/docs/frameworks/semantic-kernel/advanced.astro
@@ -1,0 +1,38 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Advanced Semantic Kernel guide | Agent-Gantry">
+  <p class="eyebrow">Advanced framework guide</p>
+  <h1>Advanced Semantic Kernel</h1>
+  <p class="lead">Scale Semantic Kernel from static tool demos to governed agent workloads with semantic selection, explicit LLM-call policy, tracing, and deployment boundaries.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/semantic-kernel/">← Basic Semantic Kernel usage</a></p>
+
+  <h2>Advanced page: dynamic tool selection</h2>
+  <p>Before each Semantic Kernel run, ask Gantry for a context-aware subset of tools. Combine request metadata, tenant policy, semantic similarity, and reranker results so the agent sees a concise, relevant tool surface.</p>
+  <pre><code>candidate_tools = gantry.select_tools(
+    query=user_message,
+    tags=["support"],
+    limit=8,
+)
+framework_tools = [SemanticKernelAdapter.convert(spec) for spec in candidate_tools]
+</code></pre>
+
+  <h2>LLM calls and model policy</h2>
+  <p>Centralize LLM calls when Semantic Kernel supports custom model clients; otherwise add middleware around the framework call. The policy should select the provider, enforce budget ceilings, redact sensitive fields, emit token metrics, and decide whether tool results should be summarized before returning to the model.</p>
+  <pre><code>response = llm_policy.complete(
+    framework="Semantic Kernel",
+    model="primary-or-fallback-model",
+    messages=messages,
+    tools=framework_tools,
+    trace_id=trace_id,
+)
+</code></pre>
+
+  <h2>Production patterns</h2>
+  <ul>
+    <li><strong>Observability:</strong> attach trace IDs to every Semantic Kernel run, LLM call, and tool execution.</li>
+    <li><strong>Safety:</strong> keep high-risk tools behind explicit allowlists, human approval, or dry-run executors.</li>
+    <li><strong>Resilience:</strong> add provider fallback for LLM calls and executor fallback for remote MCP/A2A tools.</li>
+    <li><strong>Evaluation:</strong> replay representative prompts with fixed tool snapshots before broadening dynamic retrieval.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/frameworks/semantic-kernel/index.astro
+++ b/src/pages/docs/frameworks/semantic-kernel/index.astro
@@ -1,0 +1,37 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Semantic Kernel guide | Agent-Gantry">
+  <p class="eyebrow">Framework guide</p>
+  <h1>Semantic Kernel</h1>
+  <p class="lead">Use Agent-Gantry with plugins, planners, and kernel functions. This page covers basic setup and the first production-friendly path; continue to the advanced page for dynamic retrieval, LLM calls, and operations.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/semantic-kernel/advanced/">Advanced Semantic Kernel usage →</a></p>
+
+  <h2>Basic page: register once, adapt at the edge</h2>
+  <ol>
+    <li>Create a Gantry instance near application startup.</li>
+    <li>Register deterministic Python functions with descriptions and input schemas.</li>
+    <li>Export framework-native tools for Semantic Kernel immediately before constructing the agent, graph, pipeline, or crew.</li>
+    <li>Keep authorization, rate limits, and audit metadata in Gantry instead of duplicating it inside framework glue code.</li>
+  </ol>
+  <pre><code>from agent_gantry import AgentGantry
+from agent_gantry.semantic_kernel import SemanticKernelAdapter
+
+gantry = AgentGantry()
+
+def get_order_status(order_id: str) -> str:
+    """Return the current shipping status for an order."""
+    return "in_transit"
+
+gantry.register_tool(get_order_status, tags=["support", "orders"])
+adapter = SemanticKernelAdapter(gantry)
+framework_tools = await adapter.select("check an order", limit=3)  # Native Semantic Kernel adapter export.
+</code></pre>
+
+  <h2>First tool-calling loop</h2>
+  <p>Let Semantic Kernel own the conversation lifecycle while Gantry owns the tool catalog. Start with a small tool set and assert that the framework receives only safe, documented functions.</p>
+  <div class="callout"><strong>Basic testing checklist:</strong> verify tool names, JSON schemas, auth metadata, and a happy-path invocation before wiring a live model.</div>
+
+  <h2>Basic LLM call guidance</h2>
+  <p>For early prototypes, use the model client already recommended by Semantic Kernel. Wrap that client with a thin policy function that records model name, prompt tokens, completion tokens, tool calls, and latency. Once the integration stabilizes, move the policy into Agent-Gantry's LLM adapter layer so other frameworks share the same rules.</p>
+</DocsLayout>

--- a/src/pages/docs/frameworks/smolagents/advanced.astro
+++ b/src/pages/docs/frameworks/smolagents/advanced.astro
@@ -1,0 +1,38 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Advanced Smolagents guide | Agent-Gantry">
+  <p class="eyebrow">Advanced framework guide</p>
+  <h1>Advanced Smolagents</h1>
+  <p class="lead">Scale Smolagents from static tool demos to governed agent workloads with semantic selection, explicit LLM-call policy, tracing, and deployment boundaries.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/smolagents/">← Basic Smolagents usage</a></p>
+
+  <h2>Advanced page: dynamic tool selection</h2>
+  <p>Before each Smolagents run, ask Gantry for a context-aware subset of tools. Combine request metadata, tenant policy, semantic similarity, and reranker results so the agent sees a concise, relevant tool surface.</p>
+  <pre><code>candidate_tools = gantry.select_tools(
+    query=user_message,
+    tags=["support"],
+    limit=8,
+)
+framework_tools = [SmolagentsAdapter.convert(spec) for spec in candidate_tools]
+</code></pre>
+
+  <h2>LLM calls and model policy</h2>
+  <p>Centralize LLM calls when Smolagents supports custom model clients; otherwise add middleware around the framework call. The policy should select the provider, enforce budget ceilings, redact sensitive fields, emit token metrics, and decide whether tool results should be summarized before returning to the model.</p>
+  <pre><code>response = llm_policy.complete(
+    framework="Smolagents",
+    model="primary-or-fallback-model",
+    messages=messages,
+    tools=framework_tools,
+    trace_id=trace_id,
+)
+</code></pre>
+
+  <h2>Production patterns</h2>
+  <ul>
+    <li><strong>Observability:</strong> attach trace IDs to every Smolagents run, LLM call, and tool execution.</li>
+    <li><strong>Safety:</strong> keep high-risk tools behind explicit allowlists, human approval, or dry-run executors.</li>
+    <li><strong>Resilience:</strong> add provider fallback for LLM calls and executor fallback for remote MCP/A2A tools.</li>
+    <li><strong>Evaluation:</strong> replay representative prompts with fixed tool snapshots before broadening dynamic retrieval.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/frameworks/smolagents/index.astro
+++ b/src/pages/docs/frameworks/smolagents/index.astro
@@ -1,0 +1,37 @@
+---
+import DocsLayout from '../../../../layouts/DocsLayout.astro';
+---
+<DocsLayout title="Smolagents guide | Agent-Gantry">
+  <p class="eyebrow">Framework guide</p>
+  <h1>Smolagents</h1>
+  <p class="lead">Use Agent-Gantry with lightweight code and tool-calling agents. This page covers basic setup and the first production-friendly path; continue to the advanced page for dynamic retrieval, LLM calls, and operations.</p>
+  <p><a class="pill" href="/Agent-Gantry/docs/frameworks/smolagents/advanced/">Advanced Smolagents usage →</a></p>
+
+  <h2>Basic page: register once, adapt at the edge</h2>
+  <ol>
+    <li>Create a Gantry instance near application startup.</li>
+    <li>Register deterministic Python functions with descriptions and input schemas.</li>
+    <li>Export framework-native tools for Smolagents immediately before constructing the agent, graph, pipeline, or crew.</li>
+    <li>Keep authorization, rate limits, and audit metadata in Gantry instead of duplicating it inside framework glue code.</li>
+  </ol>
+  <pre><code>from agent_gantry import AgentGantry
+from agent_gantry.smolagents import SmolagentsAdapter
+
+gantry = AgentGantry()
+
+def get_order_status(order_id: str) -> str:
+    """Return the current shipping status for an order."""
+    return "in_transit"
+
+gantry.register_tool(get_order_status, tags=["support", "orders"])
+adapter = SmolagentsAdapter(gantry)
+framework_tools = await adapter.select("check an order", limit=3)  # Native Smolagents adapter export.
+</code></pre>
+
+  <h2>First tool-calling loop</h2>
+  <p>Let Smolagents own the conversation lifecycle while Gantry owns the tool catalog. Start with a small tool set and assert that the framework receives only safe, documented functions.</p>
+  <div class="callout"><strong>Basic testing checklist:</strong> verify tool names, JSON schemas, auth metadata, and a happy-path invocation before wiring a live model.</div>
+
+  <h2>Basic LLM call guidance</h2>
+  <p>For early prototypes, use the model client already recommended by Smolagents. Wrap that client with a thin policy function that records model name, prompt tokens, completion tokens, tool calls, and latency. Once the integration stabilizes, move the policy into Agent-Gantry's LLM adapter layer so other frameworks share the same rules.</p>
+</DocsLayout>


### PR DESCRIPTION
### Motivation
- Provide framework-by-framework, stepwise guidance (basic → advanced) including LLM-call guidance so integrators have clear, consistent recipes per framework. 
- Surface concrete adapter usage examples so teams can register tools once in Gantry and export native tools at the framework boundary.
- Stop running the legacy GitHub Pages deploy in CI because the `upload-pages-artifact` + `deploy-pages` job is no longer desired.

### Description
- Introduce a framework hub page at `src/pages/docs/frameworks.astro` that links to per-framework guides and explains the two-page learning path (basic + advanced). 
- Add basic and advanced docs for the supported frameworks under `src/pages/docs/frameworks/` for: `LangChain`, `LangGraph`, `LlamaIndex`, `CrewAI`, `AutoGen`, `Semantic Kernel`, `Google ADK`, `Pydantic AI`, `OpenAI Agents SDK`, `Smolagents`, `Haystack`, and `Agno`, with concrete adapter usage examples (e.g. `LangChainAdapter`).
- Ensure examples show how to register tools with `AgentGantry` and export/select native framework tools via adapters (e.g. `adapter = LangChainAdapter(gantry)` and `framework_tools = await adapter.select(...)`).
- Remove the GitHub Pages artifact upload and deploy job from the docs workflow by editing `.github/workflows/docs.yml` so the workflow now only verifies the Astro build (`npm ci` + `npm run build`), keeping the build verification but not the Pages deployment.

### Testing
- Ran `npm ci` to install docs dependencies and the step completed successfully. 
- Ran `npm run build` (which runs `astro check && astro build`) and the Astro site build completed with no TypeScript errors and produced the static pages (build completed successfully). 
- Ran automated site checks as part of the build (`astro check`) and the build finished with 0 errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30523ddb84832ca45f6aab37ea2d97)