### PR TITLE
🎨 Palette: Add keyboard accessibility to scrollable code blocks

### DIFF
--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,11 +1,20 @@
-import { codeToHtml } from 'shiki';
+import { codeToHtml } from "shiki";
 
 export async function highlightCode(
   code: string,
-  lang: string = 'python',
+  lang: string = "python",
 ): Promise<string> {
   return codeToHtml(code.trimEnd(), {
     lang,
-    theme: 'github-dark-default',
+    theme: "github-dark-default",
+    transformers: [
+      {
+        pre(node) {
+          node.properties["tabindex"] = "0";
+          node.properties["role"] = "region";
+          node.properties["aria-label"] = "Code snippet";
+        },
+      },
+    ],
   });
 }


### PR DESCRIPTION
💡 What: Added `tabindex=0`, `role=region`, and `aria-label=Code snippet` to `shiki` generated `<pre>` elements.
🎯 Why: Without these attributes, keyboard-only users cannot scroll horizontally to read truncated code, and screen readers fail to announce the container context.
♿ Accessibility: Ensures full keyboard navigability and screen reader support for code blocks.

---
*PR created automatically by Jules for task [9657038972628781877](https://jules.google.com/task/9657038972628781877) started by @CodeHalwell*