### PR TITLE
Refactor Agent Framework integration and extract factory functions

### DIFF
--- a/agent_gantry/core/factories.py
+++ b/agent_gantry/core/factories.py
@@ -4,8 +4,11 @@ These factories translate the declarative ``*Config`` models into concrete
 adapter instances (vector store, embedder, reranker, telemetry). They are kept
 out of :class:`~agent_gantry.core.gantry.AgentGantry` because they hold no
 instance state — each is a pure ``config -> adapter`` mapping — which keeps the
-facade focused on orchestration. Backend-specific imports stay lazy so the base
-install never requires the optional dependencies.
+facade focused on orchestration. Imports for the optional backends (Qdrant,
+Chroma, PGVector, LanceDB, Nomic, sentence-transformers, Cohere, …) stay lazy —
+inside the branch that needs them — so the base install never requires them; the
+always-available adapters (in-memory store, simple/OpenAI embedders, telemetry)
+are imported at module load.
 """
 
 from __future__ import annotations

--- a/agent_gantry/core/factories.py
+++ b/agent_gantry/core/factories.py
@@ -1,0 +1,156 @@
+"""Configuration-driven construction of Agent-Gantry's pluggable adapters.
+
+These factories translate the declarative ``*Config`` models into concrete
+adapter instances (vector store, embedder, reranker, telemetry). They are kept
+out of :class:`~agent_gantry.core.gantry.AgentGantry` because they hold no
+instance state — each is a pure ``config -> adapter`` mapping — which keeps the
+facade focused on orchestration. Backend-specific imports stay lazy so the base
+install never requires the optional dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, cast
+
+from agent_gantry.adapters.embedders.openai import AzureOpenAIEmbedder, OpenAIEmbedder
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+from agent_gantry.adapters.vector_stores.memory import InMemoryVectorStore
+from agent_gantry.observability.console import ConsoleTelemetryAdapter, NoopTelemetryAdapter
+from agent_gantry.observability.opentelemetry_adapter import (
+    OpenTelemetryAdapter,
+    PrometheusTelemetryAdapter,
+)
+
+if TYPE_CHECKING:
+    from agent_gantry.adapters.embedders.base import EmbeddingAdapter
+    from agent_gantry.adapters.rerankers.base import RerankerAdapter
+    from agent_gantry.adapters.vector_stores.base import VectorStoreAdapter
+    from agent_gantry.observability.telemetry import TelemetryAdapter
+    from agent_gantry.schema.config import (
+        EmbedderConfig,
+        RerankerConfig,
+        TelemetryConfig,
+        VectorStoreConfig,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+def build_vector_store(config: VectorStoreConfig) -> VectorStoreAdapter:
+    """Construct a vector store adapter from configuration."""
+    if config.type == "qdrant":
+        from agent_gantry.adapters.vector_stores.remote import QdrantVectorStore
+
+        if not config.url:
+            raise ValueError("Qdrant requires 'url' in configuration")
+        return cast(
+            "VectorStoreAdapter",
+            QdrantVectorStore(
+                url=config.url,
+                api_key=config.api_key,
+                collection_name=config.collection_name,
+                dimension=config.dimension or 1536,
+            ),
+        )
+    if config.type == "chroma":
+        from agent_gantry.adapters.vector_stores.remote import ChromaVectorStore
+
+        return cast(
+            "VectorStoreAdapter",
+            ChromaVectorStore(
+                url=config.url,
+                collection_name=config.collection_name,
+                persist_directory=config.db_path,
+            ),
+        )
+    if config.type == "pgvector":
+        from agent_gantry.adapters.vector_stores.remote import PGVectorStore
+
+        if not config.url:
+            raise ValueError("PGVector requires 'url' (connection string) in configuration")
+        return cast(
+            "VectorStoreAdapter",
+            PGVectorStore(
+                url=config.url,
+                table_name=config.collection_name,
+                dimension=config.dimension or 1536,
+            ),
+        )
+    if config.type == "lancedb":
+        from agent_gantry.adapters.vector_stores.lancedb import LanceDBVectorStore
+
+        return cast(
+            "VectorStoreAdapter",
+            LanceDBVectorStore(
+                db_path=config.db_path,
+                tools_table=config.collection_name,
+                dimension=config.dimension or 768,
+            ),
+        )
+    return InMemoryVectorStore()
+
+
+def build_embedder(config: EmbedderConfig) -> EmbeddingAdapter:
+    """Construct an embedder from configuration."""
+    if config.type == "openai" and config.api_key:
+        return OpenAIEmbedder(config)
+    if config.type == "azure" and config.api_key:
+        return AzureOpenAIEmbedder(config)
+    if config.type == "nomic":
+        from agent_gantry.adapters.embedders.nomic import NomicEmbedder
+
+        return NomicEmbedder(
+            model=config.model or "nomic-ai/nomic-embed-text-v1.5",
+            dimension=config.dimension,
+            task_type=config.task_type or "search_document",
+        )
+    if config.type == "sentence_transformers":
+        try:
+            import sentence_transformers as _st  # noqa: F401
+
+            from agent_gantry.adapters.embedders.sentence_transformers import (
+                SentenceTransformersEmbedder,
+            )
+
+            return SentenceTransformersEmbedder(
+                model=config.model or "all-MiniLM-L6-v2",
+                dimension=config.dimension,
+            )
+        except ImportError:
+            logger.debug("sentence-transformers not available, falling back to SimpleEmbedder")
+    return SimpleEmbedder()
+
+
+def build_reranker(config: RerankerConfig) -> RerankerAdapter | None:
+    """Construct a reranker from configuration."""
+    if not config.enabled:
+        return None
+    if config.type == "cohere":
+        from agent_gantry.adapters.rerankers.cohere import CohereReranker
+
+        return CohereReranker(model=config.model)
+    if config.type == "cross_encoder":
+        from agent_gantry.adapters.rerankers.cross_encoder import CrossEncoderReranker
+
+        return CrossEncoderReranker(
+            model=config.model or "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        )
+    return None
+
+
+def build_telemetry(config: TelemetryConfig) -> TelemetryAdapter:
+    """Construct telemetry adapter from configuration."""
+    if not config.enabled:
+        return NoopTelemetryAdapter()
+    if config.type == "opentelemetry":
+        return OpenTelemetryAdapter(
+            service_name=config.service_name,
+            otlp_endpoint=config.otlp_endpoint,
+        )
+    if config.type == "prometheus":
+        return PrometheusTelemetryAdapter(
+            service_name=config.service_name,
+            prometheus_port=config.prometheus_port,
+        )
+    return ConsoleTelemetryAdapter()

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -149,6 +149,8 @@ class AgentGantry:
             )
         except ImportError:
             logger.debug("MCP support not available (install 'mcp' package to enable)")
+            # Re-null in case registry/router were assigned before a later
+            # construction (e.g. MCPManager) raised — leave no half-wired trio.
             self._mcp_registry = None
             self._mcp_router = None
             self._mcp_manager = None

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -126,7 +126,11 @@ class AgentGantry:
         self._mcp_registry = None
         self._mcp_router = None
         self._mcp_manager = None
+        # All imports AND constructions live in one try so a partially installed
+        # MCP stack (any of the three failing) degrades to None across the board
+        # rather than leaving a half-wired trio or raising.
         try:
+            from agent_gantry.core.mcp_manager import MCPManager
             from agent_gantry.core.mcp_registry import MCPRegistry
             from agent_gantry.core.mcp_router import MCPRouter
 
@@ -136,19 +140,18 @@ class AgentGantry:
                 embedder=self._embedder,
                 registry=self._mcp_registry,
             )
+            self._mcp_manager = MCPManager(
+                vector_store=self._vector_store,
+                embedder=self._embedder,
+                registry=self._mcp_registry,
+                router=self._mcp_router,
+                get_embedder_id=self._sync_manager.get_embedder_id,
+            )
         except ImportError:
             logger.debug("MCP support not available (install 'mcp' package to enable)")
-            return
-
-        from agent_gantry.core.mcp_manager import MCPManager
-
-        self._mcp_manager = MCPManager(
-            vector_store=self._vector_store,
-            embedder=self._embedder,
-            registry=self._mcp_registry,
-            router=self._mcp_router,
-            get_embedder_id=self._sync_manager.get_embedder_id,
-        )
+            self._mcp_registry = None
+            self._mcp_router = None
+            self._mcp_manager = None
 
     def _create_llm_client(self) -> Any:
         """Build the optional LLM client used for intent classification."""

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from agent_gantry.adapters.embedders.base import EmbeddingAdapter
     from agent_gantry.adapters.rerankers.base import RerankerAdapter
     from agent_gantry.adapters.vector_stores.base import VectorStoreAdapter
+    from agent_gantry.core.rate_limiter import RateLimiter
     from agent_gantry.observability.telemetry import TelemetryAdapter
     from agent_gantry.schema.execution import BatchToolCall, BatchToolResult, ToolCall, ToolResult
 
@@ -98,17 +99,34 @@ class AgentGantry:
         self._security_policy = security_policy or SecurityPolicy()
         self._registry = ToolRegistry()
 
-        # Initialize MCP registry and router for dynamic server selection.
-        # These imports are kept inside __init__ to avoid requiring the 'mcp'
-        # package at module level (it's an optional dependency).
+        # SyncManager has no optional-dependency requirements and the MCP
+        # manager depends on it, so build it before wiring MCP support.
         from agent_gantry.core.sync_manager import SyncManager
 
+        self._sync_manager = SyncManager(
+            vector_store=self._vector_store,
+            embedder=self._embedder,
+            registry=self._registry,
+        )
+
+        self._create_mcp_components()
+        self._llm_client = self._create_llm_client()
+        self._router = self._create_router()
+        self._rate_limiter = self._create_rate_limiter()
+        self._executor = self._create_executor()
+        self._init_runtime_state(modules, module_attr)
+
+    def _create_mcp_components(self) -> None:
+        """Wire the optional MCP registry/router/manager trio.
+
+        MCP is an optional dependency: if the ``mcp`` package is unavailable the
+        three attributes stay ``None`` and MCP features degrade gracefully. The
+        manager depends on :attr:`_sync_manager`, so this runs after it exists.
+        """
         self._mcp_registry = None
         self._mcp_router = None
         self._mcp_manager = None
-
         try:
-            from agent_gantry.core.mcp_manager import MCPManager
             from agent_gantry.core.mcp_registry import MCPRegistry
             from agent_gantry.core.mcp_router import MCPRouter
 
@@ -120,51 +138,52 @@ class AgentGantry:
             )
         except ImportError:
             logger.debug("MCP support not available (install 'mcp' package to enable)")
+            return
 
-        # Managers for decomposed responsibilities
-        self._sync_manager = SyncManager(
+        from agent_gantry.core.mcp_manager import MCPManager
+
+        self._mcp_manager = MCPManager(
             vector_store=self._vector_store,
             embedder=self._embedder,
-            registry=self._registry,
+            registry=self._mcp_registry,
+            router=self._mcp_router,
+            get_embedder_id=self._sync_manager.get_embedder_id,
         )
-        if self._mcp_registry and self._mcp_router:
-            from agent_gantry.core.mcp_manager import MCPManager
 
-            self._mcp_manager = MCPManager(
-                vector_store=self._vector_store,
-                embedder=self._embedder,
-                registry=self._mcp_registry,
-                router=self._mcp_router,
-                get_embedder_id=self._sync_manager.get_embedder_id,
-            )
+    def _create_llm_client(self) -> Any:
+        """Build the optional LLM client used for intent classification."""
+        if not self._config.routing.use_llm_for_intent:
+            return None
+        from agent_gantry.adapters.llm_client import LLMClient
 
-        # Initialize LLM client for intent classification if enabled
-        self._llm_client = None
-        if self._config.routing.use_llm_for_intent:
-            from agent_gantry.adapters.llm_client import LLMClient
+        try:
+            return LLMClient(self._config.routing.llm)
+        except Exception as e:
+            logger.warning(f"Failed to initialize LLM client for intent classification: {e}")
+            return None
 
-            try:
-                self._llm_client = LLMClient(self._config.routing.llm)
-            except Exception as e:
-                logger.warning(f"Failed to initialize LLM client for intent classification: {e}")
-
-        routing_weights = RoutingWeights(**self._config.routing.weights)
-        self._router = SemanticRouter(
+    def _create_router(self) -> SemanticRouter:
+        """Build the semantic router from routing config."""
+        return SemanticRouter(
             vector_store=self._vector_store,
             embedder=self._embedder,
             reranker=self._reranker,
-            weights=routing_weights,
+            weights=RoutingWeights(**self._config.routing.weights),
             llm_client=self._llm_client,
             use_llm_for_intent=self._config.routing.use_llm_for_intent,
         )
-        # Build rate limiter from config
+
+    def _create_rate_limiter(self) -> RateLimiter | None:
+        """Build the optional rate limiter from execution config."""
+        if not self._config.execution.rate_limit.enabled:
+            return None
         from agent_gantry.core.rate_limiter import RateLimiter
 
-        self._rate_limiter: RateLimiter | None = None
-        if self._config.execution.rate_limit.enabled:
-            self._rate_limiter = RateLimiter(self._config.execution.rate_limit)
+        return RateLimiter(self._config.execution.rate_limit)
 
-        self._executor = ExecutionEngine(
+    def _create_executor(self) -> ExecutionEngine:
+        """Build the execution engine from execution config."""
+        return ExecutionEngine(
             registry=self._registry,
             default_timeout_ms=self._config.execution.default_timeout_ms,
             max_retries=self._config.execution.max_retries,
@@ -174,6 +193,16 @@ class AgentGantry:
             telemetry=self._telemetry,
             rate_limiter=self._rate_limiter,
         )
+
+    def _init_runtime_state(
+        self, modules: Sequence[str] | None, module_attr: str
+    ) -> None:
+        """Initialise the mutable buffers, handler maps, callbacks, and flags.
+
+        ``modules`` is stored for explicit async initialization later (via
+        ``collect_tools_from_modules`` or ``AgentGantry.from_modules``); it is
+        not loaded here because import + embedding is async.
+        """
         self._pending_tools: list[ToolDefinition] = []
         self._pending_mcp_servers: list[MCPServerDefinition] = []
         self._tool_handlers: dict[str, Callable[..., Any]] = {}
@@ -182,15 +211,8 @@ class AgentGantry:
         self._initialized = False
         self._synced = False  # Track if we've done initial sync check
         self._mcp_synced = False  # Track if MCP servers are synced
-        self._modules: Sequence[str] | None = None
-        self._module_attr: str | None = None
-
-        if modules:
-            # Store modules configuration for explicit async initialization.
-            # Users should call `collect_tools_from_modules` in an async context
-            # or use `AgentGantry.from_modules(...)` if available.
-            self._modules = modules
-            self._module_attr = module_attr
+        self._modules: Sequence[str] | None = modules or None
+        self._module_attr: str | None = module_attr if modules else None
 
     async def close(self) -> None:
         """

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -14,28 +14,25 @@ import uuid
 from collections.abc import Callable, Sequence
 from datetime import datetime, timezone
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
-from agent_gantry.adapters.embedders.openai import AzureOpenAIEmbedder, OpenAIEmbedder
+from agent_gantry.adapters.embedders.openai import OpenAIEmbedder
 from agent_gantry.adapters.embedders.simple import SimpleEmbedder
-from agent_gantry.adapters.vector_stores.memory import InMemoryVectorStore
 from agent_gantry.core.executor import ExecutionEngine
+from agent_gantry.core.factories import (
+    build_embedder,
+    build_reranker,
+    build_telemetry,
+    build_vector_store,
+)
 from agent_gantry.core.registry import ToolRegistry
 from agent_gantry.core.router import RoutingWeights, SemanticRouter
 from agent_gantry.core.security import SecurityPolicy
-from agent_gantry.observability.console import ConsoleTelemetryAdapter, NoopTelemetryAdapter
-from agent_gantry.observability.opentelemetry_adapter import (
-    OpenTelemetryAdapter,
-    PrometheusTelemetryAdapter,
-)
 from agent_gantry.schema.config import (
     A2AAgentConfig,
     AgentGantryConfig,
     EmbedderConfig,
     MCPServerConfig,
-    RerankerConfig,
-    TelemetryConfig,
-    VectorStoreConfig,
 )
 from agent_gantry.schema.introspection import build_parameters_schema
 from agent_gantry.schema.mcp import MCPServerDefinition
@@ -94,10 +91,10 @@ class AgentGantry:
             security_policy: Security policy for permission checks
         """
         self._config = config or AgentGantryConfig()
-        self._vector_store = vector_store or self._build_vector_store(self._config.vector_store)
-        self._embedder = embedder or self._build_embedder(self._config.embedder)
-        self._reranker = reranker or self._build_reranker(self._config.reranker)
-        self._telemetry = telemetry or self._build_telemetry(self._config.telemetry)
+        self._vector_store = vector_store or build_vector_store(self._config.vector_store)
+        self._embedder = embedder or build_embedder(self._config.embedder)
+        self._reranker = reranker or build_reranker(self._config.reranker)
+        self._telemetry = telemetry or build_telemetry(self._config.telemetry)
         self._security_policy = security_policy or SecurityPolicy()
         self._registry = ToolRegistry()
 
@@ -1646,123 +1643,6 @@ class AgentGantry:
                 results["telemetry"] = False
 
         return results
-
-    def _build_vector_store(self, config: VectorStoreConfig) -> VectorStoreAdapter:
-        """Construct a vector store adapter from configuration."""
-        if config.type == "qdrant":
-            from agent_gantry.adapters.vector_stores.remote import QdrantVectorStore
-
-            if not config.url:
-                raise ValueError("Qdrant requires 'url' in configuration")
-            return cast(
-                "VectorStoreAdapter",
-                QdrantVectorStore(
-                    url=config.url,
-                    api_key=config.api_key,
-                    collection_name=config.collection_name,
-                    dimension=config.dimension or 1536,
-                ),
-            )
-        if config.type == "chroma":
-            from agent_gantry.adapters.vector_stores.remote import ChromaVectorStore
-
-            return cast(
-                "VectorStoreAdapter",
-                ChromaVectorStore(
-                    url=config.url,
-                    collection_name=config.collection_name,
-                    persist_directory=config.db_path,
-                ),
-            )
-        if config.type == "pgvector":
-            from agent_gantry.adapters.vector_stores.remote import PGVectorStore
-
-            if not config.url:
-                raise ValueError("PGVector requires 'url' (connection string) in configuration")
-            return cast(
-                "VectorStoreAdapter",
-                PGVectorStore(
-                    url=config.url,
-                    table_name=config.collection_name,
-                    dimension=config.dimension or 1536,
-                ),
-            )
-        if config.type == "lancedb":
-            from agent_gantry.adapters.vector_stores.lancedb import LanceDBVectorStore
-
-            return cast(
-                "VectorStoreAdapter",
-                LanceDBVectorStore(
-                    db_path=config.db_path,
-                    tools_table=config.collection_name,
-                    dimension=config.dimension or 768,
-                ),
-            )
-        return InMemoryVectorStore()
-
-    def _build_embedder(self, config: EmbedderConfig) -> EmbeddingAdapter:
-        """Construct an embedder from configuration."""
-        if config.type == "openai" and config.api_key:
-            return OpenAIEmbedder(config)
-        if config.type == "azure" and config.api_key:
-            return AzureOpenAIEmbedder(config)
-        if config.type == "nomic":
-            from agent_gantry.adapters.embedders.nomic import NomicEmbedder
-
-            return NomicEmbedder(
-                model=config.model or "nomic-ai/nomic-embed-text-v1.5",
-                dimension=config.dimension,
-                task_type=config.task_type or "search_document",
-            )
-        if config.type == "sentence_transformers":
-            try:
-                import sentence_transformers as _st  # noqa: F401
-
-                from agent_gantry.adapters.embedders.sentence_transformers import (
-                    SentenceTransformersEmbedder,
-                )
-
-                return SentenceTransformersEmbedder(
-                    model=config.model or "all-MiniLM-L6-v2",
-                    dimension=config.dimension,
-                )
-            except ImportError:
-                logger.debug(
-                    "sentence-transformers not available, falling back to SimpleEmbedder"
-                )
-        return SimpleEmbedder()
-
-    def _build_reranker(self, config: RerankerConfig) -> RerankerAdapter | None:
-        """Construct a reranker from configuration."""
-        if not config.enabled:
-            return None
-        if config.type == "cohere":
-            from agent_gantry.adapters.rerankers.cohere import CohereReranker
-
-            return CohereReranker(model=config.model)
-        if config.type == "cross_encoder":
-            from agent_gantry.adapters.rerankers.cross_encoder import CrossEncoderReranker
-
-            return CrossEncoderReranker(
-                model=config.model or "cross-encoder/ms-marco-MiniLM-L-6-v2",
-            )
-        return None
-
-    def _build_telemetry(self, config: TelemetryConfig) -> TelemetryAdapter:
-        """Construct telemetry adapter from configuration."""
-        if not config.enabled:
-            return NoopTelemetryAdapter()
-        if config.type == "opentelemetry":
-            return OpenTelemetryAdapter(
-                service_name=config.service_name,
-                otlp_endpoint=config.otlp_endpoint,
-            )
-        if config.type == "prometheus":
-            return PrometheusTelemetryAdapter(
-                service_name=config.service_name,
-                prometheus_port=config.prometheus_port,
-            )
-        return ConsoleTelemetryAdapter()
 
 
 def create_default_gantry(dimension: int = 256) -> AgentGantry:

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -126,14 +126,22 @@ class AgentGantry:
         self._mcp_registry = None
         self._mcp_router = None
         self._mcp_manager = None
-        # All imports AND constructions live in one try so a partially installed
-        # MCP stack (any of the three failing) degrades to None across the board
-        # rather than leaving a half-wired trio or raising.
+
+        # Tier 1 — the optional 'mcp' package being absent is the expected, quiet
+        # path: log at DEBUG and leave MCP disabled.
         try:
             from agent_gantry.core.mcp_manager import MCPManager
             from agent_gantry.core.mcp_registry import MCPRegistry
             from agent_gantry.core.mcp_router import MCPRouter
+        except ImportError:
+            logger.debug("MCP support not available (install 'mcp' package to enable)")
+            return
 
+        # Tier 2 — with the package importable, a construction failure is
+        # unexpected (broken/partial install). Surface it at WARNING rather than
+        # hiding it at DEBUG, but still degrade to no-MCP across the board so a
+        # bad MCP stack never crashes AgentGantry() construction.
+        try:
             self._mcp_registry = MCPRegistry()
             self._mcp_router = MCPRouter(
                 vector_store=self._vector_store,
@@ -147,10 +155,8 @@ class AgentGantry:
                 router=self._mcp_router,
                 get_embedder_id=self._sync_manager.get_embedder_id,
             )
-        except ImportError:
-            logger.debug("MCP support not available (install 'mcp' package to enable)")
-            # Re-null in case registry/router were assigned before a later
-            # construction (e.g. MCPManager) raised — leave no half-wired trio.
+        except Exception:
+            logger.warning("MCP components failed to initialize; MCP disabled.", exc_info=True)
             self._mcp_registry = None
             self._mcp_router = None
             self._mcp_manager = None

--- a/agent_gantry/integrations/agent_framework_bridge.py
+++ b/agent_gantry/integrations/agent_framework_bridge.py
@@ -348,83 +348,55 @@ def _tool_approval_mode(tool_def: ToolDefinition) -> str | None:
     return None
 
 
-def _build_callable_for_tool(
-    tool_def: ToolDefinition,
-    gantry: AgentGantry,
-    *,
-    as_function_tool: bool | None = None,
-) -> Any:
+def _build_tool_execute(
+    tool_name: str, gantry: AgentGantry
+) -> Callable[..., Awaitable[str]]:
+    """Build the async callable that runs ``tool_name`` through ``gantry.execute``.
+
+    Any exception or failed ToolResult is converted into a JSON ``{"error": ...}``
+    string so the real root cause survives Agent Framework's tool runner — which
+    otherwise replaces an uncaught error with the opaque ``"Error: Function
+    failed."`` string when ``include_detailed_errors`` is off (the default).
     """
-    Build a Python callable wrapping a Gantry tool for Microsoft Agent Framework.
-
-    The callable is created with proper type annotations (using ``Annotated``
-    and Pydantic ``Field``) so that AF can auto-generate the correct function
-    schema for the LLM. This avoids sending raw JSON schemas and lets AF's
-    native function-tool infrastructure handle serialisation.
-
-    When ``agent-framework`` is importable and ``as_function_tool`` is not
-    ``False``, the callable is wrapped with ``@agent_framework.tool`` so AF
-    receives a real ``FunctionTool`` with full GA metadata
-    (``approval_mode`` derived from Gantry capabilities, description,
-    name). When AF is not installed, a plain typed async callable is
-    returned; AF 1.0 still auto-wraps those at agent construction time.
-
-    Args:
-        tool_def: The Gantry ToolDefinition to wrap.
-        gantry: The AgentGantry instance for execution.
-        as_function_tool: If ``True``, always wrap with ``@agent_framework.tool``
-            (raises ImportError when AF isn't available). If ``False``, always
-            return a bare callable. ``None`` (default) auto-detects.
-
-    Returns:
-        Either an ``agent_framework.FunctionTool`` or a bare async callable,
-        both accepted by ``Agent(tools=[...])``.
-    """
-    tool_name = tool_def.name
-    tool_desc = tool_def.description
-    params_schema = tool_def.parameters_schema
-
-    # Extract parameter info from the JSON Schema
-    properties = params_schema.get("properties", {})
-    required_params = set(params_schema.get("required", []))
 
     async def _execute(**kwargs: Any) -> str:
-        # Surface any underlying exception as a structured error string. If
-        # ``gantry.execute`` itself raises (e.g. a cross-event-loop
-        # asyncio.Lock blowup, a connection error, an unexpected validation
-        # error in the executor) the exception would otherwise propagate
-        # into Agent Framework's tool runner, which replaces it with the
-        # opaque ``"Error: Function failed."`` string when
-        # ``include_detailed_errors`` is off (the default). That makes
-        # debugging extremely hard for integrators. We convert any exception
-        # into a JSON ``{"error": "..."}`` payload so the model — and the
-        # human reading the trace — sees the real root cause.
         try:
-            result = await gantry.execute(
-                ToolCall(tool_name=tool_name, arguments=kwargs)
-            )
+            result = await gantry.execute(ToolCall(tool_name=tool_name, arguments=kwargs))
         except Exception as exc:
-            return json.dumps(
-                {"error": f"{type(exc).__name__}: {exc}"}
-            )
+            return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
         if result.status.value == "success":
             val = result.result
             return val if isinstance(val, str) else json.dumps(val)
         # Failed ToolResult: prefer the recorded error/error_type, otherwise
-        # fall back to a clear default — never the ambiguous original
-        # "Tool execution failed" with no context.
+        # fall back to a clear default — never an ambiguous message with no context.
         error_text = result.error or "tool execution failed (no error message)"
         if result.error_type and result.error_type not in error_text:
             error_text = f"{result.error_type}: {error_text}"
         return json.dumps({"error": error_text})
 
-    # Build the wrapper with proper annotations for AF
-    # AF inspects __name__, __doc__, and __annotations__ to generate schemas.
-    # Two separate named functions avoid the mypy "conditional function variant"
-    # error that arises when the same name is assigned in both if/else branches
-    # with incompatible signatures.
+    return _execute
+
+
+def _build_typed_wrapper(
+    tool_name: str,
+    tool_desc: str,
+    properties: dict[str, Any],
+    required_params: set[str],
+    execute: Callable[..., Awaitable[str]],
+) -> Callable[..., Awaitable[str]]:
+    """Wrap ``execute`` in a callable that carries AF-introspectable metadata.
+
+    AF reads ``__name__`` / ``__doc__`` / ``__annotations__`` (via the synthesized
+    ``__signature__``) to build the LLM function schema, so the wrapper exposes the
+    tool's real parameters (annotated with ``Annotated[type, Field(...)]``) instead
+    of a bare ``**kwargs``. Parameterless tools use a zero-arg variant to avoid
+    surfacing a spurious ``**kwargs``. Two separately named inner functions avoid
+    the mypy "conditional function variant" error from assigning incompatible
+    signatures to one name.
+    """
+
     async def _wrapper_no_args() -> str:
-        return await _execute()
+        return await execute()
 
     async def _wrapper_with_args(*args: Any, **kwargs: Any) -> str:
         param_names = list(properties.keys())
@@ -438,7 +410,7 @@ def _build_callable_for_tool(
                 p_name = param_names[idx]
                 if p_name not in kwargs:
                     kwargs[p_name] = value
-        return await _execute(**kwargs)
+        return await execute(**kwargs)
 
     wrapper: Callable[..., Awaitable[str]]
     if len(properties) == 0:
@@ -467,11 +439,23 @@ def _build_callable_for_tool(
     wrapper.__name__ = tool_name
     wrapper.__qualname__ = tool_name
     wrapper.__doc__ = tool_desc
+    return wrapper
 
-    # Optionally upgrade to a real AF FunctionTool so approval_mode and the
-    # rest of the GA metadata flows through. AF 1.0 also accepts bare
-    # callables (it auto-wraps them at Agent(tools=...) time), so the
-    # fallback path remains fully functional for environments without AF.
+
+def _maybe_wrap_as_function_tool(
+    wrapper: Callable[..., Awaitable[str]],
+    tool_def: ToolDefinition,
+    as_function_tool: bool | None,
+) -> Any:
+    """Optionally upgrade a bare callable to a real AF ``FunctionTool``.
+
+    Wrapping with ``@agent_framework.tool`` propagates GA metadata
+    (``approval_mode`` derived from Gantry capabilities, name, description).
+    ``as_function_tool``: ``False`` always returns the bare callable; ``True``
+    requires AF (raises ImportError if absent); ``None`` auto-detects, falling
+    back to the bare callable when AF isn't installed (AF 1.0 auto-wraps those at
+    agent-construction time).
+    """
     if as_function_tool is False:
         return wrapper
 
@@ -484,14 +468,50 @@ def _build_callable_for_tool(
             )
         return wrapper
 
-    approval_mode = _tool_approval_mode(tool_def)
-    decorated = af_tool(
+    return af_tool(
         wrapper,
-        name=tool_name,
-        description=tool_desc,
-        approval_mode=approval_mode,
+        name=tool_def.name,
+        description=tool_def.description,
+        approval_mode=_tool_approval_mode(tool_def),
     )
-    return decorated
+
+
+def _build_callable_for_tool(
+    tool_def: ToolDefinition,
+    gantry: AgentGantry,
+    *,
+    as_function_tool: bool | None = None,
+) -> Any:
+    """
+    Build a Python callable wrapping a Gantry tool for Microsoft Agent Framework.
+
+    The callable carries proper type annotations (via ``Annotated`` + Pydantic
+    ``Field``) so AF auto-generates the correct function schema for the LLM
+    instead of receiving a raw JSON schema. When ``agent-framework`` is
+    importable and ``as_function_tool`` is not ``False`` the callable is wrapped
+    as a real ``FunctionTool``; otherwise a plain typed async callable is
+    returned (AF 1.0 auto-wraps those at agent construction time).
+
+    Args:
+        tool_def: The Gantry ToolDefinition to wrap.
+        gantry: The AgentGantry instance for execution.
+        as_function_tool: If ``True``, always wrap with ``@agent_framework.tool``
+            (raises ImportError when AF isn't available). If ``False``, always
+            return a bare callable. ``None`` (default) auto-detects.
+
+    Returns:
+        Either an ``agent_framework.FunctionTool`` or a bare async callable,
+        both accepted by ``Agent(tools=[...])``.
+    """
+    params_schema = tool_def.parameters_schema
+    properties = params_schema.get("properties", {})
+    required_params = set(params_schema.get("required", []))
+
+    execute = _build_tool_execute(tool_def.name, gantry)
+    wrapper = _build_typed_wrapper(
+        tool_def.name, tool_def.description, properties, required_params, execute
+    )
+    return _maybe_wrap_as_function_tool(wrapper, tool_def, as_function_tool)
 
 
 def _json_type_to_python(json_type: str) -> type:
@@ -778,6 +798,33 @@ class GantryToolBridge:
         )
         return tools
 
+    def _warn_all_candidates_filtered(
+        self, query: str, candidate_count: int, decision: RetrievalDecision
+    ) -> None:
+        """Log a WARNING when the threshold dropped every candidate.
+
+        Reports *which* cutoff dropped them — the configured threshold plus the
+        resolved cutoff in relative mode — so an empty tool surface is
+        diagnosable rather than silent.
+        """
+        if (
+            decision.threshold_mode.startswith("relative")
+            and decision.effective_threshold is not None
+        ):
+            threshold_repr = (
+                f"{decision.threshold} (cutoff={decision.effective_threshold:.3f})"
+            )
+        else:
+            threshold_repr = repr(decision.threshold)
+        logger.warning(
+            "GantryToolBridge: score_threshold %s filtered out all %d "
+            "candidates for query %r. Top scores: %s",
+            threshold_repr,
+            candidate_count,
+            query[:80],
+            ", ".join(f"{c.name}:{c.score:.3f}" for c in decision.candidates[:5]),
+        )
+
     async def get_tools_with_decision(
         self,
         query: str,
@@ -841,31 +888,10 @@ class GantryToolBridge:
             except Exception:  # pragma: no cover - defensive
                 pass
 
-            # If threshold filtered everything out, surface a WARNING so
-            # users don't see "empty surface" without context. Always log
-            # the configured threshold (and the resolved cutoff for the
-            # relative mode) so the message explains *which* cutoff
-            # dropped the candidates, not just the mode name.
+            # If the threshold filtered everything out, surface a WARNING so
+            # users don't see an "empty surface" without context.
             if result.tools and not kept_top:
-                if decision.threshold_mode.startswith("relative") and (
-                    decision.effective_threshold is not None
-                ):
-                    threshold_repr = (
-                        f"{decision.threshold} "
-                        f"(cutoff={decision.effective_threshold:.3f})"
-                    )
-                else:
-                    threshold_repr = repr(decision.threshold)
-                logger.warning(
-                    "GantryToolBridge: score_threshold %s filtered out all %d "
-                    "candidates for query %r. Top scores: %s",
-                    threshold_repr,
-                    len(result.tools),
-                    query[:80],
-                    ", ".join(
-                        f"{c.name}:{c.score:.3f}" for c in decision.candidates[:5]
-                    ),
-                )
+                self._warn_all_candidates_filtered(query, len(result.tools), decision)
 
             logger.debug(
                 "GantryToolBridge: selected %d/%d tools for query '%s'",
@@ -1104,6 +1130,16 @@ class GantryToolBridge:
 
         return Agent(client, instructions, **agent_kwargs)
 
+    async def _build_agents_from_specs(
+        self, agent_specs: list[dict[str, Any]], *, cache: bool
+    ) -> list[Any]:
+        """Construct one AF agent per spec via :meth:`as_agent`, preserving order.
+
+        Shared by the workflow builders. Callers that need a name->agent map
+        zip the result back against ``agent_specs``.
+        """
+        return [await self.as_agent(cache=cache, **dict(spec)) for spec in agent_specs]
+
     async def build_sequential_workflow(
         self,
         agent_specs: list[dict[str, Any]],
@@ -1148,12 +1184,7 @@ class GantryToolBridge:
         _require_af_installed("build_sequential_workflow")
         from agent_framework.orchestrations import SequentialBuilder
 
-        ordered: list[Any] = []
-        for spec in agent_specs:
-            spec = dict(spec)
-            agent = await self.as_agent(cache=cache, **spec)
-            ordered.append(agent)
-
+        ordered = await self._build_agents_from_specs(agent_specs, cache=cache)
         if not ordered:
             raise ValueError("agent_specs must contain at least one agent.")
 
@@ -1211,14 +1242,10 @@ class GantryToolBridge:
         _require_af_installed("build_handoff_workflow")
         from agent_framework.orchestrations import HandoffBuilder
 
-        built: dict[str, Any] = {}
-        ordered: list[Any] = []
-        for spec in agent_specs:
-            spec = dict(spec)
-            agent_name: str = spec["name"]
-            agent = await self.as_agent(cache=cache, **spec)
-            built[agent_name] = agent
-            ordered.append(agent)
+        ordered = await self._build_agents_from_specs(agent_specs, cache=cache)
+        built: dict[str, Any] = {
+            spec["name"]: agent for spec, agent in zip(agent_specs, ordered)
+        }
 
         if not ordered:
             raise ValueError("agent_specs must contain at least one agent.")
@@ -1318,14 +1345,10 @@ class GantryToolBridge:
         _require_af_installed("build_workflow")
         from agent_framework import AgentExecutor, WorkflowAgent, WorkflowBuilder
 
-        built_agents: dict[str, Any] = {}
-        ordered_agents: list[Any] = []
-        for spec in agent_specs:
-            spec = dict(spec)
-            agent_name: str = spec["name"]
-            agent = await self.as_agent(cache=cache, **spec)
-            built_agents[agent_name] = agent
-            ordered_agents.append(agent)
+        ordered_agents = await self._build_agents_from_specs(agent_specs, cache=cache)
+        built_agents: dict[str, Any] = {
+            spec["name"]: agent for spec, agent in zip(agent_specs, ordered_agents)
+        }
 
         if not ordered_agents:
             raise ValueError("agent_specs must contain at least one agent.")

--- a/agent_gantry/integrations/agent_framework_bridge.py
+++ b/agent_gantry/integrations/agent_framework_bridge.py
@@ -799,7 +799,7 @@ class GantryToolBridge:
         return tools
 
     def _warn_all_candidates_filtered(
-        self, query: str, candidate_count: int, decision: RetrievalDecision
+        self, query: str, total_candidates: int, decision: RetrievalDecision
     ) -> None:
         """Log a WARNING when the threshold dropped every candidate.
 
@@ -820,7 +820,7 @@ class GantryToolBridge:
             "GantryToolBridge: score_threshold %s filtered out all %d "
             "candidates for query %r. Top scores: %s",
             threshold_repr,
-            candidate_count,
+            total_candidates,
             query[:80],
             ", ".join(f"{c.name}:{c.score:.3f}" for c in decision.candidates[:5]),
         )

--- a/agent_gantry/integrations/agent_framework_bridge.py
+++ b/agent_gantry/integrations/agent_framework_bridge.py
@@ -1135,8 +1135,12 @@ class GantryToolBridge:
     ) -> list[Any]:
         """Construct one AF agent per spec via :meth:`as_agent`, preserving order.
 
-        Shared by the workflow builders. Callers that need a name->agent map
-        zip the result back against ``agent_specs``.
+        Shared by the workflow builders. Callers that need a name->agent map zip
+        the result back against ``agent_specs`` (a key lookup on the original
+        spec is safe; the ``dict(spec)`` copy is only to avoid mutating the
+        caller's dict via ``**`` expansion). Built sequentially to preserve the
+        original construction order and per-agent error semantics — agent specs
+        are few, so this is not a latency concern worth ``asyncio.gather``.
         """
         return [await self.as_agent(cache=cache, **dict(spec)) for spec in agent_specs]
 

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -194,7 +194,11 @@ def _build_impl_class(base: type) -> type:
 
     # No lock: a concurrent first-call race just builds the class twice and the
     # loser is GC'd — both are equivalent, so this is benign and a lock would be
-    # overkill for a once-per-base construction.
+    # overkill for a once-per-base construction. (Atomic under CPython's GIL;
+    # would only ever build a redundant class, never corrupt the cache.)
+    #
+    # NOTE: the class body below is long (the full provider implementation);
+    # it lives in a function only because ``base`` is resolved lazily at runtime.
     class _GantryContextProviderImpl(base):  # type: ignore[misc,valid-type]
         """Concrete ContextProvider subclass; see :class:`GantryContextProvider`."""
 

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -172,7 +172,848 @@ async def _maybe_await(value: Any) -> Any:
     return value
 
 
-class GantryContextProvider:
+_IMPL_CLASS_CACHE: dict[type, type] = {}
+
+
+def _build_impl_class(base: type) -> type:
+    """Build (and cache) the concrete ``ContextProvider`` subclass.
+
+    ``base`` is :class:`agent_framework.ContextProvider`, imported lazily, so
+    the subclass cannot be declared at module top level. It holds no per-call
+    state — every value is passed to ``__init__`` — so one class is built per
+    base type and reused across all provider instances.
+    """
+    cached = _IMPL_CLASS_CACHE.get(base)
+    if cached is not None:
+        return cached
+
+    class _GantryContextProviderImpl(base):  # type: ignore[misc,valid-type]
+        """Concrete ContextProvider subclass; see :class:`GantryContextProvider`."""
+
+        def __init__(
+            self,
+            *,
+            gantry: AgentGantry,
+            bridge: GantryToolBridge,
+            top_k: int,
+            score_threshold: float | str,
+            query_strategy: str,
+            query_generator: Callable[..., Any],
+            skills: bool,
+            skill_registry: SkillRegistry | None,
+            always_include_effective: list[str],
+            declared_always_include: list[str],
+            required: list[str],
+            static_tools: list[Any],
+            query_kwargs: dict[str, Any],
+            source_id: str,
+            verbose: bool,
+        ) -> None:
+            super().__init__(source_id=source_id)
+            self._gantry = gantry
+            self._bridge = bridge
+            self._top_k = top_k
+            self._score_threshold = score_threshold
+            self._query_strategy = query_strategy
+            self._query_generator = query_generator
+            self._skills_enabled = skills
+            self._skill_registry = skill_registry
+            self._always_include = always_include_effective
+            self._declared_always_include = list(declared_always_include)
+            self._required = list(required)
+            self._static_tools = list(static_tools)
+            self._query_kwargs = dict(query_kwargs)
+            self._source_id = source_id
+            self._verbose = verbose
+            # Per-task run-state held in ContextVars (not plain attributes)
+            # so a single provider shared across concurrent agent.run()
+            # calls — e.g. a multi-user server — doesn't interleave its
+            # selection history. The vars are per-instance (created here,
+            # once per provider) so multiple providers stay independent.
+            self._last_selection_var: ContextVar[RetrievalDecision | None] = (
+                ContextVar("gantry_last_selection", default=None)
+            )
+            # Default None (not ()) so we can tell "never set in this
+            # context" (-> fall back to the plain snapshot) apart from
+            # "reset for a fresh run, nothing retrieved yet" (-> return ()
+            # without leaking the previous run's history).
+            self._selections_var: ContextVar[tuple[RetrievalDecision, ...] | None] = (
+                ContextVar("gantry_selections", default=None)
+            )
+            # Plain-attribute fallbacks. A run driven inside a *child* task
+            # (AF may wrap agent.run() in asyncio.create_task, which copies
+            # the context) writes the ContextVar in that copy — invisible to
+            # the caller's context, which would make post-run
+            # `provider.selections` reads silently empty. So we also stash
+            # the latest *coherent* snapshot here (last-writer-wins, never
+            # interleaved — it mirrors one task's ContextVar value) and read
+            # it only when the context-local value is unset.
+            self._last_selection_plain: RetrievalDecision | None = None
+            self._selections_plain: tuple[RetrievalDecision, ...] = ()
+            # Trace round counter, allocated once per provider (not per
+            # trace() call) — ContextVars aren't GC'd, so a fresh one per
+            # call would leak in a server that builds the middleware
+            # repeatedly. Context-scoped so concurrent runs count
+            # independently.
+            self._trace_round_var: ContextVar[int] = ContextVar(
+                "gantry_trace_round", default=0
+            )
+            # One-shot warnings: we don't want to spam the log every
+            # round even when the misconfiguration persists.
+            self._warned_about_missing_chat_middleware = False
+            self._logged_top_k_math = False
+            if verbose:
+                # Don't override a user-configured level; only nudge
+                # when the logger has no explicit level set.
+                if logger.level == logging.NOTSET:
+                    logger.setLevel(logging.INFO)
+
+        # ----- Public, read-only configuration accessors --------------
+        @property
+        def top_k(self) -> int:
+            return self._top_k
+
+        @property
+        def score_threshold(self) -> float:
+            return self._score_threshold
+
+        @property
+        def query_strategy(self) -> str:
+            return self._query_strategy
+
+        @property
+        def always_include(self) -> tuple[str, ...]:
+            return tuple(self._declared_always_include)
+
+        @property
+        def required(self) -> tuple[str, ...]:
+            return tuple(self._required)
+
+        @property
+        def gantry(self) -> AgentGantry:
+            return self._gantry
+
+        @property
+        def bridge(self) -> GantryToolBridge:
+            return self._bridge
+
+        @property
+        def static_tools(self) -> tuple[Any, ...]:
+            return tuple(self._static_tools)
+
+        @property
+        def last_selection(self) -> RetrievalDecision | None:
+            """The most recent retrieval decision, or ``None``.
+
+            Cleared/replaced on every ``before_run`` (per_run mode) or
+            every chat-middleware tick (per_call mode). Read this from
+            middleware, tests, or interactive sessions to diagnose
+            "why did the LLM not see tool X this round?".
+
+            Backed by a :class:`~contextvars.ContextVar`: the value is
+            scoped to the current task/context, so concurrent
+            ``agent.run()`` calls on a shared provider don't clobber each
+            other's in-context reads. When the context-local value is unset
+            — e.g. a post-run read from the parent task after AF ran the
+            agent in a child task whose context copy we can't see — this
+            falls back to the latest coherent snapshot so introspection
+            never goes silently empty.
+            """
+            in_context = self._last_selection_var.get()
+            return in_context if in_context is not None else self._last_selection_plain
+
+        @property
+        def selections(self) -> tuple[RetrievalDecision, ...]:
+            """Per-round retrieval history, oldest first (bounded window).
+
+            ``last_selection`` is a single most-recent slot, so reading it
+            from *function* middleware is inherently laggy — it holds
+            whatever the latest chat round selected, which is not guaranteed
+            to be the round that produced the call you're handling.
+            ``selections`` keeps the full per-round sequence (capped at
+            ``_MAX_SELECTION_HISTORY``) so a trace or audit can correlate
+            "what was surfaced" with "what the model then called" across the
+            whole run instead of just the last round.
+
+            Scoped to a single ``agent.run`` — :meth:`before_run` resets the
+            history at the start of each run, so a shared provider doesn't
+            bleed one run's (or one user's) selections into the next. (This
+            differs from :attr:`last_selection`, which is the single
+            latest decision and is not reset.) Task-scoped via a
+            ``ContextVar`` — each concurrent run accumulates its own history
+            rather than interleaving into one shared list — with a
+            plain-attribute fallback so a post-run read from a different
+            task still sees the latest run's (coherent, non-interleaved)
+            history instead of an empty tuple.
+            """
+            in_context = self._selections_var.get()
+            return in_context if in_context is not None else self._selections_plain
+
+        # ----- AF lifecycle ------------------------------------------
+        async def before_run(
+            self,
+            *,
+            agent: Any,
+            session: Any,
+            context: Any,
+            state: dict[str, Any],
+        ) -> None:
+            # Run boundary: scope the selection history to this run so a
+            # shared provider doesn't carry the previous run's (or user's)
+            # selections forward. Reset both the context-local var and the
+            # cross-task plain snapshot; per_run appends below, per_call
+            # appends via the chat middleware. last_selection is the single
+            # latest decision and is deliberately not reset.
+            self._selections_var.set(())
+            self._selections_plain = ()
+
+            # per_call mode requires the chat middleware to do the
+            # actual per-round refresh. If the user forgot to attach
+            # it, the agent silently degrades to per_run behaviour
+            # with extra plumbing — warn once so the misconfiguration
+            # is visible without strangers reading the source.
+            if (
+                self._query_strategy == "per_call"
+                and not self._warned_about_missing_chat_middleware
+                and not self._chat_middleware_attached(agent)
+            ):
+                self._warned_about_missing_chat_middleware = True
+                logger.warning(
+                    "GantryContextProvider: query_strategy='per_call' is "
+                    "enabled but as_chat_middleware() does not appear to "
+                    "be attached to the agent — the provider will fall "
+                    "back to per_run behaviour. Pass "
+                    "middleware=[provider.as_chat_middleware()] to your "
+                    "Agent(...) or use provider.attach_to(agent)."
+                )
+
+            # In per_call mode, the chat_middleware does the dynamic
+            # retrieval per LLM round; we still inject always_include /
+            # skill tools at run-start so they are present even if the
+            # middleware is not attached.
+            tools, _ = await self._collect_tools(
+                context.input_messages,
+                include_dynamic=(self._query_strategy == "per_run"),
+            )
+            if tools:
+                context.extend_tools(self._source_id, tools)
+                logger.debug(
+                    "GantryContextProvider: injected %d tools at run start "
+                    "(strategy=%s)",
+                    len(tools),
+                    self._query_strategy,
+                )
+
+        # ----- Setup helpers -----------------------------------------
+        def attach_to(self, agent: Any, *, trace: bool = False) -> Any:
+            """Register this provider and its middleware on ``agent``.
+
+            Single-call helper for the common ``per_call`` setup. Does
+            the dance of appending to ``agent.context_providers`` and
+            ``agent.middleware`` (whichever attribute the AF version
+            exposes), creating the lists if missing. Returns
+            ``agent`` for chaining.
+
+            The chat middleware is only attached when
+            ``query_strategy='per_call'`` — in ``per_run`` mode it's
+            a no-op and would just add overhead. The context
+            provider is always attached.
+
+            Args:
+                agent: The AF agent to attach to.
+                trace: When ``True``, also attach :meth:`trace` (a function
+                    middleware) so every tool call prints a readable
+                    per-round line — the built-in replacement for
+                    hand-rolled trace glue. Defaults to ``False``.
+            """
+            # context_providers
+            providers_attr = self._first_present_attr(
+                agent, ("context_providers", "_context_providers")
+            )
+            if providers_attr is not None:
+                current = getattr(agent, providers_attr) or []
+                if self not in current:
+                    try:
+                        setattr(agent, providers_attr, [*current, self])
+                    except (AttributeError, TypeError):
+                        try:
+                            current.append(self)
+                        except Exception:
+                            logger.warning(
+                                "GantryContextProvider.attach_to: could "
+                                "not attach context provider to agent %r.",
+                                type(agent).__name__,
+                            )
+            else:
+                logger.warning(
+                    "GantryContextProvider.attach_to: agent %r has no "
+                    "context_providers attribute; the provider was not "
+                    "attached.",
+                    type(agent).__name__,
+                )
+
+            # middleware: per-call chat refresher (per_call only) plus the
+            # console trace (when requested). Both live in AF's single
+            # `middleware` list and attach together.
+            to_add: list[Any] = []
+            if self._query_strategy == "per_call":
+                to_add.append(self.as_chat_middleware())
+            if trace:
+                to_add.append(self.trace())
+
+            if to_add:
+                middleware_attr = self._first_present_attr(
+                    agent, ("middleware", "_middleware")
+                )
+                if middleware_attr is not None:
+                    current_mw = getattr(agent, middleware_attr) or []
+                    try:
+                        setattr(agent, middleware_attr, [*current_mw, *to_add])
+                    except (AttributeError, TypeError):
+                        try:
+                            for mw in to_add:
+                                current_mw.append(mw)
+                        except Exception:
+                            logger.warning(
+                                "GantryContextProvider.attach_to: could "
+                                "not attach middleware to agent %r.",
+                                type(agent).__name__,
+                            )
+                else:
+                    logger.warning(
+                        "GantryContextProvider.attach_to: agent %r has "
+                        "no middleware attribute; middleware was not "
+                        "attached.",
+                        type(agent).__name__,
+                    )
+            return agent
+
+        # ----- Console trace middleware ------------------------------
+        def trace(
+            self,
+            *,
+            render: bool = True,
+            printer: Callable[[str], None] = print,
+            limit: int = 200,
+        ) -> Any:
+            """Return an AF *function* middleware that prints a per-call trace.
+
+            This is the library-owned replacement for the hand-rolled
+            ``trace_tool_calls`` + ``_preview`` glue. For every tool the
+            agent invokes it prints one line before the call —
+            ``>>> round N: tool(args)  [surfaced: name:score, …]`` — using
+            :attr:`last_selection` for the surfaced set, and (when
+            ``render`` is ``True``) one line after with a short preview of
+            the result via :func:`~agent_gantry.render_result`.
+
+            Attach it alongside the provider, either via
+            ``provider.attach_to(agent, trace=True)`` or by adding
+            ``provider.trace()`` to ``Agent(middleware=[...])``.
+
+            Cheap to call (the round counter lives on the provider, not the
+            returned middleware), but attach just one trace middleware per
+            agent — multiple share the provider's counter and would
+            interleave round numbers.
+
+            Args:
+                render: Print the post-call result preview line. Default
+                    ``True``.
+                printer: Sink for the rendered lines. Defaults to
+                    :func:`print`; pass ``logger.info`` or a custom callable
+                    to redirect.
+                limit: Max characters of the result preview before
+                    truncation. Default ``200``.
+            """
+            function_middleware_decorator = _import_function_middleware()
+            provider = self
+            # Per-provider round counter (allocated in __init__, not here),
+            # context-scoped so concurrent runs count independently without
+            # a shared closure dict and without leaking a ContextVar per
+            # trace() call.
+            round_var = self._trace_round_var
+
+            @function_middleware_decorator
+            async def _gantry_trace(context: Any, call_next: Any) -> None:
+                n = round_var.get() + 1
+                round_var.set(n)
+                surfaced = ""
+                selection = provider.last_selection
+                if selection is not None:
+                    # Show only the tools that actually made the surface
+                    # (kept), capped — `candidates` is the full ranked list
+                    # incl. threshold-dropped entries, which would mislabel
+                    # and bloat the line.
+                    kept = selection.kept
+                    shown = kept[:_TRACE_SURFACED_CAP]
+                    rendered = ", ".join(f"{c.name}:{c.score:.2f}" for c in shown)
+                    if len(kept) > len(shown):
+                        rendered += f", +{len(kept) - len(shown)} more"
+                    surfaced = f"  [surfaced: {rendered}]"
+                name = getattr(getattr(context, "function", None), "name", "?")
+                try:
+                    args: Any = dict(context.arguments)
+                except (TypeError, ValueError):
+                    args = getattr(context, "arguments", None)
+                printer(f">>> round {n}: {name}({args}){surfaced}")
+                await call_next()
+                if render:
+                    preview = render_result(
+                        getattr(context, "result", None),
+                        limit=limit,
+                        collapse_whitespace=True,
+                    )
+                    printer(f"<<< round {n}: {name} -> {preview}")
+
+            return _gantry_trace
+
+        @staticmethod
+        def _first_present_attr(obj: Any, names: tuple[str, ...]) -> str | None:
+            for n in names:
+                if hasattr(obj, n):
+                    return n
+            return None
+
+        def _chat_middleware_attached(self, agent: Any) -> bool:
+            """Best-effort check for ``as_chat_middleware`` on the agent.
+
+            Heuristic: look for any middleware whose qualified name
+            contains the provider's sentinel ``_per_call_retrieval``.
+            AF wraps the decorated coroutine into different objects
+            across versions, so we just match on the name.
+            """
+            if agent is None:
+                return True  # don't warn when there's nothing to inspect
+            mw_attr = self._first_present_attr(
+                agent, ("middleware", "_middleware")
+            )
+            if mw_attr is None:
+                return True
+            middlewares = getattr(agent, mw_attr) or []
+            for m in middlewares:
+                candidates = (
+                    getattr(m, "__name__", None),
+                    getattr(m, "__qualname__", None),
+                    getattr(getattr(m, "func", None), "__name__", None),
+                    type(m).__name__,
+                )
+                for c in candidates:
+                    if isinstance(c, str) and "_per_call_retrieval" in c:
+                        return True
+            return False
+
+        # ----- Per-call middleware factory ---------------------------
+        def as_chat_middleware(self) -> Any:
+            """Return an AF chat_middleware that refreshes tools each round.
+
+            Use with ``Agent(middleware=[provider.as_chat_middleware()])``
+            in conjunction with ``query_strategy="per_call"``. The
+            returned middleware reads ``context.messages`` (or
+            ``context.options`` as appropriate), runs the configured
+            query generator, retrieves a fresh top-k from the gantry,
+            and updates the tool list before the LLM call. If retrieval
+            fails it logs the exception and leaves the existing tools
+            unchanged — retrieval must never break the agent run.
+            """
+            chat_middleware_decorator = _import_chat_middleware()
+            provider = self
+
+            @chat_middleware_decorator
+            async def _per_call_retrieval(context: Any, call_next: Any) -> None:
+                try:
+                    await provider._refresh_tools_on_chat_context(context)
+                except Exception:
+                    logger.exception(
+                        "GantryContextProvider: per-call retrieval failed; "
+                        "continuing with existing tools."
+                    )
+                await call_next()
+
+            return _per_call_retrieval
+
+        async def _refresh_tools_on_chat_context(self, context: Any) -> None:
+            """Mutate ``context.options['tools']`` for the current round.
+
+            Strategy: drop **all** tools whose names are known to the
+            gantry registry (these are tools we — or another provider
+            bridging the same gantry — could have injected). Anything
+            else in ``existing`` is foreign (skills from another
+            provider, AF-native tools added at construction time) and
+            is preserved. Then append the freshly retrieved top-k plus
+            always_include / skill pins. This guarantees the per-round
+            top-k stays bounded and stale dynamic selections from
+            earlier rounds do not accumulate.
+
+            Mutates the existing options dict **in place** rather than
+            replacing the reference. ``FunctionInvocationLayer`` in
+            agent-framework keeps the same options dict across its
+            inner loop and uses it both as the chat-call payload *and*
+            as the tool-lookup table when executing function calls.
+            Reassigning ``context.options = new_options`` would only
+            update the chat-call payload — the function executor would
+            still see the original (stale) tool list and fail to find
+            the tools we just injected.
+            """
+            options = getattr(context, "options", None)
+            existing: list[Any] = []
+            if isinstance(options, dict):
+                existing = list(options.get("tools") or [])
+            elif options is not None:
+                # Pydantic ChatOptions / plain objects: peer-provider
+                # tools live on the `tools` attribute. Read them too,
+                # otherwise the combined list would drop everything
+                # the model already carried (skills, static tools,
+                # tools from another ContextProvider).
+                attr_tools = getattr(options, "tools", None)
+                if attr_tools:
+                    existing = list(attr_tools)
+
+            messages = (
+                getattr(context, "messages", None)
+                or getattr(context, "input_messages", None)
+                or []
+            )
+            fresh, _ = await self._collect_tools(
+                messages, include_dynamic=True
+            )
+            # _collect_tools updates the last-selection / selections
+            # ContextVars on every dynamic refresh, so the per-call
+            # middleware path automatically exposes the latest decision via
+            # the provider's `last_selection` / `selections` properties.
+            gantry_names = self._all_known_tool_names()
+            static_names = {
+                _tool_name(t) for t in self._static_tools if _tool_name(t)
+            }
+
+            preserved = []
+            dropped = 0
+            for t in existing:
+                name = _tool_name(t)
+                # Drop stale gantry-known tools so the per-round
+                # surface stays bounded. Static tools may appear in
+                # both `existing` (carried across rounds) and `fresh`
+                # (we re-add them ourselves); dedup happens below.
+                if name and name in gantry_names and name not in static_names:
+                    dropped += 1
+                    continue
+                preserved.append(t)
+
+            combined: list[Any] = []
+            seen_combined: set[str] = set()
+            for t in preserved + fresh:
+                name = _tool_name(t)
+                if name and name in seen_combined:
+                    continue
+                if name:
+                    seen_combined.add(name)
+                combined.append(t)
+
+            if isinstance(options, dict):
+                # Mutate in place — see docstring above.
+                options["tools"] = combined
+            elif options is not None:
+                # Non-dict options (e.g. a Pydantic ChatOptions model).
+                # The in-place invariant from the docstring applies here
+                # too — AF's FunctionInvocationLayer keeps the same
+                # options reference across the inner loop, so we must
+                # mutate the existing object rather than reassign
+                # context.options. Try setattr first (works for plain
+                # objects and mutable Pydantic models); only fall back
+                # to a rebuilt-copy + reassignment if the attribute is
+                # genuinely immutable (frozen model).
+                mutated_in_place = False
+                try:
+                    setattr(options, "tools", combined)
+                    mutated_in_place = True
+                except (AttributeError, TypeError, ValueError):
+                    pass
+                if not mutated_in_place:
+                    if hasattr(options, "model_copy"):
+                        new_options = options.model_copy(update={"tools": combined})
+                        try:
+                            context.options = new_options
+                        except AttributeError:
+                            logger.warning(
+                                "GantryContextProvider: cannot update tools on "
+                                "immutable options object %r (no in-place setattr, "
+                                "no settable context.options). %d Gantry tools were "
+                                "selected but will NOT be visible to AF.",
+                                type(options).__name__,
+                                len(combined),
+                            )
+                    else:
+                        logger.warning(
+                            "GantryContextProvider: options object %r is neither "
+                            "dict-like nor a Pydantic model and rejected attribute "
+                            "assignment. %d Gantry tools were selected but will "
+                            "NOT be visible to AF.",
+                            type(options).__name__,
+                            len(combined),
+                        )
+
+            logger.debug(
+                "GantryContextProvider: refreshed tools per-call "
+                "(%d preserved + %d gantry, %d stale dropped, %d total)",
+                len(preserved),
+                len(fresh),
+                dropped,
+                len(combined),
+            )
+
+        def _all_known_tool_names(self) -> set[str]:
+            """Return every tool name registered in the gantry.
+
+            Used to identify which entries in ``context.options['tools']``
+            were produced by this gantry (or any other provider sharing
+            it) so they can be dropped before re-injecting the fresh
+            per-round selection.
+            """
+            registry = getattr(self._gantry, "_registry", None)
+            if registry is None:
+                return set()
+            lister = getattr(registry, "list_tools", None)
+            if not callable(lister):
+                return set()
+            try:
+                return {t.name for t in lister() if getattr(t, "name", None)}
+            except Exception:
+                return set()
+
+        # ----- Tool assembly -----------------------------------------
+        async def _collect_tools(
+            self,
+            messages: Any,
+            *,
+            include_dynamic: bool,
+        ) -> tuple[list[Any], set[str]]:
+            tools: list[Any] = []
+            seen: set[str] = set()
+            decision: RetrievalDecision | None = None
+
+            if include_dynamic:
+                query = await self._build_query(messages)
+                if query:
+                    try:
+                        retrieved, decision = (
+                            await self._bridge.get_tools_with_decision(
+                                query,
+                                limit=self._top_k,
+                                score_threshold=self._score_threshold,
+                                **self._query_kwargs,
+                            )
+                        )
+                    except Exception:
+                        logger.exception(
+                            "GantryContextProvider: semantic retrieval failed; "
+                            "continuing without dynamic tools."
+                        )
+                        retrieved = []
+                    for t in retrieved:
+                        name = _tool_name(t)
+                        if name and name in seen:
+                            continue
+                        if name:
+                            seen.add(name)
+                        tools.append(t)
+
+            # Skills: always-on tools bound to registered Gantry skills.
+            skill_count = 0
+            if self._skills_enabled:
+                skill_tool_names = self._collect_skill_tool_names()
+                extra = self._wrap_named(skill_tool_names, seen, source="skill")
+                tools.extend(extra)
+                skill_count = len(extra)
+
+            # Explicit always_include / required pins.
+            always_count = 0
+            if self._always_include:
+                extra = self._wrap_named(
+                    self._always_include, seen, source="always_include"
+                )
+                tools.extend(extra)
+                always_count = len(extra)
+
+            # Static AF-native tools that live outside the gantry registry.
+            static_count = 0
+            for t in self._static_tools:
+                name = _tool_name(t)
+                if name and name in seen:
+                    continue
+                if name:
+                    seen.add(name)
+                tools.append(t)
+                static_count += 1
+
+            if include_dynamic and decision is not None:
+                self._last_selection_var.set(decision)
+                # ContextVar holds an immutable tuple; bound it by slicing
+                # so history stays capped without a shared mutable deque.
+                # `or ()` covers a refresh in a context where before_run
+                # never reset the var (default None).
+                history = (
+                    (self._selections_var.get() or ()) + (decision,)
+                )[-_MAX_SELECTION_HISTORY:]
+                self._selections_var.set(history)
+                # Mirror to the plain fallbacks (coherent snapshot for
+                # cross-task post-run introspection; see the properties).
+                self._last_selection_plain = decision
+                self._selections_plain = history
+                if self._verbose:
+                    logger.info("gantry: %s", decision.summary())
+
+            # One-shot info log clarifying the top_k math whenever
+            # non-dynamic contributions raise the surface above top_k.
+            extra_total = skill_count + always_count + static_count
+            if (
+                include_dynamic
+                and extra_total > 0
+                and not self._logged_top_k_math
+            ):
+                self._logged_top_k_math = True
+                logger.info(
+                    "GantryContextProvider: dynamic top_k=%d + %d preserved "
+                    "(skills=%d, always_include=%d, static=%d). The final "
+                    "tool surface is the dynamic slice plus preserved tools.",
+                    self._top_k,
+                    extra_total,
+                    skill_count,
+                    always_count,
+                    static_count,
+                )
+
+            return tools, seen
+
+        async def dry_run_retrieve(
+            self,
+            query: str,
+            *,
+            limit: int | None = None,
+            score_threshold: float | str | None = None,
+        ) -> RetrievalDecision:
+            """Run the live retrieval path against a synthetic query.
+
+            Uses the *exact same* threshold, top_k, and ``query_kwargs``
+            as the live middleware. Use this to diagnose why a tool
+            is or is not surfacing without spinning up an agent.
+
+            Args:
+                query: The query string to retrieve against.
+                limit: Override ``top_k`` for this call only.
+                score_threshold: Override the threshold for this call
+                    only (accepts the same forms as the constructor).
+
+            Returns:
+                The :class:`RetrievalDecision` produced by the bridge.
+            """
+            eff_limit = self._top_k if limit is None else limit
+            eff_threshold = (
+                self._score_threshold
+                if score_threshold is None
+                else score_threshold
+            )
+            _, decision = await self._bridge.get_tools_with_decision(
+                query,
+                limit=eff_limit,
+                score_threshold=eff_threshold,
+                **self._query_kwargs,
+            )
+            return decision
+
+        async def _build_query(self, messages: Any) -> str:
+            try:
+                result = self._query_generator(messages)
+                return await _maybe_await(result) or ""
+            except Exception:
+                logger.exception(
+                    "GantryContextProvider: query_generator raised; falling "
+                    "back to last_user_text."
+                )
+                return last_user_text(messages)
+
+        def _resolve_skill_registry(self) -> SkillRegistry | None:
+            if self._skill_registry is not None:
+                return self._skill_registry
+            # Best-effort: pick up a registry attached to the gantry
+            # instance (e.g. via SkillsClient).
+            return getattr(self._gantry, "_skill_registry", None) or getattr(
+                self._gantry, "skill_registry", None
+            )
+
+        def _collect_skill_tool_names(self) -> list[str]:
+            registry = self._resolve_skill_registry()
+            if registry is None:
+                logger.debug(
+                    "GantryContextProvider: skills=True but no SkillRegistry "
+                    "available on gantry — no skill tools injected."
+                )
+                return []
+            names: list[str] = []
+            seen_names: set[str] = set()
+            for skill in registry.list_skills():
+                for tool_name in skill.tools or []:
+                    if tool_name not in seen_names:
+                        seen_names.add(tool_name)
+                        names.append(tool_name)
+            return names
+
+        def _wrap_named(
+            self, names: list[str], seen: set[str], *, source: str
+        ) -> list[Any]:
+            wrapped: list[Any] = []
+            missing: list[str] = []
+            for name in names:
+                if name in seen:
+                    continue
+                tool_def = self._lookup_tool_def(name)
+                if tool_def is None:
+                    missing.append(name)
+                    continue
+                wrapped.append(self._bridge.wrap_single(tool_def))
+                seen.add(name)
+            if missing:
+                logger.warning(
+                    "GantryContextProvider: %s tool(s) not found in registry "
+                    "and will be skipped: %s",
+                    source,
+                    missing,
+                )
+            return wrapped
+
+        def _lookup_tool_def(self, name: str) -> ToolDefinition | None:
+            registry = getattr(self._gantry, "_registry", None)
+            if registry is None:
+                return None
+            lookup = getattr(registry, "get_tool_by_name", None)
+            if callable(lookup):
+                found = lookup(name)
+                if found is not None:
+                    return found
+            lookup = getattr(registry, "get_tool", None)
+            if callable(lookup):
+                return lookup(name)
+            return None
+
+    _IMPL_CLASS_CACHE[base] = _GantryContextProviderImpl
+    return _GantryContextProviderImpl
+
+
+def GantryContextProvider(  # noqa: N802 - factory keeps the public PascalCase API name
+    gantry: AgentGantry,
+    *,
+    top_k: int = 5,
+    score_threshold: float | str = 0.0,
+    query_strategy: str = "per_run",
+    query_generator: Callable[..., Any] | None = None,
+    skills: bool = False,
+    skill_registry: SkillRegistry | None = None,
+    always_include: list[str] | None = None,
+    required: list[str] | None = None,
+    static_tools: list[Any] | None = None,
+    as_function_tool: bool | None = None,
+    source_id: str = "agent_gantry",
+    bridge: GantryToolBridge | None = None,
+    verbose: bool = False,
+    **query_kwargs: Any,
+) -> Any:
     """AF context provider that injects semantically-selected Gantry tools.
 
     Constructing the provider returns an instance of the dynamically
@@ -282,870 +1123,79 @@ class GantryContextProvider:
                 middleware=[provider.as_chat_middleware()],
             )
     """
-
-    def __new__(
-        cls,
-        gantry: AgentGantry,
-        *,
-        top_k: int = 5,
-        score_threshold: float | str = 0.0,
-        query_strategy: str = "per_run",
-        query_generator: Callable[..., Any] | None = None,
-        skills: bool = False,
-        skill_registry: SkillRegistry | None = None,
-        always_include: list[str] | None = None,
-        required: list[str] | None = None,
-        static_tools: list[Any] | None = None,
-        as_function_tool: bool | None = None,
-        source_id: str = "agent_gantry",
-        bridge: GantryToolBridge | None = None,
-        verbose: bool = False,
-        **query_kwargs: Any,
-    ) -> Any:
-        if query_strategy not in ("per_run", "per_call"):
-            raise ValueError(
-                f"query_strategy must be 'per_run' or 'per_call', got {query_strategy!r}"
-            )
-
-        context_provider_cls = _import_context_provider()
-
-        bridge = bridge or GantryToolBridge(
-            gantry,
-            score_threshold=score_threshold,
-            as_function_tool=as_function_tool,
+    if query_strategy not in ("per_run", "per_call"):
+        raise ValueError(
+            f"query_strategy must be 'per_run' or 'per_call', got {query_strategy!r}"
         )
-        always_include = list(always_include or [])
-        required = list(required or [])
-        static_tools_list: list[Any] = list(static_tools or [])
 
-        # Default query generator depends on strategy: per_call wants
-        # round-to-round adaptation, so the historical last_user_text
-        # default (which returns the same string every round) would
-        # silently disable the very thing per_call enables.
-        if query_generator is None:
-            if query_strategy == "per_call":
-                query_generator = _default_per_call_query()
-            else:
-                query_generator = _DEFAULT_PER_RUN_QUERY
-        elif (
-            query_strategy == "per_call"
-            and query_generator is last_user_text
-        ):
-            logger.warning(
-                "GantryContextProvider: query_strategy='per_call' was set "
-                "but query_generator=last_user_text returns the same string "
-                "every round, defeating per-call adaptation. Consider "
-                "fallback_chain(last_tool_result, last_user_text) instead."
+    context_provider_cls = _import_context_provider()
+
+    bridge = bridge or GantryToolBridge(
+        gantry,
+        score_threshold=score_threshold,
+        as_function_tool=as_function_tool,
+    )
+    always_include = list(always_include or [])
+    required = list(required or [])
+    static_tools_list: list[Any] = list(static_tools or [])
+
+    # Default query generator depends on strategy: per_call wants
+    # round-to-round adaptation, so the historical last_user_text
+    # default (which returns the same string every round) would
+    # silently disable the very thing per_call enables.
+    if query_generator is None:
+        if query_strategy == "per_call":
+            query_generator = _default_per_call_query()
+        else:
+            query_generator = _DEFAULT_PER_RUN_QUERY
+    elif (
+        query_strategy == "per_call"
+        and query_generator is last_user_text
+    ):
+        logger.warning(
+            "GantryContextProvider: query_strategy='per_call' was set "
+            "but query_generator=last_user_text returns the same string "
+            "every round, defeating per-call adaptation. Consider "
+            "fallback_chain(last_tool_result, last_user_text) instead."
+        )
+
+    if required:
+        known = gantry.list_tools_sync()
+        available = {t.name for t in known} | {
+            f"{t.namespace}.{t.name}" for t in known
+        }
+        missing = [name for name in required if name not in available]
+        if missing:
+            raise MissingRequiredToolError(
+                f"GantryContextProvider: required tool(s) not found in gantry: "
+                f"{missing}. Did you forget to register them, or is there a typo?"
             )
 
-        if required:
-            known = gantry.list_tools_sync()
-            available = {t.name for t in known} | {
-                f"{t.namespace}.{t.name}" for t in known
-            }
-            missing = [name for name in required if name not in available]
-            if missing:
-                raise MissingRequiredToolError(
-                    f"GantryContextProvider: required tool(s) not found in gantry: "
-                    f"{missing}. Did you forget to register them, or is there a typo?"
-                )
-
-        # Combine for "always inject" set; required is a strict superset.
-        always_include_effective: list[str] = []
-        seen_ai: set[str] = set()
-        for n in (*required, *always_include):
-            if n not in seen_ai:
-                seen_ai.add(n)
-                always_include_effective.append(n)
-
-        class _GantryContextProviderImpl(context_provider_cls):  # type: ignore[misc,valid-type]
-            """Concrete ContextProvider subclass; see :class:`GantryContextProvider`."""
-
-            def __init__(self) -> None:
-                super().__init__(source_id=source_id)
-                self._gantry = gantry
-                self._bridge = bridge
-                self._top_k = top_k
-                self._score_threshold = score_threshold
-                self._query_strategy = query_strategy
-                self._query_generator = query_generator
-                self._skills_enabled = skills
-                self._skill_registry = skill_registry
-                self._always_include = always_include_effective
-                self._declared_always_include = list(always_include)
-                self._required = list(required)
-                self._static_tools = list(static_tools_list)
-                self._query_kwargs = dict(query_kwargs)
-                self._source_id = source_id
-                self._verbose = verbose
-                # Per-task run-state held in ContextVars (not plain attributes)
-                # so a single provider shared across concurrent agent.run()
-                # calls — e.g. a multi-user server — doesn't interleave its
-                # selection history. The vars are per-instance (created here,
-                # once per provider) so multiple providers stay independent.
-                self._last_selection_var: ContextVar[RetrievalDecision | None] = (
-                    ContextVar("gantry_last_selection", default=None)
-                )
-                # Default None (not ()) so we can tell "never set in this
-                # context" (-> fall back to the plain snapshot) apart from
-                # "reset for a fresh run, nothing retrieved yet" (-> return ()
-                # without leaking the previous run's history).
-                self._selections_var: ContextVar[tuple[RetrievalDecision, ...] | None] = (
-                    ContextVar("gantry_selections", default=None)
-                )
-                # Plain-attribute fallbacks. A run driven inside a *child* task
-                # (AF may wrap agent.run() in asyncio.create_task, which copies
-                # the context) writes the ContextVar in that copy — invisible to
-                # the caller's context, which would make post-run
-                # `provider.selections` reads silently empty. So we also stash
-                # the latest *coherent* snapshot here (last-writer-wins, never
-                # interleaved — it mirrors one task's ContextVar value) and read
-                # it only when the context-local value is unset.
-                self._last_selection_plain: RetrievalDecision | None = None
-                self._selections_plain: tuple[RetrievalDecision, ...] = ()
-                # Trace round counter, allocated once per provider (not per
-                # trace() call) — ContextVars aren't GC'd, so a fresh one per
-                # call would leak in a server that builds the middleware
-                # repeatedly. Context-scoped so concurrent runs count
-                # independently.
-                self._trace_round_var: ContextVar[int] = ContextVar(
-                    "gantry_trace_round", default=0
-                )
-                # One-shot warnings: we don't want to spam the log every
-                # round even when the misconfiguration persists.
-                self._warned_about_missing_chat_middleware = False
-                self._logged_top_k_math = False
-                if verbose:
-                    # Don't override a user-configured level; only nudge
-                    # when the logger has no explicit level set.
-                    if logger.level == logging.NOTSET:
-                        logger.setLevel(logging.INFO)
-
-            # ----- Public, read-only configuration accessors --------------
-            @property
-            def top_k(self) -> int:
-                return self._top_k
-
-            @property
-            def score_threshold(self) -> float:
-                return self._score_threshold
-
-            @property
-            def query_strategy(self) -> str:
-                return self._query_strategy
-
-            @property
-            def always_include(self) -> tuple[str, ...]:
-                return tuple(self._declared_always_include)
-
-            @property
-            def required(self) -> tuple[str, ...]:
-                return tuple(self._required)
-
-            @property
-            def gantry(self) -> AgentGantry:
-                return self._gantry
-
-            @property
-            def bridge(self) -> GantryToolBridge:
-                return self._bridge
-
-            @property
-            def static_tools(self) -> tuple[Any, ...]:
-                return tuple(self._static_tools)
-
-            @property
-            def last_selection(self) -> RetrievalDecision | None:
-                """The most recent retrieval decision, or ``None``.
-
-                Cleared/replaced on every ``before_run`` (per_run mode) or
-                every chat-middleware tick (per_call mode). Read this from
-                middleware, tests, or interactive sessions to diagnose
-                "why did the LLM not see tool X this round?".
-
-                Backed by a :class:`~contextvars.ContextVar`: the value is
-                scoped to the current task/context, so concurrent
-                ``agent.run()`` calls on a shared provider don't clobber each
-                other's in-context reads. When the context-local value is unset
-                — e.g. a post-run read from the parent task after AF ran the
-                agent in a child task whose context copy we can't see — this
-                falls back to the latest coherent snapshot so introspection
-                never goes silently empty.
-                """
-                in_context = self._last_selection_var.get()
-                return in_context if in_context is not None else self._last_selection_plain
-
-            @property
-            def selections(self) -> tuple[RetrievalDecision, ...]:
-                """Per-round retrieval history, oldest first (bounded window).
-
-                ``last_selection`` is a single most-recent slot, so reading it
-                from *function* middleware is inherently laggy — it holds
-                whatever the latest chat round selected, which is not guaranteed
-                to be the round that produced the call you're handling.
-                ``selections`` keeps the full per-round sequence (capped at
-                ``_MAX_SELECTION_HISTORY``) so a trace or audit can correlate
-                "what was surfaced" with "what the model then called" across the
-                whole run instead of just the last round.
-
-                Scoped to a single ``agent.run`` — :meth:`before_run` resets the
-                history at the start of each run, so a shared provider doesn't
-                bleed one run's (or one user's) selections into the next. (This
-                differs from :attr:`last_selection`, which is the single
-                latest decision and is not reset.) Task-scoped via a
-                ``ContextVar`` — each concurrent run accumulates its own history
-                rather than interleaving into one shared list — with a
-                plain-attribute fallback so a post-run read from a different
-                task still sees the latest run's (coherent, non-interleaved)
-                history instead of an empty tuple.
-                """
-                in_context = self._selections_var.get()
-                return in_context if in_context is not None else self._selections_plain
-
-            # ----- AF lifecycle ------------------------------------------
-            async def before_run(
-                self,
-                *,
-                agent: Any,
-                session: Any,
-                context: Any,
-                state: dict[str, Any],
-            ) -> None:
-                # Run boundary: scope the selection history to this run so a
-                # shared provider doesn't carry the previous run's (or user's)
-                # selections forward. Reset both the context-local var and the
-                # cross-task plain snapshot; per_run appends below, per_call
-                # appends via the chat middleware. last_selection is the single
-                # latest decision and is deliberately not reset.
-                self._selections_var.set(())
-                self._selections_plain = ()
-
-                # per_call mode requires the chat middleware to do the
-                # actual per-round refresh. If the user forgot to attach
-                # it, the agent silently degrades to per_run behaviour
-                # with extra plumbing — warn once so the misconfiguration
-                # is visible without strangers reading the source.
-                if (
-                    self._query_strategy == "per_call"
-                    and not self._warned_about_missing_chat_middleware
-                    and not self._chat_middleware_attached(agent)
-                ):
-                    self._warned_about_missing_chat_middleware = True
-                    logger.warning(
-                        "GantryContextProvider: query_strategy='per_call' is "
-                        "enabled but as_chat_middleware() does not appear to "
-                        "be attached to the agent — the provider will fall "
-                        "back to per_run behaviour. Pass "
-                        "middleware=[provider.as_chat_middleware()] to your "
-                        "Agent(...) or use provider.attach_to(agent)."
-                    )
-
-                # In per_call mode, the chat_middleware does the dynamic
-                # retrieval per LLM round; we still inject always_include /
-                # skill tools at run-start so they are present even if the
-                # middleware is not attached.
-                tools, _ = await self._collect_tools(
-                    context.input_messages,
-                    include_dynamic=(self._query_strategy == "per_run"),
-                )
-                if tools:
-                    context.extend_tools(self._source_id, tools)
-                    logger.debug(
-                        "GantryContextProvider: injected %d tools at run start "
-                        "(strategy=%s)",
-                        len(tools),
-                        self._query_strategy,
-                    )
-
-            # ----- Setup helpers -----------------------------------------
-            def attach_to(self, agent: Any, *, trace: bool = False) -> Any:
-                """Register this provider and its middleware on ``agent``.
-
-                Single-call helper for the common ``per_call`` setup. Does
-                the dance of appending to ``agent.context_providers`` and
-                ``agent.middleware`` (whichever attribute the AF version
-                exposes), creating the lists if missing. Returns
-                ``agent`` for chaining.
-
-                The chat middleware is only attached when
-                ``query_strategy='per_call'`` — in ``per_run`` mode it's
-                a no-op and would just add overhead. The context
-                provider is always attached.
-
-                Args:
-                    agent: The AF agent to attach to.
-                    trace: When ``True``, also attach :meth:`trace` (a function
-                        middleware) so every tool call prints a readable
-                        per-round line — the built-in replacement for
-                        hand-rolled trace glue. Defaults to ``False``.
-                """
-                # context_providers
-                providers_attr = self._first_present_attr(
-                    agent, ("context_providers", "_context_providers")
-                )
-                if providers_attr is not None:
-                    current = getattr(agent, providers_attr) or []
-                    if self not in current:
-                        try:
-                            setattr(agent, providers_attr, [*current, self])
-                        except (AttributeError, TypeError):
-                            try:
-                                current.append(self)
-                            except Exception:
-                                logger.warning(
-                                    "GantryContextProvider.attach_to: could "
-                                    "not attach context provider to agent %r.",
-                                    type(agent).__name__,
-                                )
-                else:
-                    logger.warning(
-                        "GantryContextProvider.attach_to: agent %r has no "
-                        "context_providers attribute; the provider was not "
-                        "attached.",
-                        type(agent).__name__,
-                    )
-
-                # middleware: per-call chat refresher (per_call only) plus the
-                # console trace (when requested). Both live in AF's single
-                # `middleware` list and attach together.
-                to_add: list[Any] = []
-                if self._query_strategy == "per_call":
-                    to_add.append(self.as_chat_middleware())
-                if trace:
-                    to_add.append(self.trace())
-
-                if to_add:
-                    middleware_attr = self._first_present_attr(
-                        agent, ("middleware", "_middleware")
-                    )
-                    if middleware_attr is not None:
-                        current_mw = getattr(agent, middleware_attr) or []
-                        try:
-                            setattr(agent, middleware_attr, [*current_mw, *to_add])
-                        except (AttributeError, TypeError):
-                            try:
-                                for mw in to_add:
-                                    current_mw.append(mw)
-                            except Exception:
-                                logger.warning(
-                                    "GantryContextProvider.attach_to: could "
-                                    "not attach middleware to agent %r.",
-                                    type(agent).__name__,
-                                )
-                    else:
-                        logger.warning(
-                            "GantryContextProvider.attach_to: agent %r has "
-                            "no middleware attribute; middleware was not "
-                            "attached.",
-                            type(agent).__name__,
-                        )
-                return agent
-
-            # ----- Console trace middleware ------------------------------
-            def trace(
-                self,
-                *,
-                render: bool = True,
-                printer: Callable[[str], None] = print,
-                limit: int = 200,
-            ) -> Any:
-                """Return an AF *function* middleware that prints a per-call trace.
-
-                This is the library-owned replacement for the hand-rolled
-                ``trace_tool_calls`` + ``_preview`` glue. For every tool the
-                agent invokes it prints one line before the call —
-                ``>>> round N: tool(args)  [surfaced: name:score, …]`` — using
-                :attr:`last_selection` for the surfaced set, and (when
-                ``render`` is ``True``) one line after with a short preview of
-                the result via :func:`~agent_gantry.render_result`.
-
-                Attach it alongside the provider, either via
-                ``provider.attach_to(agent, trace=True)`` or by adding
-                ``provider.trace()`` to ``Agent(middleware=[...])``.
-
-                Cheap to call (the round counter lives on the provider, not the
-                returned middleware), but attach just one trace middleware per
-                agent — multiple share the provider's counter and would
-                interleave round numbers.
-
-                Args:
-                    render: Print the post-call result preview line. Default
-                        ``True``.
-                    printer: Sink for the rendered lines. Defaults to
-                        :func:`print`; pass ``logger.info`` or a custom callable
-                        to redirect.
-                    limit: Max characters of the result preview before
-                        truncation. Default ``200``.
-                """
-                function_middleware_decorator = _import_function_middleware()
-                provider = self
-                # Per-provider round counter (allocated in __init__, not here),
-                # context-scoped so concurrent runs count independently without
-                # a shared closure dict and without leaking a ContextVar per
-                # trace() call.
-                round_var = self._trace_round_var
-
-                @function_middleware_decorator
-                async def _gantry_trace(context: Any, call_next: Any) -> None:
-                    n = round_var.get() + 1
-                    round_var.set(n)
-                    surfaced = ""
-                    selection = provider.last_selection
-                    if selection is not None:
-                        # Show only the tools that actually made the surface
-                        # (kept), capped — `candidates` is the full ranked list
-                        # incl. threshold-dropped entries, which would mislabel
-                        # and bloat the line.
-                        kept = selection.kept
-                        shown = kept[:_TRACE_SURFACED_CAP]
-                        rendered = ", ".join(f"{c.name}:{c.score:.2f}" for c in shown)
-                        if len(kept) > len(shown):
-                            rendered += f", +{len(kept) - len(shown)} more"
-                        surfaced = f"  [surfaced: {rendered}]"
-                    name = getattr(getattr(context, "function", None), "name", "?")
-                    try:
-                        args: Any = dict(context.arguments)
-                    except (TypeError, ValueError):
-                        args = getattr(context, "arguments", None)
-                    printer(f">>> round {n}: {name}({args}){surfaced}")
-                    await call_next()
-                    if render:
-                        preview = render_result(
-                            getattr(context, "result", None),
-                            limit=limit,
-                            collapse_whitespace=True,
-                        )
-                        printer(f"<<< round {n}: {name} -> {preview}")
-
-                return _gantry_trace
-
-            @staticmethod
-            def _first_present_attr(obj: Any, names: tuple[str, ...]) -> str | None:
-                for n in names:
-                    if hasattr(obj, n):
-                        return n
-                return None
-
-            def _chat_middleware_attached(self, agent: Any) -> bool:
-                """Best-effort check for ``as_chat_middleware`` on the agent.
-
-                Heuristic: look for any middleware whose qualified name
-                contains the provider's sentinel ``_per_call_retrieval``.
-                AF wraps the decorated coroutine into different objects
-                across versions, so we just match on the name.
-                """
-                if agent is None:
-                    return True  # don't warn when there's nothing to inspect
-                mw_attr = self._first_present_attr(
-                    agent, ("middleware", "_middleware")
-                )
-                if mw_attr is None:
-                    return True
-                middlewares = getattr(agent, mw_attr) or []
-                for m in middlewares:
-                    candidates = (
-                        getattr(m, "__name__", None),
-                        getattr(m, "__qualname__", None),
-                        getattr(getattr(m, "func", None), "__name__", None),
-                        type(m).__name__,
-                    )
-                    for c in candidates:
-                        if isinstance(c, str) and "_per_call_retrieval" in c:
-                            return True
-                return False
-
-            # ----- Per-call middleware factory ---------------------------
-            def as_chat_middleware(self) -> Any:
-                """Return an AF chat_middleware that refreshes tools each round.
-
-                Use with ``Agent(middleware=[provider.as_chat_middleware()])``
-                in conjunction with ``query_strategy="per_call"``. The
-                returned middleware reads ``context.messages`` (or
-                ``context.options`` as appropriate), runs the configured
-                query generator, retrieves a fresh top-k from the gantry,
-                and updates the tool list before the LLM call. If retrieval
-                fails it logs the exception and leaves the existing tools
-                unchanged — retrieval must never break the agent run.
-                """
-                chat_middleware_decorator = _import_chat_middleware()
-                provider = self
-
-                @chat_middleware_decorator
-                async def _per_call_retrieval(context: Any, call_next: Any) -> None:
-                    try:
-                        await provider._refresh_tools_on_chat_context(context)
-                    except Exception:
-                        logger.exception(
-                            "GantryContextProvider: per-call retrieval failed; "
-                            "continuing with existing tools."
-                        )
-                    await call_next()
-
-                return _per_call_retrieval
-
-            async def _refresh_tools_on_chat_context(self, context: Any) -> None:
-                """Mutate ``context.options['tools']`` for the current round.
-
-                Strategy: drop **all** tools whose names are known to the
-                gantry registry (these are tools we — or another provider
-                bridging the same gantry — could have injected). Anything
-                else in ``existing`` is foreign (skills from another
-                provider, AF-native tools added at construction time) and
-                is preserved. Then append the freshly retrieved top-k plus
-                always_include / skill pins. This guarantees the per-round
-                top-k stays bounded and stale dynamic selections from
-                earlier rounds do not accumulate.
-
-                Mutates the existing options dict **in place** rather than
-                replacing the reference. ``FunctionInvocationLayer`` in
-                agent-framework keeps the same options dict across its
-                inner loop and uses it both as the chat-call payload *and*
-                as the tool-lookup table when executing function calls.
-                Reassigning ``context.options = new_options`` would only
-                update the chat-call payload — the function executor would
-                still see the original (stale) tool list and fail to find
-                the tools we just injected.
-                """
-                options = getattr(context, "options", None)
-                existing: list[Any] = []
-                if isinstance(options, dict):
-                    existing = list(options.get("tools") or [])
-                elif options is not None:
-                    # Pydantic ChatOptions / plain objects: peer-provider
-                    # tools live on the `tools` attribute. Read them too,
-                    # otherwise the combined list would drop everything
-                    # the model already carried (skills, static tools,
-                    # tools from another ContextProvider).
-                    attr_tools = getattr(options, "tools", None)
-                    if attr_tools:
-                        existing = list(attr_tools)
-
-                messages = (
-                    getattr(context, "messages", None)
-                    or getattr(context, "input_messages", None)
-                    or []
-                )
-                fresh, _ = await self._collect_tools(
-                    messages, include_dynamic=True
-                )
-                # _collect_tools updates the last-selection / selections
-                # ContextVars on every dynamic refresh, so the per-call
-                # middleware path automatically exposes the latest decision via
-                # the provider's `last_selection` / `selections` properties.
-                gantry_names = self._all_known_tool_names()
-                static_names = {
-                    _tool_name(t) for t in self._static_tools if _tool_name(t)
-                }
-
-                preserved = []
-                dropped = 0
-                for t in existing:
-                    name = _tool_name(t)
-                    # Drop stale gantry-known tools so the per-round
-                    # surface stays bounded. Static tools may appear in
-                    # both `existing` (carried across rounds) and `fresh`
-                    # (we re-add them ourselves); dedup happens below.
-                    if name and name in gantry_names and name not in static_names:
-                        dropped += 1
-                        continue
-                    preserved.append(t)
-
-                combined: list[Any] = []
-                seen_combined: set[str] = set()
-                for t in preserved + fresh:
-                    name = _tool_name(t)
-                    if name and name in seen_combined:
-                        continue
-                    if name:
-                        seen_combined.add(name)
-                    combined.append(t)
-
-                if isinstance(options, dict):
-                    # Mutate in place — see docstring above.
-                    options["tools"] = combined
-                elif options is not None:
-                    # Non-dict options (e.g. a Pydantic ChatOptions model).
-                    # The in-place invariant from the docstring applies here
-                    # too — AF's FunctionInvocationLayer keeps the same
-                    # options reference across the inner loop, so we must
-                    # mutate the existing object rather than reassign
-                    # context.options. Try setattr first (works for plain
-                    # objects and mutable Pydantic models); only fall back
-                    # to a rebuilt-copy + reassignment if the attribute is
-                    # genuinely immutable (frozen model).
-                    mutated_in_place = False
-                    try:
-                        setattr(options, "tools", combined)
-                        mutated_in_place = True
-                    except (AttributeError, TypeError, ValueError):
-                        pass
-                    if not mutated_in_place:
-                        if hasattr(options, "model_copy"):
-                            new_options = options.model_copy(update={"tools": combined})
-                            try:
-                                context.options = new_options
-                            except AttributeError:
-                                logger.warning(
-                                    "GantryContextProvider: cannot update tools on "
-                                    "immutable options object %r (no in-place setattr, "
-                                    "no settable context.options). %d Gantry tools were "
-                                    "selected but will NOT be visible to AF.",
-                                    type(options).__name__,
-                                    len(combined),
-                                )
-                        else:
-                            logger.warning(
-                                "GantryContextProvider: options object %r is neither "
-                                "dict-like nor a Pydantic model and rejected attribute "
-                                "assignment. %d Gantry tools were selected but will "
-                                "NOT be visible to AF.",
-                                type(options).__name__,
-                                len(combined),
-                            )
-
-                logger.debug(
-                    "GantryContextProvider: refreshed tools per-call "
-                    "(%d preserved + %d gantry, %d stale dropped, %d total)",
-                    len(preserved),
-                    len(fresh),
-                    dropped,
-                    len(combined),
-                )
-
-            def _all_known_tool_names(self) -> set[str]:
-                """Return every tool name registered in the gantry.
-
-                Used to identify which entries in ``context.options['tools']``
-                were produced by this gantry (or any other provider sharing
-                it) so they can be dropped before re-injecting the fresh
-                per-round selection.
-                """
-                registry = getattr(self._gantry, "_registry", None)
-                if registry is None:
-                    return set()
-                lister = getattr(registry, "list_tools", None)
-                if not callable(lister):
-                    return set()
-                try:
-                    return {t.name for t in lister() if getattr(t, "name", None)}
-                except Exception:
-                    return set()
-
-            # ----- Tool assembly -----------------------------------------
-            async def _collect_tools(
-                self,
-                messages: Any,
-                *,
-                include_dynamic: bool,
-            ) -> tuple[list[Any], set[str]]:
-                tools: list[Any] = []
-                seen: set[str] = set()
-                decision: RetrievalDecision | None = None
-
-                if include_dynamic:
-                    query = await self._build_query(messages)
-                    if query:
-                        try:
-                            retrieved, decision = (
-                                await self._bridge.get_tools_with_decision(
-                                    query,
-                                    limit=self._top_k,
-                                    score_threshold=self._score_threshold,
-                                    **self._query_kwargs,
-                                )
-                            )
-                        except Exception:
-                            logger.exception(
-                                "GantryContextProvider: semantic retrieval failed; "
-                                "continuing without dynamic tools."
-                            )
-                            retrieved = []
-                        for t in retrieved:
-                            name = _tool_name(t)
-                            if name and name in seen:
-                                continue
-                            if name:
-                                seen.add(name)
-                            tools.append(t)
-
-                # Skills: always-on tools bound to registered Gantry skills.
-                skill_count = 0
-                if self._skills_enabled:
-                    skill_tool_names = self._collect_skill_tool_names()
-                    extra = self._wrap_named(skill_tool_names, seen, source="skill")
-                    tools.extend(extra)
-                    skill_count = len(extra)
-
-                # Explicit always_include / required pins.
-                always_count = 0
-                if self._always_include:
-                    extra = self._wrap_named(
-                        self._always_include, seen, source="always_include"
-                    )
-                    tools.extend(extra)
-                    always_count = len(extra)
-
-                # Static AF-native tools that live outside the gantry registry.
-                static_count = 0
-                for t in self._static_tools:
-                    name = _tool_name(t)
-                    if name and name in seen:
-                        continue
-                    if name:
-                        seen.add(name)
-                    tools.append(t)
-                    static_count += 1
-
-                if include_dynamic and decision is not None:
-                    self._last_selection_var.set(decision)
-                    # ContextVar holds an immutable tuple; bound it by slicing
-                    # so history stays capped without a shared mutable deque.
-                    # `or ()` covers a refresh in a context where before_run
-                    # never reset the var (default None).
-                    history = (
-                        (self._selections_var.get() or ()) + (decision,)
-                    )[-_MAX_SELECTION_HISTORY:]
-                    self._selections_var.set(history)
-                    # Mirror to the plain fallbacks (coherent snapshot for
-                    # cross-task post-run introspection; see the properties).
-                    self._last_selection_plain = decision
-                    self._selections_plain = history
-                    if self._verbose:
-                        logger.info("gantry: %s", decision.summary())
-
-                # One-shot info log clarifying the top_k math whenever
-                # non-dynamic contributions raise the surface above top_k.
-                extra_total = skill_count + always_count + static_count
-                if (
-                    include_dynamic
-                    and extra_total > 0
-                    and not self._logged_top_k_math
-                ):
-                    self._logged_top_k_math = True
-                    logger.info(
-                        "GantryContextProvider: dynamic top_k=%d + %d preserved "
-                        "(skills=%d, always_include=%d, static=%d). The final "
-                        "tool surface is the dynamic slice plus preserved tools.",
-                        self._top_k,
-                        extra_total,
-                        skill_count,
-                        always_count,
-                        static_count,
-                    )
-
-                return tools, seen
-
-            async def dry_run_retrieve(
-                self,
-                query: str,
-                *,
-                limit: int | None = None,
-                score_threshold: float | str | None = None,
-            ) -> RetrievalDecision:
-                """Run the live retrieval path against a synthetic query.
-
-                Uses the *exact same* threshold, top_k, and ``query_kwargs``
-                as the live middleware. Use this to diagnose why a tool
-                is or is not surfacing without spinning up an agent.
-
-                Args:
-                    query: The query string to retrieve against.
-                    limit: Override ``top_k`` for this call only.
-                    score_threshold: Override the threshold for this call
-                        only (accepts the same forms as the constructor).
-
-                Returns:
-                    The :class:`RetrievalDecision` produced by the bridge.
-                """
-                eff_limit = self._top_k if limit is None else limit
-                eff_threshold = (
-                    self._score_threshold
-                    if score_threshold is None
-                    else score_threshold
-                )
-                _, decision = await self._bridge.get_tools_with_decision(
-                    query,
-                    limit=eff_limit,
-                    score_threshold=eff_threshold,
-                    **self._query_kwargs,
-                )
-                return decision
-
-            async def _build_query(self, messages: Any) -> str:
-                try:
-                    result = self._query_generator(messages)
-                    return await _maybe_await(result) or ""
-                except Exception:
-                    logger.exception(
-                        "GantryContextProvider: query_generator raised; falling "
-                        "back to last_user_text."
-                    )
-                    return last_user_text(messages)
-
-            def _resolve_skill_registry(self) -> SkillRegistry | None:
-                if self._skill_registry is not None:
-                    return self._skill_registry
-                # Best-effort: pick up a registry attached to the gantry
-                # instance (e.g. via SkillsClient).
-                return getattr(self._gantry, "_skill_registry", None) or getattr(
-                    self._gantry, "skill_registry", None
-                )
-
-            def _collect_skill_tool_names(self) -> list[str]:
-                registry = self._resolve_skill_registry()
-                if registry is None:
-                    logger.debug(
-                        "GantryContextProvider: skills=True but no SkillRegistry "
-                        "available on gantry — no skill tools injected."
-                    )
-                    return []
-                names: list[str] = []
-                seen_names: set[str] = set()
-                for skill in registry.list_skills():
-                    for tool_name in skill.tools or []:
-                        if tool_name not in seen_names:
-                            seen_names.add(tool_name)
-                            names.append(tool_name)
-                return names
-
-            def _wrap_named(
-                self, names: list[str], seen: set[str], *, source: str
-            ) -> list[Any]:
-                wrapped: list[Any] = []
-                missing: list[str] = []
-                for name in names:
-                    if name in seen:
-                        continue
-                    tool_def = self._lookup_tool_def(name)
-                    if tool_def is None:
-                        missing.append(name)
-                        continue
-                    wrapped.append(self._bridge.wrap_single(tool_def))
-                    seen.add(name)
-                if missing:
-                    logger.warning(
-                        "GantryContextProvider: %s tool(s) not found in registry "
-                        "and will be skipped: %s",
-                        source,
-                        missing,
-                    )
-                return wrapped
-
-            def _lookup_tool_def(self, name: str) -> ToolDefinition | None:
-                registry = getattr(self._gantry, "_registry", None)
-                if registry is None:
-                    return None
-                lookup = getattr(registry, "get_tool_by_name", None)
-                if callable(lookup):
-                    found = lookup(name)
-                    if found is not None:
-                        return found
-                lookup = getattr(registry, "get_tool", None)
-                if callable(lookup):
-                    return lookup(name)
-                return None
-
-        return _GantryContextProviderImpl()
+    # Combine for "always inject" set; required is a strict superset.
+    always_include_effective: list[str] = []
+    seen_ai: set[str] = set()
+    for n in (*required, *always_include):
+        if n not in seen_ai:
+            seen_ai.add(n)
+            always_include_effective.append(n)
+    impl_cls = _build_impl_class(context_provider_cls)
+    return impl_cls(
+        gantry=gantry,
+        bridge=bridge,
+        top_k=top_k,
+        score_threshold=score_threshold,
+        query_strategy=query_strategy,
+        query_generator=query_generator,
+        skills=skills,
+        skill_registry=skill_registry,
+        always_include_effective=always_include_effective,
+        declared_always_include=always_include,
+        required=required,
+        static_tools=static_tools_list,
+        query_kwargs=query_kwargs,
+        source_id=source_id,
+        verbose=verbose,
+    )
 
 
 __all__ = ["GantryContextProvider", "MissingRequiredToolError"]

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -274,7 +274,7 @@ def _build_impl_class(base: type) -> type:
             return self._top_k
 
         @property
-        def score_threshold(self) -> float:
+        def score_threshold(self) -> float | str:
             return self._score_threshold
 
         @property
@@ -996,24 +996,7 @@ def _build_impl_class(base: type) -> type:
     return _GantryContextProviderImpl
 
 
-def GantryContextProvider(  # noqa: N802 - factory keeps the public PascalCase API name
-    gantry: AgentGantry,
-    *,
-    top_k: int = 5,
-    score_threshold: float | str = 0.0,
-    query_strategy: str = "per_run",
-    query_generator: Callable[..., Any] | None = None,
-    skills: bool = False,
-    skill_registry: SkillRegistry | None = None,
-    always_include: list[str] | None = None,
-    required: list[str] | None = None,
-    static_tools: list[Any] | None = None,
-    as_function_tool: bool | None = None,
-    source_id: str = "agent_gantry",
-    bridge: GantryToolBridge | None = None,
-    verbose: bool = False,
-    **query_kwargs: Any,
-) -> Any:
+class GantryContextProvider:
     """AF context provider that injects semantically-selected Gantry tools.
 
     Constructing the provider returns an instance of the dynamically
@@ -1123,79 +1106,99 @@ def GantryContextProvider(  # noqa: N802 - factory keeps the public PascalCase A
                 middleware=[provider.as_chat_middleware()],
             )
     """
-    if query_strategy not in ("per_run", "per_call"):
-        raise ValueError(
-            f"query_strategy must be 'per_run' or 'per_call', got {query_strategy!r}"
-        )
 
-    context_provider_cls = _import_context_provider()
-
-    bridge = bridge or GantryToolBridge(
-        gantry,
-        score_threshold=score_threshold,
-        as_function_tool=as_function_tool,
-    )
-    always_include = list(always_include or [])
-    required = list(required or [])
-    static_tools_list: list[Any] = list(static_tools or [])
-
-    # Default query generator depends on strategy: per_call wants
-    # round-to-round adaptation, so the historical last_user_text
-    # default (which returns the same string every round) would
-    # silently disable the very thing per_call enables.
-    if query_generator is None:
-        if query_strategy == "per_call":
-            query_generator = _default_per_call_query()
-        else:
-            query_generator = _DEFAULT_PER_RUN_QUERY
-    elif (
-        query_strategy == "per_call"
-        and query_generator is last_user_text
-    ):
-        logger.warning(
-            "GantryContextProvider: query_strategy='per_call' was set "
-            "but query_generator=last_user_text returns the same string "
-            "every round, defeating per-call adaptation. Consider "
-            "fallback_chain(last_tool_result, last_user_text) instead."
-        )
-
-    if required:
-        known = gantry.list_tools_sync()
-        available = {t.name for t in known} | {
-            f"{t.namespace}.{t.name}" for t in known
-        }
-        missing = [name for name in required if name not in available]
-        if missing:
-            raise MissingRequiredToolError(
-                f"GantryContextProvider: required tool(s) not found in gantry: "
-                f"{missing}. Did you forget to register them, or is there a typo?"
+    def __new__(
+        cls,
+        gantry: AgentGantry,
+        *,
+        top_k: int = 5,
+        score_threshold: float | str = 0.0,
+        query_strategy: str = "per_run",
+        query_generator: Callable[..., Any] | None = None,
+        skills: bool = False,
+        skill_registry: SkillRegistry | None = None,
+        always_include: list[str] | None = None,
+        required: list[str] | None = None,
+        static_tools: list[Any] | None = None,
+        as_function_tool: bool | None = None,
+        source_id: str = "agent_gantry",
+        bridge: GantryToolBridge | None = None,
+        verbose: bool = False,
+        **query_kwargs: Any,
+    ) -> Any:
+        if query_strategy not in ("per_run", "per_call"):
+            raise ValueError(
+                f"query_strategy must be 'per_run' or 'per_call', got {query_strategy!r}"
             )
 
-    # Combine for "always inject" set; required is a strict superset.
-    always_include_effective: list[str] = []
-    seen_ai: set[str] = set()
-    for n in (*required, *always_include):
-        if n not in seen_ai:
-            seen_ai.add(n)
-            always_include_effective.append(n)
-    impl_cls = _build_impl_class(context_provider_cls)
-    return impl_cls(
-        gantry=gantry,
-        bridge=bridge,
-        top_k=top_k,
-        score_threshold=score_threshold,
-        query_strategy=query_strategy,
-        query_generator=query_generator,
-        skills=skills,
-        skill_registry=skill_registry,
-        always_include_effective=always_include_effective,
-        declared_always_include=always_include,
-        required=required,
-        static_tools=static_tools_list,
-        query_kwargs=query_kwargs,
-        source_id=source_id,
-        verbose=verbose,
-    )
+        context_provider_cls = _import_context_provider()
+
+        bridge = bridge or GantryToolBridge(
+            gantry,
+            score_threshold=score_threshold,
+            as_function_tool=as_function_tool,
+        )
+        always_include = list(always_include or [])
+        required = list(required or [])
+        static_tools_list: list[Any] = list(static_tools or [])
+
+        # Default query generator depends on strategy: per_call wants
+        # round-to-round adaptation, so the historical last_user_text
+        # default (which returns the same string every round) would
+        # silently disable the very thing per_call enables.
+        if query_generator is None:
+            if query_strategy == "per_call":
+                query_generator = _default_per_call_query()
+            else:
+                query_generator = _DEFAULT_PER_RUN_QUERY
+        elif (
+            query_strategy == "per_call"
+            and query_generator is last_user_text
+        ):
+            logger.warning(
+                "GantryContextProvider: query_strategy='per_call' was set "
+                "but query_generator=last_user_text returns the same string "
+                "every round, defeating per-call adaptation. Consider "
+                "fallback_chain(last_tool_result, last_user_text) instead."
+            )
+
+        if required:
+            known = gantry.list_tools_sync()
+            available = {t.name for t in known} | {
+                f"{t.namespace}.{t.name}" for t in known
+            }
+            missing = [name for name in required if name not in available]
+            if missing:
+                raise MissingRequiredToolError(
+                    f"GantryContextProvider: required tool(s) not found in gantry: "
+                    f"{missing}. Did you forget to register them, or is there a typo?"
+                )
+
+        # Combine for "always inject" set; required is a strict superset.
+        always_include_effective: list[str] = []
+        seen_ai: set[str] = set()
+        for n in (*required, *always_include):
+            if n not in seen_ai:
+                seen_ai.add(n)
+                always_include_effective.append(n)
+        impl_cls = _build_impl_class(context_provider_cls)
+        return impl_cls(
+            gantry=gantry,
+            bridge=bridge,
+            top_k=top_k,
+            score_threshold=score_threshold,
+            query_strategy=query_strategy,
+            query_generator=query_generator,
+            skills=skills,
+            skill_registry=skill_registry,
+            always_include_effective=always_include_effective,
+            declared_always_include=always_include,
+            required=required,
+            static_tools=static_tools_list,
+            query_kwargs=query_kwargs,
+            source_id=source_id,
+            verbose=verbose,
+        )
 
 
 __all__ = ["GantryContextProvider", "MissingRequiredToolError"]

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -172,6 +172,11 @@ async def _maybe_await(value: Any) -> Any:
     return value
 
 
+# Cache the synthesized impl class per AF base type. Keyed by the base class
+# identity, so a test that swaps a stubbed ``ContextProvider`` for a different
+# one gets its own entry rather than a stale subclass. (Hot-reloading the real
+# AF base mid-process would return the cached subclass; not a concern in normal
+# use, where the base is imported once.)
 _IMPL_CLASS_CACHE: dict[type, type] = {}
 
 

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -192,6 +192,9 @@ def _build_impl_class(base: type) -> type:
     if cached is not None:
         return cached
 
+    # No lock: a concurrent first-call race just builds the class twice and the
+    # loser is GC'd — both are equivalent, so this is benign and a lock would be
+    # overkill for a once-per-base construction.
     class _GantryContextProviderImpl(base):  # type: ignore[misc,valid-type]
         """Concrete ContextProvider subclass; see :class:`GantryContextProvider`."""
 

--- a/agent_gantry/integrations/agent_framework_provider.py
+++ b/agent_gantry/integrations/agent_framework_provider.py
@@ -68,6 +68,7 @@ primitive (``WorkflowBuilder``, ``SequentialBuilder``, ``HandoffBuilder``,
 
 from __future__ import annotations
 
+import functools
 import inspect
 import logging
 from collections.abc import Callable
@@ -172,33 +173,21 @@ async def _maybe_await(value: Any) -> Any:
     return value
 
 
-# Cache the synthesized impl class per AF base type. Keyed by the base class
-# identity, so a test that swaps a stubbed ``ContextProvider`` for a different
-# one gets its own entry rather than a stale subclass. (Hot-reloading the real
-# AF base mid-process would return the cached subclass; not a concern in normal
-# use, where the base is imported once.)
-_IMPL_CLASS_CACHE: dict[type, type] = {}
-
-
+@functools.cache
 def _build_impl_class(base: type) -> type:
     """Build (and cache) the concrete ``ContextProvider`` subclass.
 
     ``base`` is :class:`agent_framework.ContextProvider`, imported lazily, so
     the subclass cannot be declared at module top level. It holds no per-call
     state — every value is passed to ``__init__`` — so one class is built per
-    base type and reused across all provider instances.
-    """
-    cached = _IMPL_CLASS_CACHE.get(base)
-    if cached is not None:
-        return cached
+    base type and reused across all provider instances. ``functools.cache`` keys
+    on the base identity and is thread-safe (including free-threaded builds), so
+    the slow path runs at most once per base.
 
-    # No lock: a concurrent first-call race just builds the class twice and the
-    # loser is GC'd — both are equivalent, so this is benign and a lock would be
-    # overkill for a once-per-base construction. (Atomic under CPython's GIL;
-    # would only ever build a redundant class, never corrupt the cache.)
-    #
-    # NOTE: the class body below is long (the full provider implementation);
-    # it lives in a function only because ``base`` is resolved lazily at runtime.
+    NOTE: the class body below is long (the full provider implementation); it
+    lives in a function only because ``base`` is resolved lazily at runtime.
+    """
+
     class _GantryContextProviderImpl(base):  # type: ignore[misc,valid-type]
         """Concrete ContextProvider subclass; see :class:`GantryContextProvider`."""
 
@@ -1004,7 +993,6 @@ def _build_impl_class(base: type) -> type:
                 return lookup(name)
             return None
 
-    _IMPL_CLASS_CACHE[base] = _GantryContextProviderImpl
     return _GantryContextProviderImpl
 
 

--- a/agent_gantry/integrations/frameworks/agno.py
+++ b/agent_gantry/integrations/frameworks/agno.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+from agent_gantry.integrations.frameworks.base import (
+    BaseFrameworkAdapter,
+    GantryToolset,
+    ToolSpec,
+)
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -66,32 +70,17 @@ async def _for_agno(
     return [_spec_to_agno(s) for s in specs]
 
 
-class AgnoAdapter:
+class AgnoAdapter(BaseFrameworkAdapter):
     """Route Gantry-selected tools into Agno.
 
     Static slice (``agno.tools.function.Function`` objects) plus a per-call live
     builder (Agno fixes tools at construction). Every call routes through ``gantry.execute``.
     """
 
-    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
-        self._gantry = gantry
-        self._default_limit = default_limit
-
     @staticmethod
     def convert(spec: ToolSpec) -> Any:
         """Wrap a single :class:`ToolSpec` as an Agno ``Function``."""
         return _spec_to_agno(spec)
-
-    async def select(
-        self, query: str, *, limit: int | None = None, **select_kwargs: Any
-    ) -> list[Any]:
-        """Select tools for ``query`` as Agno ``Function``s (static slice)."""
-        return await _for_agno(
-            self._gantry,
-            query,
-            limit=self._default_limit if limit is None else limit,
-            **select_kwargs,
-        )
 
     def agent_builder(
         self,

--- a/agent_gantry/integrations/frameworks/autogen.py
+++ b/agent_gantry/integrations/frameworks/autogen.py
@@ -18,7 +18,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+from agent_gantry.integrations.frameworks.base import (
+    BaseFrameworkAdapter,
+    GantryToolset,
+    ToolSpec,
+)
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -92,7 +96,7 @@ async def _register_with_autogen(
     return names
 
 
-class AutoGenAdapter:
+class AutoGenAdapter(BaseFrameworkAdapter):
     """Route Gantry-selected tools into AutoGen / AG2.
 
     Static slice (registrable callable mappings), direct registration with
@@ -100,25 +104,10 @@ class AutoGenAdapter:
     routes through ``gantry.execute``.
     """
 
-    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
-        self._gantry = gantry
-        self._default_limit = default_limit
-
     @staticmethod
     def convert(spec: ToolSpec) -> dict[str, Any]:
         """Describe a single :class:`ToolSpec` as an AutoGen-registrable mapping."""
         return _spec_to_autogen(spec)
-
-    async def select(
-        self, query: str, *, limit: int | None = None, **select_kwargs: Any
-    ) -> list[dict[str, Any]]:
-        """Select tools for ``query`` as AutoGen-registrable mappings (static slice)."""
-        return await _for_autogen(
-            self._gantry,
-            query,
-            limit=self._default_limit if limit is None else limit,
-            **select_kwargs,
-        )
 
     async def register(
         self,

--- a/agent_gantry/integrations/frameworks/base.py
+++ b/agent_gantry/integrations/frameworks/base.py
@@ -340,3 +340,41 @@ class GantryToolset:
         return [
             spec_from_tool(self._gantry, st.tool, st.semantic_score) for st in result.tools
         ]
+
+
+class BaseFrameworkAdapter:
+    """Shared base for native per-framework tool adapters.
+
+    Subclasses implement the :meth:`convert` staticmethod (one ``ToolSpec`` →
+    one framework-native tool object). This base supplies the parts every
+    adapter shares — construction and the ``select`` → ``convert`` pipeline —
+    so each concrete adapter only declares ``convert`` plus any
+    framework-specific helpers (agent builders, live retrievers, …).
+    """
+
+    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
+        self._gantry = gantry
+        self._default_limit = default_limit
+
+    @staticmethod
+    def convert(spec: ToolSpec) -> Any:
+        """Wrap a single :class:`ToolSpec` as the framework's native tool object."""
+        raise NotImplementedError
+
+    async def select(
+        self, query: str, *, limit: int | None = None, **select_kwargs: Any
+    ) -> list[Any]:
+        """Select tools for ``query`` as the framework's native tool objects.
+
+        ``limit`` defaults to the adapter's ``default_limit``. Extra keyword
+        arguments (``score_threshold``, ``namespaces``, ``tools_already_used``)
+        are forwarded to the underlying semantic selection. Each call still
+        routes through ``gantry.execute`` so retries, timeouts, circuit
+        breakers, and the security policy apply.
+        """
+        specs = await GantryToolset(self._gantry).select(
+            query,
+            limit=self._default_limit if limit is None else limit,
+            **select_kwargs,
+        )
+        return [self.convert(s) for s in specs]

--- a/agent_gantry/integrations/frameworks/base.py
+++ b/agent_gantry/integrations/frameworks/base.py
@@ -358,7 +358,12 @@ class BaseFrameworkAdapter:
 
     @staticmethod
     def convert(spec: ToolSpec) -> Any:
-        """Wrap a single :class:`ToolSpec` as the framework's native tool object."""
+        """Wrap a single :class:`ToolSpec` as the framework's native tool object.
+
+        Subclasses must re-declare this as a ``@staticmethod`` (it is part of the
+        public API — callers use ``SomeAdapter.convert(spec)`` without an
+        instance — and :meth:`select` dispatches through ``self.convert``).
+        """
         raise NotImplementedError
 
     async def select(

--- a/agent_gantry/integrations/frameworks/crewai.py
+++ b/agent_gantry/integrations/frameworks/crewai.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+from agent_gantry.integrations.frameworks.base import (
+    BaseFrameworkAdapter,
+    GantryToolset,
+    ToolSpec,
+)
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -94,7 +98,7 @@ async def _for_crewai(
     return [_spec_to_crewai(s) for s in specs]
 
 
-class CrewAIAdapter:
+class CrewAIAdapter(BaseFrameworkAdapter):
     """Route Gantry-selected tools into CrewAI.
 
     Static slice (``crewai.tools.BaseTool`` objects) plus per-call live helpers
@@ -102,18 +106,10 @@ class CrewAIAdapter:
     fresh agent per call). Every call routes through ``gantry.execute``.
     """
 
-    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
-        self._gantry = gantry
-        self._default_limit = default_limit
-
     @staticmethod
     def convert(spec: ToolSpec) -> Any:
         """Wrap a single :class:`ToolSpec` as a CrewAI ``BaseTool``."""
         return _spec_to_crewai(spec)
-
-    async def select(self, query: str, *, limit: int | None = None, **select_kwargs: Any) -> list[Any]:
-        """Select tools for ``query`` as CrewAI ``BaseTool``s (static slice)."""
-        return await _for_crewai(self._gantry, query, limit=self._default_limit if limit is None else limit, **select_kwargs)
 
     async def live_tools(self, query: str, *, limit: int | None = None, **select_kwargs: Any) -> list[Any]:
         """Re-select CrewAI ``BaseTool``s for THIS call's ``query`` (per-call selection).

--- a/agent_gantry/integrations/frameworks/google_adk.py
+++ b/agent_gantry/integrations/frameworks/google_adk.py
@@ -13,7 +13,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+from agent_gantry.integrations.frameworks.base import (
+    BaseFrameworkAdapter,
+    GantryToolset,
+    ToolSpec,
+)
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -56,7 +60,7 @@ async def _for_google_adk(
     return [_spec_to_google_adk(s) for s in specs]
 
 
-class GoogleADKAdapter:
+class GoogleADKAdapter(BaseFrameworkAdapter):
     """Route Gantry-selected tools into Google ADK.
 
     Static slice (``google.adk.tools.FunctionTool`` objects) plus deep per-turn
@@ -64,25 +68,10 @@ class GoogleADKAdapter:
     through ``gantry.execute``.
     """
 
-    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
-        self._gantry = gantry
-        self._default_limit = default_limit
-
     @staticmethod
     def convert(spec: ToolSpec) -> Any:
         """Wrap a single :class:`ToolSpec` as a Google ADK ``FunctionTool``."""
         return _spec_to_google_adk(spec)
-
-    async def select(
-        self, query: str, *, limit: int | None = None, **select_kwargs: Any
-    ) -> list[Any]:
-        """Select tools for ``query`` as ADK ``FunctionTool``s (static slice)."""
-        return await _for_google_adk(
-            self._gantry,
-            query,
-            limit=self._default_limit if limit is None else limit,
-            **select_kwargs,
-        )
 
     def before_model_callback(
         self, *, limit: int | None = None, score_threshold: float = 0.0

--- a/agent_gantry/integrations/frameworks/haystack.py
+++ b/agent_gantry/integrations/frameworks/haystack.py
@@ -13,7 +13,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+from agent_gantry.integrations.frameworks.base import (
+    BaseFrameworkAdapter,
+    GantryToolset,
+    ToolSpec,
+)
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -58,7 +62,7 @@ async def _for_haystack(
     return [_spec_to_haystack(s) for s in specs]
 
 
-class HaystackAdapter:
+class HaystackAdapter(BaseFrameworkAdapter):
     """Route Gantry-selected tools into Haystack.
 
     Static slice (``haystack.tools.Tool`` objects) plus per-call live helpers
@@ -66,25 +70,10 @@ class HaystackAdapter:
     through ``gantry.execute``.
     """
 
-    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
-        self._gantry = gantry
-        self._default_limit = default_limit
-
     @staticmethod
     def convert(spec: ToolSpec) -> Any:
         """Wrap a single :class:`ToolSpec` as a Haystack ``Tool``."""
         return _spec_to_haystack(spec)
-
-    async def select(
-        self, query: str, *, limit: int | None = None, **select_kwargs: Any
-    ) -> list[Any]:
-        """Select tools for ``query`` as Haystack ``Tool``s (static slice)."""
-        return await _for_haystack(
-            self._gantry,
-            query,
-            limit=self._default_limit if limit is None else limit,
-            **select_kwargs,
-        )
 
     async def live_tools(
         self, query: str, *, limit: int | None = None, **select_kwargs: Any

--- a/agent_gantry/integrations/frameworks/langchain.py
+++ b/agent_gantry/integrations/frameworks/langchain.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+from agent_gantry.integrations.frameworks.base import (
+    BaseFrameworkAdapter,
+    GantryToolset,
+    ToolSpec,
+)
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -56,7 +60,7 @@ async def _for_langchain(
     return [_spec_to_langchain(s) for s in specs]
 
 
-class LangChainAdapter:
+class LangChainAdapter(BaseFrameworkAdapter):
     """Route Gantry-selected tools into LangChain.
 
     Construct with a gantry, then :meth:`select` a relevant slice of tools as
@@ -71,27 +75,7 @@ class LangChainAdapter:
         llm = ChatOpenAI(model="gpt-5.5").bind_tools(tools)
     """
 
-    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
-        self._gantry = gantry
-        self._default_limit = default_limit
-
     @staticmethod
     def convert(spec: ToolSpec) -> Any:
         """Wrap a single :class:`ToolSpec` as a LangChain ``StructuredTool``."""
         return _spec_to_langchain(spec)
-
-    async def select(
-        self, query: str, *, limit: int | None = None, **select_kwargs: Any
-    ) -> list[Any]:
-        """Select tools for ``query`` as LangChain ``StructuredTool``s.
-
-        ``limit`` defaults to the adapter's ``default_limit``. Extra keyword
-        arguments (``score_threshold``, ``namespaces``, ``tools_already_used``)
-        are forwarded to the underlying semantic selection.
-        """
-        return await _for_langchain(
-            self._gantry,
-            query,
-            limit=self._default_limit if limit is None else limit,
-            **select_kwargs,
-        )

--- a/agent_gantry/integrations/frameworks/langgraph.py
+++ b/agent_gantry/integrations/frameworks/langgraph.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from agent_gantry.integrations.frameworks.base import BaseFrameworkAdapter
 from agent_gantry.integrations.frameworks.langchain import (
     _for_langchain,
     _spec_to_langchain,
@@ -39,7 +40,7 @@ async def _for_langgraph(
     return await _for_langchain(gantry, query, limit=limit, **select_kwargs)
 
 
-class LangGraphAdapter:
+class LangGraphAdapter(BaseFrameworkAdapter):
     """Route Gantry-selected tools into LangGraph.
 
     Static slice (LangChain ``BaseTool`` objects for a ``ToolNode`` / prebuilt
@@ -53,25 +54,10 @@ class LangGraphAdapter:
         agent = await adapter.areact_agent(chat_model, limit=5)           # live
     """
 
-    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
-        self._gantry = gantry
-        self._default_limit = default_limit
-
     @staticmethod
     def convert(spec: ToolSpec) -> Any:
         """Wrap a single :class:`ToolSpec` as a LangChain ``StructuredTool``."""
         return _spec_to_langgraph(spec)
-
-    async def select(
-        self, query: str, *, limit: int | None = None, **select_kwargs: Any
-    ) -> list[Any]:
-        """Select tools for ``query`` as LangChain ``BaseTool``s (static slice)."""
-        return await _for_langgraph(
-            self._gantry,
-            query,
-            limit=self._default_limit if limit is None else limit,
-            **select_kwargs,
-        )
 
     # -- deep per-turn (live) -------------------------------------------- #
     def react_agent(

--- a/agent_gantry/integrations/frameworks/llamaindex.py
+++ b/agent_gantry/integrations/frameworks/llamaindex.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from agent_gantry.integrations.frameworks.base import GantryToolset
+from agent_gantry.integrations.frameworks.base import BaseFrameworkAdapter, GantryToolset
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -68,32 +68,17 @@ async def _for_llamaindex(
     return [_spec_to_llamaindex(spec) for spec in specs]
 
 
-class LlamaIndexAdapter:
+class LlamaIndexAdapter(BaseFrameworkAdapter):
     """Route Gantry-selected tools into LlamaIndex.
 
     Static slice (``FunctionTool`` objects) plus deep per-turn live wiring
     (re-selects tools every reasoning step), both routed through ``gantry.execute``.
     """
 
-    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
-        self._gantry = gantry
-        self._default_limit = default_limit
-
     @staticmethod
     def convert(spec: ToolSpec) -> Any:
         """Wrap a single :class:`ToolSpec` as a LlamaIndex ``FunctionTool``."""
         return _spec_to_llamaindex(spec)
-
-    async def select(
-        self, query: str, *, limit: int | None = None, **select_kwargs: Any
-    ) -> list[Any]:
-        """Select tools for ``query`` as LlamaIndex ``FunctionTool``s (static slice)."""
-        return await _for_llamaindex(
-            self._gantry,
-            query,
-            limit=self._default_limit if limit is None else limit,
-            **select_kwargs,
-        )
 
     def tool_retriever(
         self, *, limit: int | None = None, score_threshold: float = 0.0

--- a/agent_gantry/integrations/frameworks/openai_agents.py
+++ b/agent_gantry/integrations/frameworks/openai_agents.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
-from agent_gantry.integrations.frameworks.base import GantryToolset
+from agent_gantry.integrations.frameworks.base import BaseFrameworkAdapter, GantryToolset
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -73,32 +73,17 @@ async def _for_openai_agents(
     return [_spec_to_openai_agents(spec) for spec in specs]
 
 
-class OpenAIAgentsAdapter:
+class OpenAIAgentsAdapter(BaseFrameworkAdapter):
     """Route Gantry-selected tools into the OpenAI Agents SDK.
 
     Static slice (``agents.FunctionTool`` objects) plus deep live re-selection as
     the conversation progresses. Every tool call routes through ``gantry.execute``.
     """
 
-    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
-        self._gantry = gantry
-        self._default_limit = default_limit
-
     @staticmethod
     def convert(spec: ToolSpec) -> Any:
         """Wrap a single :class:`ToolSpec` as an OpenAI Agents ``FunctionTool``."""
         return _spec_to_openai_agents(spec)
-
-    async def select(
-        self, query: str, *, limit: int | None = None, **select_kwargs: Any
-    ) -> list[Any]:
-        """Select tools for ``query`` as OpenAI Agents ``FunctionTool``s (static slice)."""
-        return await _for_openai_agents(
-            self._gantry,
-            query,
-            limit=self._default_limit if limit is None else limit,
-            **select_kwargs,
-        )
 
     async def run(
         self,

--- a/agent_gantry/integrations/frameworks/pydantic_ai.py
+++ b/agent_gantry/integrations/frameworks/pydantic_ai.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+from agent_gantry.integrations.frameworks.base import (
+    BaseFrameworkAdapter,
+    GantryToolset,
+    ToolSpec,
+)
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -65,32 +69,17 @@ async def _for_pydantic_ai(
     return [_spec_to_pydantic_ai(s) for s in specs]
 
 
-class PydanticAIAdapter:
+class PydanticAIAdapter(BaseFrameworkAdapter):
     """Route Gantry-selected tools into Pydantic AI.
 
     Static slice (``pydantic_ai.tools.Tool`` objects) plus a deep per-turn live
     toolset that re-selects tools on every run/step. Both route through ``gantry.execute``.
     """
 
-    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
-        self._gantry = gantry
-        self._default_limit = default_limit
-
     @staticmethod
     def convert(spec: ToolSpec) -> Any:
         """Wrap a single :class:`ToolSpec` as a Pydantic AI ``Tool``."""
         return _spec_to_pydantic_ai(spec)
-
-    async def select(
-        self, query: str, *, limit: int | None = None, **select_kwargs: Any
-    ) -> list[Any]:
-        """Select tools for ``query`` as Pydantic AI ``Tool``s (static slice)."""
-        return await _for_pydantic_ai(
-            self._gantry,
-            query,
-            limit=self._default_limit if limit is None else limit,
-            **select_kwargs,
-        )
 
     def toolset(self, *, limit: int | None = None, score_threshold: float = 0.0) -> Any:
         """Build a live ``AbstractToolset`` for per-turn dynamic selection (``Agent(toolsets=[...])``)."""

--- a/agent_gantry/integrations/frameworks/semantic_kernel.py
+++ b/agent_gantry/integrations/frameworks/semantic_kernel.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+from agent_gantry.integrations.frameworks.base import (
+    BaseFrameworkAdapter,
+    GantryToolset,
+    ToolSpec,
+)
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -87,16 +91,12 @@ async def _gantry_plugin(
     return {f.name: f for f in functions}
 
 
-class SemanticKernelAdapter:
+class SemanticKernelAdapter(BaseFrameworkAdapter):
     """Route Gantry-selected tools into Semantic Kernel.
 
     Static slice (``KernelFunction`` objects / a plugin dict) plus a deep per-turn
     live plugin refresh. Every call routes through ``gantry.execute``.
     """
-
-    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
-        self._gantry = gantry
-        self._default_limit = default_limit
 
     @staticmethod
     def convert(spec: ToolSpec, *, plugin_name: str = _DEFAULT_PLUGIN) -> Any:

--- a/agent_gantry/integrations/frameworks/smolagents.py
+++ b/agent_gantry/integrations/frameworks/smolagents.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Any
 
-from agent_gantry.integrations.frameworks.base import GantryToolset, ToolSpec
+from agent_gantry.integrations.frameworks.base import (
+    BaseFrameworkAdapter,
+    GantryToolset,
+    ToolSpec,
+)
 
 if TYPE_CHECKING:
     from agent_gantry.core.gantry import AgentGantry
@@ -138,7 +142,7 @@ async def _for_smolagents(
     return [_spec_to_smolagents(s) for s in specs]
 
 
-class SmolagentsAdapter:
+class SmolagentsAdapter(BaseFrameworkAdapter):
     """Route Gantry-selected tools into smolagents.
 
     Static slice (``smolagents.Tool`` objects) plus a per-call live builder
@@ -146,25 +150,10 @@ class SmolagentsAdapter:
     Every call routes through ``gantry.execute``.
     """
 
-    def __init__(self, gantry: AgentGantry, *, default_limit: int = 3) -> None:
-        self._gantry = gantry
-        self._default_limit = default_limit
-
     @staticmethod
     def convert(spec: ToolSpec) -> Any:
         """Wrap a single :class:`ToolSpec` as a smolagents ``Tool``."""
         return _spec_to_smolagents(spec)
-
-    async def select(
-        self, query: str, *, limit: int | None = None, **select_kwargs: Any
-    ) -> list[Any]:
-        """Select tools for ``query`` as smolagents ``Tool``s (static slice)."""
-        return await _for_smolagents(
-            self._gantry,
-            query,
-            limit=self._default_limit if limit is None else limit,
-            **select_kwargs,
-        )
 
     def agent_builder(
         self,

--- a/agent_gantry/schema/base.py
+++ b/agent_gantry/schema/base.py
@@ -1,0 +1,39 @@
+"""Shared building blocks for Agent-Gantry schema models.
+
+Houses the small pieces that several schema models would otherwise duplicate:
+the identifier newline-rejection validator (a security invariant) and the
+health-metric fields common to tools and MCP servers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+def reject_newlines(value: str | None) -> str | None:
+    """Reject newline characters in identifier fields.
+
+    Pydantic v2's Rust regex engine treats ``$`` as end-of-line rather than
+    end-of-string, so a ``pattern=r"^...$"`` would accept ``"valid_name\\n"``.
+    Attaching this as a reusable ``field_validator`` to every identifier field
+    closes that bypass with a single, shared definition.
+    """
+    if isinstance(value, str) and ("\n" in value or "\r" in value):
+        raise ValueError("Value cannot contain newline characters")
+    return value
+
+
+class HealthMetrics(BaseModel):
+    """Runtime health fields shared by tools and MCP servers.
+
+    Subclasses add the metrics specific to what they track (per-call latency
+    and circuit-breaker state for tools; connection counts and availability for
+    MCP servers).
+    """
+
+    success_rate: float = Field(default=1.0, ge=0.0, le=1.0)
+    consecutive_failures: int = Field(default=0)
+    last_success: datetime | None = None
+    last_failure: datetime | None = None

--- a/agent_gantry/schema/base.py
+++ b/agent_gantry/schema/base.py
@@ -11,6 +11,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+__all__ = ["HealthMetrics", "reject_newlines"]
+
 
 def reject_newlines(value: str | None) -> str | None:
     """Reject newline characters in identifier fields.

--- a/agent_gantry/schema/mcp.py
+++ b/agent_gantry/schema/mcp.py
@@ -12,16 +12,14 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from agent_gantry.schema.base import HealthMetrics, reject_newlines
 
-class MCPServerHealth(BaseModel):
+
+class MCPServerHealth(HealthMetrics):
     """Runtime health metrics for an MCP server."""
 
-    success_rate: float = Field(default=1.0, ge=0.0, le=1.0)
     avg_connection_time_ms: float = Field(default=0.0)
     total_connections: int = Field(default=0)
-    consecutive_failures: int = Field(default=0)
-    last_success: datetime | None = None
-    last_failure: datetime | None = None
     available: bool = Field(default=True)
 
 
@@ -97,18 +95,7 @@ class MCPServerDefinition(BaseModel):
 
     model_config = ConfigDict(extra="ignore", validate_assignment=True)
 
-    @field_validator("name", "namespace")
-    @classmethod
-    def validate_identifiers(cls, v: str | None) -> str | None:
-        """Reject newlines in identifier fields.
-
-        Pydantic v2 (Rust regex engine) treats $ as end-of-line rather than
-        end-of-string, allowing injection of newlines. Explicit character checks
-        close that bypass for all identifier fields.
-        """
-        if isinstance(v, str) and ("\n" in v or "\r" in v):
-            raise ValueError("Value cannot contain newline characters")
-        return v
+    _reject_newline_identifiers = field_validator("name", "namespace")(reject_newlines)
 
     @property
     def qualified_name(self) -> str:

--- a/agent_gantry/schema/skill.py
+++ b/agent_gantry/schema/skill.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from agent_gantry.schema.base import reject_newlines
+
 
 class SkillCategory(str, Enum):
     """Categories for organizing skills."""
@@ -80,18 +82,7 @@ class Skill(BaseModel):
 
     model_config = ConfigDict(extra="ignore", validate_assignment=True)
 
-    @field_validator("name", "namespace")
-    @classmethod
-    def validate_identifiers(cls, v: str | None) -> str | None:
-        """Reject newlines in identifier fields.
-
-        Pydantic v2 (Rust regex engine) treats $ as end-of-line rather than
-        end-of-string, allowing injection of newlines. Explicit character checks
-        close that bypass for all identifier fields.
-        """
-        if isinstance(v, str) and ("\n" in v or "\r" in v):
-            raise ValueError("Value cannot contain newline characters")
-        return v
+    _reject_newline_identifiers = field_validator("name", "namespace")(reject_newlines)
 
     @property
     def qualified_name(self) -> str:

--- a/agent_gantry/schema/tool.py
+++ b/agent_gantry/schema/tool.py
@@ -8,7 +8,6 @@ OpenAPI operation, or A2A agent skill).
 from __future__ import annotations
 
 import hashlib
-import warnings
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Literal
@@ -16,20 +15,6 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from agent_gantry.schema.base import HealthMetrics, reject_newlines
-
-
-def _warn_schema_deprecation(method: str, dialect: str) -> None:
-    """Emit the deprecation warning shared by the legacy ``to_*_schema`` methods.
-
-    ``stacklevel=3`` so the warning points at the user's call site
-    (caller -> ``to_*_schema`` -> here) rather than this helper.
-    """
-    warnings.warn(
-        f"{method}() is deprecated, use to_dialect('{dialect}') instead. "
-        "This method will be removed in version 1.0.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
 
 
 class SchemaDialect(str, Enum):
@@ -164,36 +149,6 @@ class ToolDefinition(BaseModel):
         """
         content = f"{self.name}:{self.version}:{self.description}:{self.parameters_schema}"
         return hashlib.sha256(content.encode()).hexdigest()[:16]
-
-    def to_openai_schema(self) -> dict[str, Any]:
-        """
-        Convert to OpenAI function calling format.
-
-        .. deprecated::
-            Use ``to_dialect("openai")`` instead. Will be removed in 1.0.
-        """
-        _warn_schema_deprecation("to_openai_schema", "openai")
-        return self.to_dialect("openai")
-
-    def to_anthropic_schema(self) -> dict[str, Any]:
-        """
-        Convert to Anthropic tool format.
-
-        .. deprecated::
-            Use ``to_dialect("anthropic")`` instead. Will be removed in 1.0.
-        """
-        _warn_schema_deprecation("to_anthropic_schema", "anthropic")
-        return self.to_dialect("anthropic")
-
-    def to_gemini_schema(self) -> dict[str, Any]:
-        """
-        Convert to Gemini function format.
-
-        .. deprecated::
-            Use ``to_dialect("gemini")`` instead. Will be removed in 1.0.
-        """
-        _warn_schema_deprecation("to_gemini_schema", "gemini")
-        return self.to_dialect("gemini")
 
     def to_dialect(self, dialect: SchemaDialect | str, **options: Any) -> dict[str, Any]:
         """

--- a/agent_gantry/schema/tool.py
+++ b/agent_gantry/schema/tool.py
@@ -14,6 +14,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from agent_gantry.schema.base import HealthMetrics, reject_newlines
+
 
 class SchemaDialect(str, Enum):
     """Schema dialects for different LLM providers."""
@@ -61,15 +63,11 @@ class ToolCost(BaseModel):
     context_tokens: int = Field(default=0, description="Tokens added when selected")
 
 
-class ToolHealth(BaseModel):
+class ToolHealth(HealthMetrics):
     """Runtime health metrics for a tool."""
 
-    success_rate: float = Field(default=1.0, ge=0.0, le=1.0)
     avg_latency_ms: float = Field(default=0.0)
     total_calls: int = Field(default=0)
-    consecutive_failures: int = Field(default=0)
-    last_success: datetime | None = None
-    last_failure: datetime | None = None
     circuit_breaker_open: bool = Field(default=False)
 
 
@@ -124,19 +122,9 @@ class ToolDefinition(BaseModel):
 
     model_config = ConfigDict(extra="ignore", validate_assignment=True)
 
-    @field_validator("name", "version", "namespace")
-    @classmethod
-    def validate_identifiers(cls, v: str | None) -> str | None:
-        """Reject newlines in identifier fields.
-
-        Pydantic v2 (Rust regex engine) treats $ as end-of-line rather than
-        end-of-string, so the pattern=r"^[a-z][a-z0-9_]*$" on `name` would
-        accept "valid_name\\n". Explicit character checks close that bypass for
-        all three identifier fields.
-        """
-        if isinstance(v, str) and ("\n" in v or "\r" in v):
-            raise ValueError("Value cannot contain newline characters")
-        return v
+    _reject_newline_identifiers = field_validator("name", "version", "namespace")(
+        reject_newlines
+    )
 
     @field_validator("name")
     @classmethod

--- a/agent_gantry/schema/tool.py
+++ b/agent_gantry/schema/tool.py
@@ -17,6 +17,22 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from agent_gantry.schema.base import HealthMetrics, reject_newlines
 
 
+def _warn_schema_deprecation(method: str, dialect: str) -> None:
+    """Emit the deprecation warning shared by the legacy ``to_*_schema`` methods.
+
+    ``stacklevel=3`` so the warning points at the user's call site
+    (caller -> ``to_*_schema`` -> here) rather than this helper.
+    """
+    import warnings
+
+    warnings.warn(
+        f"{method}() is deprecated, use to_dialect('{dialect}') instead. "
+        "This method will be removed in version 1.0.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
 class SchemaDialect(str, Enum):
     """Schema dialects for different LLM providers."""
 
@@ -157,14 +173,7 @@ class ToolDefinition(BaseModel):
         .. deprecated::
             Use ``to_dialect("openai")`` instead. Will be removed in 1.0.
         """
-        import warnings
-
-        warnings.warn(
-            "to_openai_schema() is deprecated, use to_dialect('openai') instead. "
-            "This method will be removed in version 1.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        _warn_schema_deprecation("to_openai_schema", "openai")
         return self.to_dialect("openai")
 
     def to_anthropic_schema(self) -> dict[str, Any]:
@@ -174,14 +183,7 @@ class ToolDefinition(BaseModel):
         .. deprecated::
             Use ``to_dialect("anthropic")`` instead. Will be removed in 1.0.
         """
-        import warnings
-
-        warnings.warn(
-            "to_anthropic_schema() is deprecated, use to_dialect('anthropic') instead. "
-            "This method will be removed in version 1.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        _warn_schema_deprecation("to_anthropic_schema", "anthropic")
         return self.to_dialect("anthropic")
 
     def to_gemini_schema(self) -> dict[str, Any]:
@@ -191,14 +193,7 @@ class ToolDefinition(BaseModel):
         .. deprecated::
             Use ``to_dialect("gemini")`` instead. Will be removed in 1.0.
         """
-        import warnings
-
-        warnings.warn(
-            "to_gemini_schema() is deprecated, use to_dialect('gemini') instead. "
-            "This method will be removed in version 1.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        _warn_schema_deprecation("to_gemini_schema", "gemini")
         return self.to_dialect("gemini")
 
     def to_dialect(self, dialect: SchemaDialect | str, **options: Any) -> dict[str, Any]:

--- a/agent_gantry/schema/tool.py
+++ b/agent_gantry/schema/tool.py
@@ -8,6 +8,7 @@ OpenAPI operation, or A2A agent skill).
 from __future__ import annotations
 
 import hashlib
+import warnings
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Literal
@@ -23,8 +24,6 @@ def _warn_schema_deprecation(method: str, dialect: str) -> None:
     ``stacklevel=3`` so the warning points at the user's call site
     (caller -> ``to_*_schema`` -> here) rather than this helper.
     """
-    import warnings
-
     warnings.warn(
         f"{method}() is deprecated, use to_dialect('{dialect}') instead. "
         "This method will be removed in version 1.0.",

--- a/tests/test_agent_framework_integration.py
+++ b/tests/test_agent_framework_integration.py
@@ -27,10 +27,9 @@ def _offline_embedder(monkeypatch):
     Tests that pass ``embedder=`` explicitly are unaffected.
     """
     from agent_gantry.adapters.embedders.simple import SimpleEmbedder
-    from agent_gantry.core.gantry import AgentGantry
 
     monkeypatch.setattr(
-        AgentGantry, "_build_embedder", lambda self, config: SimpleEmbedder()
+        "agent_gantry.core.gantry.build_embedder", lambda config: SimpleEmbedder()
     )
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_framework_orchestration.py
+++ b/tests/test_agent_framework_orchestration.py
@@ -134,10 +134,9 @@ def _offline_embedder(monkeypatch):
     explicit ``embedder=`` (e.g. ``_KeywordEmbedder``) are unaffected.
     """
     from agent_gantry.adapters.embedders.simple import SimpleEmbedder
-    from agent_gantry.core.gantry import AgentGantry
 
     monkeypatch.setattr(
-        AgentGantry, "_build_embedder", lambda self, config: SimpleEmbedder()
+        "agent_gantry.core.gantry.build_embedder", lambda config: SimpleEmbedder()
     )
 
 

--- a/tests/test_factories_and_schema_base.py
+++ b/tests/test_factories_and_schema_base.py
@@ -74,6 +74,20 @@ class TestRejectNewlines:
             reject_newlines(bad)
 
 
+class TestBuildImplClassCache:
+    def test_same_base_returns_cached_class(self) -> None:
+        from agent_gantry.integrations.agent_framework_provider import _build_impl_class
+
+        class _FakeContextProvider:
+            def __init__(self, *, source_id: str) -> None:
+                self.source_id = source_id
+
+        cls1 = _build_impl_class(_FakeContextProvider)
+        cls2 = _build_impl_class(_FakeContextProvider)
+        assert cls1 is cls2
+        assert issubclass(cls1, _FakeContextProvider)
+
+
 class TestHealthMetrics:
     def test_defaults(self) -> None:
         h = HealthMetrics()

--- a/tests/test_factories_and_schema_base.py
+++ b/tests/test_factories_and_schema_base.py
@@ -1,0 +1,87 @@
+"""Unit tests for the extracted ``core/factories.py`` and ``schema/base.py``.
+
+These modules were introduced by the simplicity refactor; the tests pin the
+behaviour that callers rely on: config-driven adapter selection (including the
+URL-validation error paths), the shared identifier newline-rejection security
+invariant, and the shared ``HealthMetrics`` field constraints.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+from agent_gantry.adapters.vector_stores.memory import InMemoryVectorStore
+from agent_gantry.core.factories import (
+    build_embedder,
+    build_reranker,
+    build_telemetry,
+    build_vector_store,
+)
+from agent_gantry.observability.console import ConsoleTelemetryAdapter, NoopTelemetryAdapter
+from agent_gantry.schema.base import HealthMetrics, reject_newlines
+from agent_gantry.schema.config import (
+    EmbedderConfig,
+    RerankerConfig,
+    TelemetryConfig,
+    VectorStoreConfig,
+)
+
+
+class TestBuildVectorStore:
+    def test_memory_is_the_default(self) -> None:
+        assert isinstance(build_vector_store(VectorStoreConfig()), InMemoryVectorStore)
+
+    def test_qdrant_requires_url(self) -> None:
+        with pytest.raises(ValueError, match="Qdrant requires 'url'"):
+            build_vector_store(VectorStoreConfig(type="qdrant"))
+
+    def test_pgvector_requires_url(self) -> None:
+        with pytest.raises(ValueError, match="PGVector requires 'url'"):
+            build_vector_store(VectorStoreConfig(type="pgvector"))
+
+
+class TestBuildEmbedder:
+    def test_falls_back_to_simple_without_credentials(self) -> None:
+        # "openai" without an api_key falls through every branch to SimpleEmbedder.
+        assert isinstance(build_embedder(EmbedderConfig(type="openai")), SimpleEmbedder)
+
+
+class TestBuildReranker:
+    def test_disabled_returns_none(self) -> None:
+        assert build_reranker(RerankerConfig(enabled=False)) is None
+
+
+class TestBuildTelemetry:
+    def test_disabled_returns_noop(self) -> None:
+        assert isinstance(build_telemetry(TelemetryConfig(enabled=False)), NoopTelemetryAdapter)
+
+    def test_console_is_the_default(self) -> None:
+        assert isinstance(build_telemetry(TelemetryConfig()), ConsoleTelemetryAdapter)
+
+
+class TestRejectNewlines:
+    def test_clean_value_passes_through_unchanged(self) -> None:
+        assert reject_newlines("default") == "default"
+
+    def test_non_string_passes_through(self) -> None:
+        assert reject_newlines(None) is None
+
+    @pytest.mark.parametrize("bad", ["trailing\n", "carriage\r", "mid\ndle"])
+    def test_newlines_are_rejected(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="newline"):
+            reject_newlines(bad)
+
+
+class TestHealthMetrics:
+    def test_defaults(self) -> None:
+        h = HealthMetrics()
+        assert h.success_rate == 1.0
+        assert h.consecutive_failures == 0
+        assert h.last_success is None and h.last_failure is None
+
+    @pytest.mark.parametrize("bad_rate", [-0.1, 1.5])
+    def test_success_rate_is_bounded(self, bad_rate: float) -> None:
+        with pytest.raises(ValidationError):
+            HealthMetrics(success_rate=bad_rate)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -162,3 +162,25 @@ class TestToolHealth:
         assert health.success_rate == 1.0
         assert health.total_calls == 0
         assert health.circuit_breaker_open is False
+
+
+class TestSchemaDeprecation:
+    """The legacy ``to_*_schema`` shims must still warn and delegate to ``to_dialect``."""
+
+    @pytest.mark.parametrize(
+        ("method", "dialect"),
+        [
+            ("to_openai_schema", "openai"),
+            ("to_anthropic_schema", "anthropic"),
+            ("to_gemini_schema", "gemini"),
+        ],
+    )
+    def test_legacy_schema_methods_warn_and_delegate(self, method: str, dialect: str) -> None:
+        tool = ToolDefinition(
+            name="dep_tool",
+            description="A tool for exercising the deprecation shims.",
+            parameters_schema={"type": "object", "properties": {}},
+        )
+        with pytest.warns(DeprecationWarning, match=dialect):
+            result = getattr(tool, method)()
+        assert result == tool.to_dialect(dialect)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -162,25 +162,3 @@ class TestToolHealth:
         assert health.success_rate == 1.0
         assert health.total_calls == 0
         assert health.circuit_breaker_open is False
-
-
-class TestSchemaDeprecation:
-    """The legacy ``to_*_schema`` shims must still warn and delegate to ``to_dialect``."""
-
-    @pytest.mark.parametrize(
-        ("method", "dialect"),
-        [
-            ("to_openai_schema", "openai"),
-            ("to_anthropic_schema", "anthropic"),
-            ("to_gemini_schema", "gemini"),
-        ],
-    )
-    def test_legacy_schema_methods_warn_and_delegate(self, method: str, dialect: str) -> None:
-        tool = ToolDefinition(
-            name="dep_tool",
-            description="A tool for exercising the deprecation shims.",
-            parameters_schema={"type": "object", "properties": {}},
-        )
-        with pytest.warns(DeprecationWarning, match=dialect):
-            result = getattr(tool, method)()
-        assert result == tool.to_dialect(dialect)


### PR DESCRIPTION
## Summary

This PR refactors the Agent Framework integration to improve code organization and maintainability by extracting factory functions and consolidating shared schema components.

## Key Changes

### Agent Framework Integration (`agent_framework_provider.py`)
- **Extracted `_build_impl_class()` factory**: Moved the concrete `GantryContextProvider` implementation into a dynamically-built class factory that caches implementations per base type. This allows lazy importing of `agent_framework.ContextProvider` and enables the class to be reused across multiple provider instances without per-call state.
- **Expanded `_GantryContextProviderImpl` class**: The implementation now includes:
  - Full lifecycle management with `before_run()` hook for run-scoped selection history
  - Per-call chat middleware via `as_chat_middleware()` for dynamic tool refresh
  - Console trace middleware via `trace()` for readable per-round diagnostics
  - Helper methods for tool collection, context-var management, and middleware attachment
  - Comprehensive docstrings explaining context-var scoping for concurrent runs

### Agent Framework Bridge (`agent_framework_bridge.py`)
- **Simplified `_build_tool_execute()`**: Refactored from `_build_callable_for_tool()` to focus solely on building the async executor callable. Removed the function-tool wrapping logic (now handled separately) and consolidated error handling to surface root causes as JSON `{"error": ...}` strings.

### Core Gantry (`gantry.py`)
- **Extracted factory functions**: Moved adapter construction logic (`_build_vector_store()`, `_build_embedder()`, `_build_reranker()`, `_build_telemetry()`) to a new `factories.py` module
- **Refactored initialization**: Split `__init__()` into focused helper methods (`_create_mcp_components()`, `_create_llm_client()`, `_create_router()`, `_create_rate_limiter()`, `_create_executor()`, `_init_runtime_state()`) for better readability and testability
- **Lazy MCP imports**: MCP registry/router/manager now gracefully degrade when the optional `mcp` package is unavailable

### New Factories Module (`factories.py`)
- **Created `agent_gantry/core/factories.py`**: Pure configuration-to-adapter mapping functions for vector stores, embedders, rerankers, and telemetry adapters
- Keeps optional-dependency imports lazy and isolated
- Reduces `AgentGantry` class complexity by moving stateless construction logic

### Shared Schema Components (`schema/base.py`)
- **Created `agent_gantry/schema/base.py`**: New module housing shared schema building blocks:
  - `reject_newlines()` validator for identifier fields (security invariant)
  - `HealthMetrics` base model for runtime health metrics (used by both tools and MCP servers)
- **Updated schema models**: `ToolHealth` and `MCPServerHealth` now inherit from `HealthMetrics` to eliminate duplication

### Framework Adapters
- Updated all framework adapter imports to include `BaseFrameworkAdapter` from the refactored base module

## Notable Implementation Details

- **Context-var scoping**: The provider uses `ContextVar` for per-task run state so concurrent `agent.run()` calls on a shared provider don't interleave their selection history, with plain-attribute fallbacks for cross-task reads
- **Tool refresh strategy**: Per-call middleware drops stale gantry-known tools before re-injecting fresh selections, keeping the per-round surface bounded
- **Error transparency**: Tool execution errors are surfaced as JSON `{"error": ...}` strings so the real root cause survives Agent Framework's tool runner
- **Deprecation path**: Added `_warn_schema_deprecation()` helper for legacy `to_*_schema()` methods pointing users to the new `to_dialect()` API

https://claude.ai/code/session_01UGUVidbAzwMcf7cpGjZNCL