### PR TITLE
🎨 Palette: Add ARIA region to scrollable code blocks

### DIFF
--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,11 +1,20 @@
-import { codeToHtml } from 'shiki';
+import { codeToHtml } from "shiki";
 
 export async function highlightCode(
   code: string,
-  lang: string = 'python',
+  lang: string = "python",
 ): Promise<string> {
   return codeToHtml(code.trimEnd(), {
     lang,
-    theme: 'github-dark-default',
+    theme: "github-dark-default",
+    transformers: [
+      {
+        pre(node) {
+          node.properties.tabindex = "0";
+          node.properties.role = "region";
+          node.properties["aria-label"] = "Code snippet";
+        },
+      },
+    ],
   });
 }


### PR DESCRIPTION
💡 What: Added role="region", tabindex="0" and aria-label="Code snippet" to syntax-highlighted code blocks via Shiki transformers.
🎯 Why: Screen readers cannot properly announce or navigate horizontally scrollable code blocks without these properties, and keyboard users cannot scroll them.
♿ Accessibility: Ensures code snippets are keyboard-focusable and announced as distinct, navigable regions for screen reader users.

---
*PR created automatically by Jules for task [14194670550258896870](https://jules.google.com/task/14194670550258896870) started by @CodeHalwell*