### PR TITLE
🎨 Palette: [UX improvement] Add ARIA tablist to ToolJourney

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -100,3 +100,7 @@
 ## 2024-06-17 - Accessible Sidebar Navigation
 **Learning:** When building complex sidebar navigation with categorized sections (e.g., using `<div>` for titles above `<ul>` submenus), always associate navigation section titles with their respective submenus by assigning an `id` to the title and adding `aria-labelledby="[id]"` to the `<ul>` element to ensure screen readers properly announce the category context.
 **Action:** Apply this pattern using `<nav>` tags, structured `<ul>` / `<li>` lists, and `aria-labelledby` attributes for complex sectioned navigations.
+
+## 2026-06-01 - [ARIA Tablist for Interactive Switchers]
+**Learning:** When building interactive components that switch between content sections (like a journey map), standard buttons alone leave screen readers without context about the relationship between the controls and the content.
+**Action:** Always implement the ARIA tablist pattern (`role="tablist"`, `role="tab"`, `aria-selected`, `role="tabpanel"`) and ensure the tabpanel has `tabIndex={0}` so keyboard users can shift focus to the newly revealed content.

--- a/src/components/ToolJourney.tsx
+++ b/src/components/ToolJourney.tsx
@@ -10,10 +10,14 @@ export default function ToolJourney({ stages }: Props) {
 
   return (
     <div className="card">
-      <div className="grid">
+      <div className="grid" role="tablist" aria-label="Implementation stages">
         {stages.map((s, i) => (
           <button
             key={s.title}
+            role="tab"
+            aria-selected={i === active}
+            aria-controls="journey-tabpanel"
+            id={`journey-tab-${i}`}
             onClick={() => setActive(i)}
             style={{
               padding: '1rem',
@@ -32,14 +36,21 @@ export default function ToolJourney({ stages }: Props) {
           </button>
         ))}
       </div>
-      <h3>{stage.title}</h3>
-      <p className="lead" style={{ fontSize: '1rem' }}>
-        {stage.detail}
-      </p>
-      <figure
-        className="code-block"
-        dangerouslySetInnerHTML={{ __html: stage.codeHtml }}
-      />
+      <div
+        role="tabpanel"
+        id="journey-tabpanel"
+        aria-labelledby={`journey-tab-${active}`}
+        tabIndex={0}
+      >
+        <h3>{stage.title}</h3>
+        <p className="lead" style={{ fontSize: '1rem' }}>
+          {stage.detail}
+        </p>
+        <figure
+          className="code-block"
+          dangerouslySetInnerHTML={{ __html: stage.codeHtml }}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
💡 What: Added ARIA tablist roles, aria-selected states, and a focusable tabpanel to the ToolJourney component.
🎯 Why: Makes the interactive stage switcher accessible to screen reader users who need explicit tab roles to understand the interactive relationship, and enables keyboard users to scroll the tab panel.
📸 Before/After: Visuals remain unchanged, but accessibility tree now correctly maps the interactive tab switcher.
♿ Accessibility: Implemented the ARIA tablist pattern with proper roles and tabIndex properties.

---
*PR created automatically by Jules for task [10200875254809051040](https://jules.google.com/task/10200875254809051040) started by @CodeHalwell*