### PR TITLE
⚡ Bolt: Use deque for O(1) recent message truncation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -44,3 +44,6 @@
 ## 2026-06-12 - Optimize generator expressions in sum() for counting
 **Learning:** In Python, using generator expressions inside sum() for counting items (e.g., sum(1 for x in iterable if condition)) incurs significant generator overhead. For performance-critical paths, replacing these with an inline for loop that manually accumulates a counter variable provides a measurable speedup.
 **Action:** Replace generator expressions used inside sum() for counting with an inline for loop.
+## 2026-06-23 - Optimize sliding window histories
+**Learning:** Using `list.pop(0)` for rolling histories incurs O(N) overhead because all subsequent elements must be shifted in memory. This creates a bottleneck in tight loops or long-running instances.
+**Action:** Use `collections.deque(maxlen=N)` for O(1) appending and automatic truncation from either end.

--- a/agent_gantry/core/context.py
+++ b/agent_gantry/core/context.py
@@ -6,6 +6,8 @@ Manages conversation state for context-aware routing.
 
 from __future__ import annotations
 
+from collections import deque
+
 from agent_gantry.schema.query import ConversationContext
 from agent_gantry.schema.tool import ToolCapability
 
@@ -34,7 +36,7 @@ class ConversationContextManager:
             user_capabilities: User's allowed capabilities
         """
         self._max_messages = max_recent_messages
-        self._recent_messages: list[dict[str, str]] = []
+        self._recent_messages: deque[dict[str, str]] = deque(maxlen=max_recent_messages)
         self._tools_used: list[str] = []
         self._tools_failed: list[str] = []
         self._conversation_summary: str | None = None
@@ -49,8 +51,6 @@ class ConversationContextManager:
             content: Message content
         """
         self._recent_messages.append({"role": role, "content": content})
-        if len(self._recent_messages) > self._max_messages:
-            self._recent_messages.pop(0)
 
     def record_tool_used(self, tool_name: str) -> None:
         """
@@ -94,7 +94,7 @@ class ConversationContextManager:
         return ConversationContext(
             query=query,
             conversation_summary=self._conversation_summary,
-            recent_messages=self._recent_messages.copy(),
+            recent_messages=list(self._recent_messages),
             tools_already_used=self._tools_used.copy(),
             tools_failed=self._tools_failed.copy(),
             user_capabilities=self._user_capabilities,
@@ -102,7 +102,7 @@ class ConversationContextManager:
 
     def reset(self) -> None:
         """Reset the conversation context."""
-        self._recent_messages = []
+        self._recent_messages.clear()
         self._tools_used = []
         self._tools_failed = []
         self._conversation_summary = None


### PR DESCRIPTION
💡 What: Replaced list with deque(maxlen=N) in ConversationContextManager. 🎯 Why: list.pop(0) is an O(N) operation which causes overhead for rolling histories. 📊 Impact: O(1) appending and popping from either end. 🔬 Measurement: Observe faster add_message processing when conversation history is long.

---
*PR created automatically by Jules for task [8901961563754524967](https://jules.google.com/task/8901961563754524967) started by @CodeHalwell*