### PR TITLE
🎨 Palette: Improve screen reader accessibility for provider matrix

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,7 @@
 ## 2026-06-01 - [ARIA Tablist for Interactive Switchers]
 **Learning:** When building interactive components that switch between content sections (like a journey map), standard buttons alone leave screen readers without context about the relationship between the controls and the content.
 **Action:** Always implement the ARIA tablist pattern (`role="tablist"`, `role="tab"`, `aria-selected`, `role="tabpanel"`) and ensure the tabpanel has `tabIndex={0}` so keyboard users can shift focus to the newly revealed content.
+
+## 2024-06-24 - Accessible Badge/Pill Lists
+**Learning:** When displaying groups of inline visual badges or "pills" (like tags, categories, or providers) using flat `<span>` or `<div>` elements, screen readers announce them as a single, confusing run-on sentence without semantic boundaries.
+**Action:** Always wrap groups of visual badges in a semantic list structure (`<ul role="list">` and `<li>`), applying CSS flexbox to maintain the inline wrapping visual layout, so assistive technologies can announce the list size and individual items clearly.

--- a/src/components/ProviderMatrix.tsx
+++ b/src/components/ProviderMatrix.tsx
@@ -1,6 +1,60 @@
 const groups = [
- ['LLM SDKs', ['OpenAI / Azure / OpenRouter', 'Anthropic Claude', 'Google GenAI', 'Google Vertex AI', 'Groq', 'Mistral via OpenAI-compatible endpoint']],
- ['Frameworks', ['Microsoft Agent Framework', 'LangChain', 'LangGraph', 'LlamaIndex', 'CrewAI', 'AutoGen', 'Semantic Kernel', 'Google ADK', 'Pydantic AI', 'OpenAI Agents SDK', 'Smolagents', 'Haystack', 'Agno']],
- ['Protocols and storage', ['MCP server/client routing', 'A2A server/executor', 'LanceDB persistence', 'Qdrant / Chroma / pgvector adapters', 'Nomic / OpenAI / sentence-transformers embeddings', 'Cohere / cross-encoder rerankers']],
+  [
+    "LLM SDKs",
+    [
+      "OpenAI / Azure / OpenRouter",
+      "Anthropic Claude",
+      "Google GenAI",
+      "Google Vertex AI",
+      "Groq",
+      "Mistral via OpenAI-compatible endpoint",
+    ],
+  ],
+  [
+    "Frameworks",
+    [
+      "Microsoft Agent Framework",
+      "LangChain",
+      "LangGraph",
+      "LlamaIndex",
+      "CrewAI",
+      "AutoGen",
+      "Semantic Kernel",
+      "Google ADK",
+      "Pydantic AI",
+      "OpenAI Agents SDK",
+      "Smolagents",
+      "Haystack",
+      "Agno",
+    ],
+  ],
+  [
+    "Protocols and storage",
+    [
+      "MCP server/client routing",
+      "A2A server/executor",
+      "LanceDB persistence",
+      "Qdrant / Chroma / pgvector adapters",
+      "Nomic / OpenAI / sentence-transformers embeddings",
+      "Cohere / cross-encoder rerankers",
+    ],
+  ],
 ];
-export default function ProviderMatrix(){return <div className="grid">{groups.map(([name,items])=><section className="card" key={name as string}><h3>{name}</h3>{(items as string[]).map(i=><span className="pill" key={i}>{i}</span>)}</section>)}</div>}
+export default function ProviderMatrix() {
+  return (
+    <div className="grid">
+      {groups.map(([name, items]) => (
+        <section className="card" key={name as string}>
+          <h3>{name}</h3>
+          <ul aria-label={name as string} className="pill-list" role="list">
+            {(items as string[]).map((i) => (
+              <li key={i}>
+                <span className="pill">{i}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -171,6 +171,13 @@ a:hover {
 .card h3 {
   margin-top: 0;
 }
+.pill-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+}
 .pill {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
💡 What: Updated the provider matrix component to use semantic list elements (`<ul>` and `<li>`) wrapped around the visual pills.
🎯 Why: Previously, the pills were flat `<span>` elements, causing screen readers to announce them as a single, confusing run-on sentence without boundaries.
📸 Before/After: Visuals remain unchanged (inline wrapped pills), but underlying HTML structure is now semantic.
♿ Accessibility: Screen readers will now correctly announce the number of items and pause between each provider pill.

---
*PR created automatically by Jules for task [1960210799254503478](https://jules.google.com/task/1960210799254503478) started by @CodeHalwell*