### PR TITLE
⚡ Bolt: Optimize LanceDB queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -47,3 +47,6 @@
 ## 2026-06-23 - Optimize sliding window histories
 **Learning:** Using `list.pop(0)` for rolling histories incurs O(N) overhead because all subsequent elements must be shifted in memory. This creates a bottleneck in tight loops or long-running instances.
 **Action:** Use `collections.deque(maxlen=N)` for O(1) appending and automatic truncation from either end.
+## 2024-05-30 - LanceDB Mixins Pagination Optimization
+**Learning:** In LanceDB table read operations (`list_all` and `list_all_skills`), reading the entire table into memory via `table.to_pylist()` and then manually slicing it with `records = records[offset : offset + limit]` creates a huge memory bottleneck for large datasets.
+**Action:** Use LanceDB native `.query().where(...).limit(...).offset(...).to_arrow().to_pylist()` instead of loading all rows into a Python list and filtering/slicing in memory.

--- a/agent_gantry/adapters/vector_stores/lancedb.py
+++ b/agent_gantry/adapters/vector_stores/lancedb.py
@@ -311,6 +311,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             ValueError: If tools and embeddings have different lengths or
                        if embedding dimensions don't match configured dimension
         """
+
         def to_record(tool: ToolDefinition, embedding: list[float], now: str) -> dict[str, Any]:
             return {
                 "id": f"{tool.namespace}.{tool.name}",
@@ -354,6 +355,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             ValueError: If skills and embeddings have different lengths or
                        if embedding dimensions don't match configured dimension
         """
+
         def to_record(skill: Skill, embedding: list[float], now: str) -> dict[str, Any]:
             return {
                 "id": f"{skill.namespace}.{skill.name}",
@@ -686,16 +688,13 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(namespace, "namespace")
 
         try:
-            # Use to_arrow for listing (doesn't require pandas)
-            table = self._tools_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace if specified
+            query = self._tools_table.query()
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                safe_ns = _escape_sql_string(namespace)
+                query = query.where(f"namespace = '{safe_ns}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            table = query.limit(limit).offset(offset).to_arrow()
+            records = table.to_pylist()
 
             return [
                 ToolDefinition.model_validate_json(r["tool_json"])
@@ -734,17 +733,20 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(category, "category")
 
         try:
-            table = self._skills_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace and category
+            query = self._skills_table.query()
+            filters = []
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                safe_ns = _escape_sql_string(namespace)
+                filters.append(f"namespace = '{safe_ns}'")
             if category:
-                records = [r for r in records if r.get("category") == category]
+                safe_cat = _escape_sql_string(category)
+                filters.append(f"category = '{safe_cat}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            if filters:
+                query = query.where(" AND ".join(filters))
+
+            table = query.limit(limit).offset(offset).to_arrow()
+            records = table.to_pylist()
 
             return [
                 Skill.model_validate_json(r["skill_json"])
@@ -773,10 +775,8 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                # For namespace filtering, we need to scan records
-                table = self._tools_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                safe_ns = _escape_sql_string(namespace)
+                return int(self._tools_table.count_rows(f"namespace = '{safe_ns}'"))
             # Use count_rows() for efficient counting when no filter
             return int(self._tools_table.count_rows())
         except Exception as e:
@@ -801,9 +801,8 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                table = self._skills_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                safe_ns = _escape_sql_string(namespace)
+                return int(self._skills_table.count_rows(f"namespace = '{safe_ns}'"))
             return int(self._skills_table.count_rows())
         except Exception as e:
             logger.warning(f"Error counting skills: {e}")
@@ -958,4 +957,3 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
     def dimension(self) -> int:
         """Return the vector dimension."""
         return self._dimension
-

--- a/agent_gantry/adapters/vector_stores/lancedb_mixins.py
+++ b/agent_gantry/adapters/vector_stores/lancedb_mixins.py
@@ -342,16 +342,13 @@ class LanceDBToolsMixin:
             _validate_identifier(namespace, "namespace")
 
         try:
-            # Use to_arrow for listing (doesn't require pandas)
-            table = self._tools_table.to_arrow()  # type: ignore
-            records = table.to_pylist()
-
-            # Filter by namespace if specified
+            query = self._tools_table.query()  # type: ignore
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                safe_ns = _escape_sql_string(namespace)
+                query = query.where(f"namespace = '{safe_ns}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            table = query.limit(limit).offset(offset).to_arrow()
+            records = table.to_pylist()
 
             return [
                 ToolDefinition.model_validate_json(r["tool_json"])
@@ -380,10 +377,8 @@ class LanceDBToolsMixin:
 
         try:
             if namespace:
-                # For namespace filtering, we need to scan records
-                table = self._tools_table.to_arrow()  # type: ignore
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                safe_ns = _escape_sql_string(namespace)
+                return int(self._tools_table.count_rows(f"namespace = '{safe_ns}'"))  # type: ignore
             # Use count_rows() for efficient counting when no filter
             return int(self._tools_table.count_rows())  # type: ignore
         except Exception as e:
@@ -703,17 +698,20 @@ class LanceDBSkillsMixin:
             _validate_identifier(category, "category")
 
         try:
-            table = self._skills_table.to_arrow()  # type: ignore
-            records = table.to_pylist()
-
-            # Filter by namespace and category
+            query = self._skills_table.query()  # type: ignore
+            filters = []
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                safe_ns = _escape_sql_string(namespace)
+                filters.append(f"namespace = '{safe_ns}'")
             if category:
-                records = [r for r in records if r.get("category") == category]
+                safe_cat = _escape_sql_string(category)
+                filters.append(f"category = '{safe_cat}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            if filters:
+                query = query.where(" AND ".join(filters))
+
+            table = query.limit(limit).offset(offset).to_arrow()
+            records = table.to_pylist()
 
             return [
                 Skill.model_validate_json(r["skill_json"])
@@ -742,9 +740,8 @@ class LanceDBSkillsMixin:
 
         try:
             if namespace:
-                table = self._skills_table.to_arrow()  # type: ignore
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                safe_ns = _escape_sql_string(namespace)
+                return int(self._skills_table.count_rows(f"namespace = '{safe_ns}'"))  # type: ignore
             return int(self._skills_table.count_rows())  # type: ignore
         except Exception as e:
             logger.warning(f"Error counting skills: {e}")


### PR DESCRIPTION
💡 What: Replaced in-memory Python list filtering and slicing in `list_all` and `count` methods with LanceDB's native `.query().where().limit().offset()` and `count_rows()` with filters.
🎯 Why: Avoids loading the entire table into memory via `.to_arrow().to_pylist()`, which is an O(N) memory and time bottleneck for large datasets.
📊 Impact: Substantially reduces memory consumption and latency for paginated lists and count lookups.
🔬 Measurement: Verify tests still pass and pagination logic yields identical outputs with significantly less peak memory allocation.

---
*PR created automatically by Jules for task [17730613993508373943](https://jules.google.com/task/17730613993508373943) started by @CodeHalwell*