### PR TITLE
🎨 Palette: Accessible semantic lists for visual badges

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,7 @@
 ## 2026-06-01 - [ARIA Tablist for Interactive Switchers]
 **Learning:** When building interactive components that switch between content sections (like a journey map), standard buttons alone leave screen readers without context about the relationship between the controls and the content.
 **Action:** Always implement the ARIA tablist pattern (`role="tablist"`, `role="tab"`, `aria-selected`, `role="tabpanel"`) and ensure the tabpanel has `tabIndex={0}` so keyboard users can shift focus to the newly revealed content.
+
+## 2026-06-26 - [Semantic Grouping for Visual Badges]
+**Learning:** When displaying groups of inline visual badges or 'pills' (like tags, categories, or integrations), simply rendering flat `<span>` elements leaves screen readers unable to announce the item count or boundaries. Users lose context about how many items exist or where one begins and ends.
+**Action:** Always wrap visual badges or pills in a semantic list structure (`<ul role="list">` and `<li>`) and apply CSS flexbox for wrapping, ensuring assistive technologies correctly announce the collection.

--- a/src/components/ProviderMatrix.tsx
+++ b/src/components/ProviderMatrix.tsx
@@ -1,6 +1,69 @@
 const groups = [
- ['LLM SDKs', ['OpenAI / Azure / OpenRouter', 'Anthropic Claude', 'Google GenAI', 'Google Vertex AI', 'Groq', 'Mistral via OpenAI-compatible endpoint']],
- ['Frameworks', ['Microsoft Agent Framework', 'LangChain', 'LangGraph', 'LlamaIndex', 'CrewAI', 'AutoGen', 'Semantic Kernel', 'Google ADK', 'Pydantic AI', 'OpenAI Agents SDK', 'Smolagents', 'Haystack', 'Agno']],
- ['Protocols and storage', ['MCP server/client routing', 'A2A server/executor', 'LanceDB persistence', 'Qdrant / Chroma / pgvector adapters', 'Nomic / OpenAI / sentence-transformers embeddings', 'Cohere / cross-encoder rerankers']],
+  [
+    "LLM SDKs",
+    [
+      "OpenAI / Azure / OpenRouter",
+      "Anthropic Claude",
+      "Google GenAI",
+      "Google Vertex AI",
+      "Groq",
+      "Mistral via OpenAI-compatible endpoint",
+    ],
+  ],
+  [
+    "Frameworks",
+    [
+      "Microsoft Agent Framework",
+      "LangChain",
+      "LangGraph",
+      "LlamaIndex",
+      "CrewAI",
+      "AutoGen",
+      "Semantic Kernel",
+      "Google ADK",
+      "Pydantic AI",
+      "OpenAI Agents SDK",
+      "Smolagents",
+      "Haystack",
+      "Agno",
+    ],
+  ],
+  [
+    "Protocols and storage",
+    [
+      "MCP server/client routing",
+      "A2A server/executor",
+      "LanceDB persistence",
+      "Qdrant / Chroma / pgvector adapters",
+      "Nomic / OpenAI / sentence-transformers embeddings",
+      "Cohere / cross-encoder rerankers",
+    ],
+  ],
 ];
-export default function ProviderMatrix(){return <div className="grid">{groups.map(([name,items])=><section className="card" key={name as string}><h3>{name}</h3>{(items as string[]).map(i=><span className="pill" key={i}>{i}</span>)}</section>)}</div>}
+export default function ProviderMatrix() {
+  return (
+    <div className="grid">
+      {groups.map(([name, items]) => (
+        <section className="card" key={name as string}>
+          <h3>{name}</h3>
+          <ul
+            role="list"
+            style={{
+              listStyle: "none",
+              padding: 0,
+              margin: 0,
+              display: "flex",
+              flexWrap: "wrap",
+            }}
+          >
+            {(items as string[]).map((i) => (
+              <li key={i}>
+                <span className="pill">{i}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,11 +11,11 @@ const stages = await buildHighlightedJourneyStages();
     <p class="eyebrow">Universal Tool Orchestration Platform</p>
     <h1>Give every agent the right tools at the right moment.</h1>
     <p class="lead">Agent-Gantry is a Python 0.8.0 library for semantic tool routing, secure execution, provider schema conversion, MCP/A2A interoperability, and framework adapters. It replaces prompt-stuffing hundreds of tools with a governed retrieval-and-execution layer.</p>
-    <p>
-      <a class="pill" href="/Agent-Gantry/docs/getting-started/">Start the journey →</a>
-      <a class="pill" href="/Agent-Gantry/docs/api/">API reference</a>
-      <a class="pill" href="/Agent-Gantry/docs/frameworks/agent-framework/">Microsoft Agent Framework →</a>
-    </p>
+    <ul role="list" style="list-style:none;padding:0;margin:0;display:flex;flex-wrap:wrap;">
+      <li><a class="pill" href="/Agent-Gantry/docs/getting-started/">Start the journey →</a></li>
+      <li><a class="pill" href="/Agent-Gantry/docs/api/">API reference</a></li>
+      <li><a class="pill" href="/Agent-Gantry/docs/frameworks/agent-framework/">Microsoft Agent Framework →</a></li>
+    </ul>
   </section>
   <section class="grid">
     <div class="card"><div class="kpi">~79–90%</div><h3>Less tool context</h3><p>Retrieve top-k tools instead of injecting the entire registry into every model call.</p></div>


### PR DESCRIPTION
💡 What: Converted flat span 'pill' lists into semantic unordered lists (ul/li).
🎯 Why: Screen readers could not announce the total count or boundaries of integrations and quick links when rendered as flat spans.
📸 Before/After: Visuals remain identical (flex wrap applied inline with list-style:none).
♿ Accessibility: Screen reader users can now hear "List with N items" when navigating the integration matrix and quick links, providing clear context.

---
*PR created automatically by Jules for task [9249113670352271597](https://jules.google.com/task/9249113670352271597) started by @CodeHalwell*