### PR TITLE
🎨 Palette: Accessible lists for ProviderMatrix pills

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,6 @@
 ## 2026-06-01 - [ARIA Tablist for Interactive Switchers]
 **Learning:** When building interactive components that switch between content sections (like a journey map), standard buttons alone leave screen readers without context about the relationship between the controls and the content.
 **Action:** Always implement the ARIA tablist pattern (`role="tablist"`, `role="tab"`, `aria-selected`, `role="tabpanel"`) and ensure the tabpanel has `tabIndex={0}` so keyboard users can shift focus to the newly revealed content.
+## 2026-06-27 - [Semantic Grouping for Visual Pills]
+**Learning:** When displaying groups of inline visual badges or 'pills' (like tags or categories), using flat `<span>` or `<div>` elements causes screen readers to announce them as a single run-on string without boundaries or item counts. Users cannot easily discern how many items are present or where one item ends and another begins.
+**Action:** Always wrap groups of visual badges or pills in a semantic list structure (`<ul role="list">`) and apply CSS flexbox for wrapping, rather than using flat elements. This ensures screen readers announce the item count and item boundaries correctly.

--- a/src/components/ProviderMatrix.tsx
+++ b/src/components/ProviderMatrix.tsx
@@ -3,4 +3,30 @@ const groups = [
  ['Frameworks', ['Microsoft Agent Framework', 'LangChain', 'LangGraph', 'LlamaIndex', 'CrewAI', 'AutoGen', 'Semantic Kernel', 'Google ADK', 'Pydantic AI', 'OpenAI Agents SDK', 'Smolagents', 'Haystack', 'Agno']],
  ['Protocols and storage', ['MCP server/client routing', 'A2A server/executor', 'LanceDB persistence', 'Qdrant / Chroma / pgvector adapters', 'Nomic / OpenAI / sentence-transformers embeddings', 'Cohere / cross-encoder rerankers']],
 ];
-export default function ProviderMatrix(){return <div className="grid">{groups.map(([name,items])=><section className="card" key={name as string}><h3>{name}</h3>{(items as string[]).map(i=><span className="pill" key={i}>{i}</span>)}</section>)}</div>}
+export default function ProviderMatrix() {
+  return (
+    <div className="grid">
+      {groups.map(([name, items]) => (
+        <section className="card" key={name as string}>
+          <h3>{name as string}</h3>
+          <ul
+            role="list"
+            style={{
+              listStyle: 'none',
+              padding: 0,
+              margin: 0,
+              display: 'flex',
+              flexWrap: 'wrap',
+            }}
+          >
+            {(items as string[]).map((i) => (
+              <li key={i} style={{ margin: 0, padding: 0 }}>
+                <span className="pill">{i}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
💡 What: Refactored the ProviderMatrix component to use semantic `<ul>` and `<li>` tags instead of flat `<span>` tags for rendering the lists of supported tools, frameworks, and SDKs.

🎯 Why: To improve accessibility.

📸 Before/After: Visual presentation remains the same, but structural HTML is now a proper list.

♿ Accessibility: Flat `<span>` lists cause screen readers to read the text as a continuous string without indicating boundaries or the total number of items. Grouping them in a semantic `role="list"` ensures screen readers announce the list context, number of items, and each item individually.

---
*PR created automatically by Jules for task [3846938477185907544](https://jules.google.com/task/3846938477185907544) started by @CodeHalwell*