### PR TITLE
🎨 Palette: Use semantic lists for visual badges

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,7 @@
 ## 2026-06-01 - [ARIA Tablist for Interactive Switchers]
 **Learning:** When building interactive components that switch between content sections (like a journey map), standard buttons alone leave screen readers without context about the relationship between the controls and the content.
 **Action:** Always implement the ARIA tablist pattern (`role="tablist"`, `role="tab"`, `aria-selected`, `role="tabpanel"`) and ensure the tabpanel has `tabIndex={0}` so keyboard users can shift focus to the newly revealed content.
+
+## 2026-06-28 - [Semantic Lists for Visual Badges]
+**Learning:** When displaying groups of inline visual badges or 'pills' (like tags or categories), wrapping them in a semantic list structure (`<ul role="list">` and `<li>`) and applying CSS flexbox for wrapping, rather than using flat `<span>` or `<div>` elements, ensures screen readers announce the item count and boundaries correctly.
+**Action:** Always wrap visual pill or badge collections in an unordered list, ensuring `list-style: none` is applied and flex wrap is used for responsive layout.

--- a/src/components/ProviderMatrix.tsx
+++ b/src/components/ProviderMatrix.tsx
@@ -3,4 +3,4 @@ const groups = [
  ['Frameworks', ['Microsoft Agent Framework', 'LangChain', 'LangGraph', 'LlamaIndex', 'CrewAI', 'AutoGen', 'Semantic Kernel', 'Google ADK', 'Pydantic AI', 'OpenAI Agents SDK', 'Smolagents', 'Haystack', 'Agno']],
  ['Protocols and storage', ['MCP server/client routing', 'A2A server/executor', 'LanceDB persistence', 'Qdrant / Chroma / pgvector adapters', 'Nomic / OpenAI / sentence-transformers embeddings', 'Cohere / cross-encoder rerankers']],
 ];
-export default function ProviderMatrix(){return <div className="grid">{groups.map(([name,items])=><section className="card" key={name as string}><h3>{name}</h3>{(items as string[]).map(i=><span className="pill" key={i}>{i}</span>)}</section>)}</div>}
+export default function ProviderMatrix(){return <div className="grid">{groups.map(([name,items])=><section className="card" key={name as string}><h3>{name}</h3><ul role="list" style={{ display: 'flex', flexWrap: 'wrap', listStyle: 'none', padding: 0, margin: 0 }}>{(items as string[]).map(i=><li className="pill" key={i}>{i}</li>)}</ul></section>)}</div>}


### PR DESCRIPTION
💡 What: Converted flat <span> pills into a semantic <ul> list with <li> elements in ProviderMatrix.
🎯 Why: Groups of inline visual badges lack semantic grouping when built with flat spans.
📸 Before/After: Visuals remain identical.
♿ Accessibility: Screen readers now correctly announce the total number of items and their boundaries.

---
*PR created automatically by Jules for task [10624256600148982600](https://jules.google.com/task/10624256600148982600) started by @CodeHalwell*