### PR TITLE
⚡ Bolt: optimize LanceDB querying and pagination

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -47,3 +47,6 @@
 ## 2026-06-23 - Optimize sliding window histories
 **Learning:** Using `list.pop(0)` for rolling histories incurs O(N) overhead because all subsequent elements must be shifted in memory. This creates a bottleneck in tight loops or long-running instances.
 **Action:** Use `collections.deque(maxlen=N)` for O(1) appending and automatic truncation from either end.
+## $(date +%Y-%m-%d) - Optimize LanceDB querying and pagination
+**Learning:** When querying LanceDB tables in Python, avoiding loading the entire table into memory via `table.to_pylist()` for filtering or pagination (e.g., `records[offset:offset+limit]`), as it creates an O(N) memory bottleneck on large datasets.
+**Action:** Instead, leverage LanceDB's native query builders like `.search().where(...).limit(...).offset(...).to_arrow()` and `count_rows(...)` to push operations to the database level.

--- a/agent_gantry/adapters/vector_stores/lancedb.py
+++ b/agent_gantry/adapters/vector_stores/lancedb.py
@@ -311,6 +311,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             ValueError: If tools and embeddings have different lengths or
                        if embedding dimensions don't match configured dimension
         """
+
         def to_record(tool: ToolDefinition, embedding: list[float], now: str) -> dict[str, Any]:
             return {
                 "id": f"{tool.namespace}.{tool.name}",
@@ -354,6 +355,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             ValueError: If skills and embeddings have different lengths or
                        if embedding dimensions don't match configured dimension
         """
+
         def to_record(skill: Skill, embedding: list[float], now: str) -> dict[str, Any]:
             return {
                 "id": f"{skill.namespace}.{skill.name}",
@@ -686,16 +688,12 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(namespace, "namespace")
 
         try:
-            # Use to_arrow for listing (doesn't require pandas)
-            table = self._tools_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace if specified
+            query = self._tools_table.search()
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                escaped_namespace = _escape_sql_string(namespace)
+                query = query.where(f"namespace = '{escaped_namespace}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            records = query.limit(limit).offset(offset).to_arrow().to_pylist()
 
             return [
                 ToolDefinition.model_validate_json(r["tool_json"])
@@ -734,17 +732,16 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(category, "category")
 
         try:
-            table = self._skills_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace and category
+            query = self._skills_table.search()
+            conditions = []
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                conditions.append(f"namespace = '{_escape_sql_string(namespace)}'")
             if category:
-                records = [r for r in records if r.get("category") == category]
+                conditions.append(f"category = '{_escape_sql_string(category)}'")
+            if conditions:
+                query = query.where(" AND ".join(conditions))
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            records = query.limit(limit).offset(offset).to_arrow().to_pylist()
 
             return [
                 Skill.model_validate_json(r["skill_json"])
@@ -773,10 +770,8 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                # For namespace filtering, we need to scan records
-                table = self._tools_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                escaped_namespace = _escape_sql_string(namespace)
+                return int(self._tools_table.count_rows(f"namespace = '{escaped_namespace}'"))
             # Use count_rows() for efficient counting when no filter
             return int(self._tools_table.count_rows())
         except Exception as e:
@@ -801,9 +796,8 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                table = self._skills_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                escaped_namespace = _escape_sql_string(namespace)
+                return int(self._skills_table.count_rows(f"namespace = '{escaped_namespace}'"))
             return int(self._skills_table.count_rows())
         except Exception as e:
             logger.warning(f"Error counting skills: {e}")
@@ -958,4 +952,3 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
     def dimension(self) -> int:
         """Return the vector dimension."""
         return self._dimension
-

--- a/agent_gantry/adapters/vector_stores/lancedb_mixins.py
+++ b/agent_gantry/adapters/vector_stores/lancedb_mixins.py
@@ -342,16 +342,12 @@ class LanceDBToolsMixin:
             _validate_identifier(namespace, "namespace")
 
         try:
-            # Use to_arrow for listing (doesn't require pandas)
-            table = self._tools_table.to_arrow()  # type: ignore
-            records = table.to_pylist()
-
-            # Filter by namespace if specified
+            query = self._tools_table.search()  # type: ignore
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                escaped_namespace = _escape_sql_string(namespace)
+                query = query.where(f"namespace = '{escaped_namespace}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            records = query.limit(limit).offset(offset).to_arrow().to_pylist()
 
             return [
                 ToolDefinition.model_validate_json(r["tool_json"])
@@ -380,10 +376,8 @@ class LanceDBToolsMixin:
 
         try:
             if namespace:
-                # For namespace filtering, we need to scan records
-                table = self._tools_table.to_arrow()  # type: ignore
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                escaped_namespace = _escape_sql_string(namespace)
+                return int(self._tools_table.count_rows(f"namespace = '{escaped_namespace}'"))  # type: ignore
             # Use count_rows() for efficient counting when no filter
             return int(self._tools_table.count_rows())  # type: ignore
         except Exception as e:
@@ -703,17 +697,16 @@ class LanceDBSkillsMixin:
             _validate_identifier(category, "category")
 
         try:
-            table = self._skills_table.to_arrow()  # type: ignore
-            records = table.to_pylist()
-
-            # Filter by namespace and category
+            query = self._skills_table.search()  # type: ignore
+            conditions = []
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                conditions.append(f"namespace = '{_escape_sql_string(namespace)}'")
             if category:
-                records = [r for r in records if r.get("category") == category]
+                conditions.append(f"category = '{_escape_sql_string(category)}'")
+            if conditions:
+                query = query.where(" AND ".join(conditions))
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            records = query.limit(limit).offset(offset).to_arrow().to_pylist()
 
             return [
                 Skill.model_validate_json(r["skill_json"])
@@ -742,9 +735,8 @@ class LanceDBSkillsMixin:
 
         try:
             if namespace:
-                table = self._skills_table.to_arrow()  # type: ignore
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                escaped_namespace = _escape_sql_string(namespace)
+                return int(self._skills_table.count_rows(f"namespace = '{escaped_namespace}'"))  # type: ignore
             return int(self._skills_table.count_rows())  # type: ignore
         except Exception as e:
             logger.warning(f"Error counting skills: {e}")


### PR DESCRIPTION
💡 What: Replaced in-memory Python list filtering and pagination for LanceDB tables with native LanceDB queries (\`.search().where(...).limit(...).offset(...)\` and \`count_rows(...)\`).
🎯 Why: Calling \`table.to_pylist()\` loads the entire table into memory, creating an O(N) memory bottleneck and slowing down operations as the vector store grows.
📊 Impact: Eliminates O(N) memory overhead for \`list_all\`, \`list_all_skills\`, \`count\`, and \`count_skills\` operations by pushing pagination and filtering to the database level.
🔬 Measurement: Verify tests still pass and memory usage remains flat when querying large LanceDB databases.

---
*PR created automatically by Jules for task [3459219774324610150](https://jules.google.com/task/3459219774324610150) started by @CodeHalwell*