### PR TITLE
🎨 Palette: Wrap provider matrix pills in semantic lists

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,7 @@
 ## 2026-06-01 - [ARIA Tablist for Interactive Switchers]
 **Learning:** When building interactive components that switch between content sections (like a journey map), standard buttons alone leave screen readers without context about the relationship between the controls and the content.
 **Action:** Always implement the ARIA tablist pattern (`role="tablist"`, `role="tab"`, `aria-selected`, `role="tabpanel"`) and ensure the tabpanel has `tabIndex={0}` so keyboard users can shift focus to the newly revealed content.
+
+## 2026-06-29 - [Semantic Grouping for Badges/Pills]
+**Learning:** When displaying groups of inline visual badges or 'pills', flat containers cause screen readers to announce them as a single block without counts. Wrapping them in semantic list structures allows screen readers to announce boundaries and item counts.
+**Action:** Always wrap groups of visual badges or pills in an unordered list (`<ul role="list">`) with list items (`<li>`), using flexbox inline styles to maintain wrapping and layout.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,4 +1,4 @@
-💡 What: Optimized the sliding window rate limiter in SecurityPolicy.check_permission by replacing an O(N) list comprehension with a fast forward-search and index slice.
-🎯 Why: When calculating counts over a chronologically sorted collection, iterating over the entire list with a comprehension is O(N). By finding the split index and breaking early, we reduce the overhead and take advantage of python slice optimizations.
-📊 Impact: Reduces CPU time for sliding window cleanup operations, making rate limiting faster.
-🔬 Measurement: Check the updated python unit test execution time or run microbenchmarks on agent_gantry.core.security.SecurityPolicy.check_permission under heavy load.
+💡 What: Wrapped the flat list of provider matrix 'pill' spans in a semantic `<ul>` and `<li>` structure.
+🎯 Why: Screen readers previously read the inline spans as a single continuous string without indicating the number of items or boundaries between them.
+📸 Before/After: Visual layout remains completely unchanged (using inline flex styles), but the DOM is now properly structured.
+♿ Accessibility: Added `<ul role="list">` and `<li>` to ensure screen readers announce item counts and boundaries.

--- a/src/components/ProviderMatrix.tsx
+++ b/src/components/ProviderMatrix.tsx
@@ -1,6 +1,69 @@
 const groups = [
- ['LLM SDKs', ['OpenAI / Azure / OpenRouter', 'Anthropic Claude', 'Google GenAI', 'Google Vertex AI', 'Groq', 'Mistral via OpenAI-compatible endpoint']],
- ['Frameworks', ['Microsoft Agent Framework', 'LangChain', 'LangGraph', 'LlamaIndex', 'CrewAI', 'AutoGen', 'Semantic Kernel', 'Google ADK', 'Pydantic AI', 'OpenAI Agents SDK', 'Smolagents', 'Haystack', 'Agno']],
- ['Protocols and storage', ['MCP server/client routing', 'A2A server/executor', 'LanceDB persistence', 'Qdrant / Chroma / pgvector adapters', 'Nomic / OpenAI / sentence-transformers embeddings', 'Cohere / cross-encoder rerankers']],
+  [
+    "LLM SDKs",
+    [
+      "OpenAI / Azure / OpenRouter",
+      "Anthropic Claude",
+      "Google GenAI",
+      "Google Vertex AI",
+      "Groq",
+      "Mistral via OpenAI-compatible endpoint",
+    ],
+  ],
+  [
+    "Frameworks",
+    [
+      "Microsoft Agent Framework",
+      "LangChain",
+      "LangGraph",
+      "LlamaIndex",
+      "CrewAI",
+      "AutoGen",
+      "Semantic Kernel",
+      "Google ADK",
+      "Pydantic AI",
+      "OpenAI Agents SDK",
+      "Smolagents",
+      "Haystack",
+      "Agno",
+    ],
+  ],
+  [
+    "Protocols and storage",
+    [
+      "MCP server/client routing",
+      "A2A server/executor",
+      "LanceDB persistence",
+      "Qdrant / Chroma / pgvector adapters",
+      "Nomic / OpenAI / sentence-transformers embeddings",
+      "Cohere / cross-encoder rerankers",
+    ],
+  ],
 ];
-export default function ProviderMatrix(){return <div className="grid">{groups.map(([name,items])=><section className="card" key={name as string}><h3>{name}</h3>{(items as string[]).map(i=><span className="pill" key={i}>{i}</span>)}</section>)}</div>}
+export default function ProviderMatrix() {
+  return (
+    <div className="grid">
+      {groups.map(([name, items]) => (
+        <section className="card" key={name as string}>
+          <h3>{name}</h3>
+          <ul
+            role="list"
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              padding: 0,
+              margin: 0,
+              listStyle: "none",
+            }}
+          >
+            {(items as string[]).map((i) => (
+              <li key={i} style={{ display: "flex" }}>
+                <span className="pill">{i}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
💡 What: Wrapped the flat list of provider matrix 'pill' spans in a semantic `<ul>` and `<li>` structure.
🎯 Why: Screen readers previously read the inline spans as a single continuous string without indicating the number of items or boundaries between them.
📸 Before/After: Visual layout remains completely unchanged (using inline flex styles), but the DOM is now properly structured.
♿ Accessibility: Added `<ul role="list">` and `<li>` to ensure screen readers announce item counts and boundaries.

---
*PR created automatically by Jules for task [9907733381905058264](https://jules.google.com/task/9907733381905058264) started by @CodeHalwell*