### PR TITLE
🎨 Palette: wrap pills in semantic list for a11y

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,6 @@
 ## 2026-06-01 - [ARIA Tablist for Interactive Switchers]
 **Learning:** When building interactive components that switch between content sections (like a journey map), standard buttons alone leave screen readers without context about the relationship between the controls and the content.
 **Action:** Always implement the ARIA tablist pattern (`role="tablist"`, `role="tab"`, `aria-selected`, `role="tabpanel"`) and ensure the tabpanel has `tabIndex={0}` so keyboard users can shift focus to the newly revealed content.
+## 2026-06-30 - [Semantic Lists for Inline Badges/Pills]
+**Learning:** When displaying groups of inline visual badges or 'pills' (like tags or categories), using flat `<span>` elements means screen readers do not announce the item count or boundaries correctly.
+**Action:** Always wrap groups of visual badges/pills in a semantic list structure (`<ul role="list">` and `<li>`) and apply CSS flexbox for wrapping (using inline styles if necessary to avoid custom CSS).

--- a/src/components/ProviderMatrix.tsx
+++ b/src/components/ProviderMatrix.tsx
@@ -1,6 +1,69 @@
 const groups = [
- ['LLM SDKs', ['OpenAI / Azure / OpenRouter', 'Anthropic Claude', 'Google GenAI', 'Google Vertex AI', 'Groq', 'Mistral via OpenAI-compatible endpoint']],
- ['Frameworks', ['Microsoft Agent Framework', 'LangChain', 'LangGraph', 'LlamaIndex', 'CrewAI', 'AutoGen', 'Semantic Kernel', 'Google ADK', 'Pydantic AI', 'OpenAI Agents SDK', 'Smolagents', 'Haystack', 'Agno']],
- ['Protocols and storage', ['MCP server/client routing', 'A2A server/executor', 'LanceDB persistence', 'Qdrant / Chroma / pgvector adapters', 'Nomic / OpenAI / sentence-transformers embeddings', 'Cohere / cross-encoder rerankers']],
+  [
+    "LLM SDKs",
+    [
+      "OpenAI / Azure / OpenRouter",
+      "Anthropic Claude",
+      "Google GenAI",
+      "Google Vertex AI",
+      "Groq",
+      "Mistral via OpenAI-compatible endpoint",
+    ],
+  ],
+  [
+    "Frameworks",
+    [
+      "Microsoft Agent Framework",
+      "LangChain",
+      "LangGraph",
+      "LlamaIndex",
+      "CrewAI",
+      "AutoGen",
+      "Semantic Kernel",
+      "Google ADK",
+      "Pydantic AI",
+      "OpenAI Agents SDK",
+      "Smolagents",
+      "Haystack",
+      "Agno",
+    ],
+  ],
+  [
+    "Protocols and storage",
+    [
+      "MCP server/client routing",
+      "A2A server/executor",
+      "LanceDB persistence",
+      "Qdrant / Chroma / pgvector adapters",
+      "Nomic / OpenAI / sentence-transformers embeddings",
+      "Cohere / cross-encoder rerankers",
+    ],
+  ],
 ];
-export default function ProviderMatrix(){return <div className="grid">{groups.map(([name,items])=><section className="card" key={name as string}><h3>{name}</h3>{(items as string[]).map(i=><span className="pill" key={i}>{i}</span>)}</section>)}</div>}
+export default function ProviderMatrix() {
+  return (
+    <div className="grid">
+      {groups.map(([name, items]) => (
+        <section className="card" key={name as string}>
+          <h3>{name}</h3>
+          <ul
+            role="list"
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              padding: 0,
+              margin: 0,
+              listStyle: "none",
+            }}
+          >
+            {(items as string[]).map((i) => (
+              <li key={i}>
+                <span className="pill">{i}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
💡 What: Wrapped flat inline span elements with a semantic `<ul role="list">` and `<li>` structure using flexbox inline styles to maintain layout.

🎯 Why: Users relying on screen readers need context on the number of items and the boundaries of lists. Flat spans don't provide this context, but a semantic list correctly announces the items.

📸 Before/After: Visual presentation remains exactly the same.

♿ Accessibility: Ensures groups of inline pills/badges are properly announced as lists by screen readers with item counts and proper boundaries.

---
*PR created automatically by Jules for task [18441599784276503419](https://jules.google.com/task/18441599784276503419) started by @CodeHalwell*