### PR TITLE
🎨 Palette: Semantic list for provider pills

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,6 @@
 ## 2026-06-01 - [ARIA Tablist for Interactive Switchers]
 **Learning:** When building interactive components that switch between content sections (like a journey map), standard buttons alone leave screen readers without context about the relationship between the controls and the content.
 **Action:** Always implement the ARIA tablist pattern (`role="tablist"`, `role="tab"`, `aria-selected`, `role="tabpanel"`) and ensure the tabpanel has `tabIndex={0}` so keyboard users can shift focus to the newly revealed content.
+## 2025-07-01 - [Semantic Wrapping for Inline Badges/Pills]
+**Learning:** When displaying groups of inline visual badges or 'pills' (like tags or categories), simply mapping them out as flat `<span>` elements strips them of collection semantics. Screen readers won't announce how many items are in the group, and they blend together conceptually.
+**Action:** Always wrap visual groups of items in a semantic list structure (`<ul role="list">`) and list items (`<li>`), applying CSS flexbox (using inline styles to avoid custom CSS boundaries if necessary) for wrapping, rather than using flat `<span>` or `<div>` elements.

--- a/src/components/ProviderMatrix.tsx
+++ b/src/components/ProviderMatrix.tsx
@@ -1,6 +1,70 @@
 const groups = [
- ['LLM SDKs', ['OpenAI / Azure / OpenRouter', 'Anthropic Claude', 'Google GenAI', 'Google Vertex AI', 'Groq', 'Mistral via OpenAI-compatible endpoint']],
- ['Frameworks', ['Microsoft Agent Framework', 'LangChain', 'LangGraph', 'LlamaIndex', 'CrewAI', 'AutoGen', 'Semantic Kernel', 'Google ADK', 'Pydantic AI', 'OpenAI Agents SDK', 'Smolagents', 'Haystack', 'Agno']],
- ['Protocols and storage', ['MCP server/client routing', 'A2A server/executor', 'LanceDB persistence', 'Qdrant / Chroma / pgvector adapters', 'Nomic / OpenAI / sentence-transformers embeddings', 'Cohere / cross-encoder rerankers']],
+  [
+    "LLM SDKs",
+    [
+      "OpenAI / Azure / OpenRouter",
+      "Anthropic Claude",
+      "Google GenAI",
+      "Google Vertex AI",
+      "Groq",
+      "Mistral via OpenAI-compatible endpoint",
+    ],
+  ],
+  [
+    "Frameworks",
+    [
+      "Microsoft Agent Framework",
+      "LangChain",
+      "LangGraph",
+      "LlamaIndex",
+      "CrewAI",
+      "AutoGen",
+      "Semantic Kernel",
+      "Google ADK",
+      "Pydantic AI",
+      "OpenAI Agents SDK",
+      "Smolagents",
+      "Haystack",
+      "Agno",
+    ],
+  ],
+  [
+    "Protocols and storage",
+    [
+      "MCP server/client routing",
+      "A2A server/executor",
+      "LanceDB persistence",
+      "Qdrant / Chroma / pgvector adapters",
+      "Nomic / OpenAI / sentence-transformers embeddings",
+      "Cohere / cross-encoder rerankers",
+    ],
+  ],
 ];
-export default function ProviderMatrix(){return <div className="grid">{groups.map(([name,items])=><section className="card" key={name as string}><h3>{name}</h3>{(items as string[]).map(i=><span className="pill" key={i}>{i}</span>)}</section>)}</div>}
+
+export default function ProviderMatrix() {
+  return (
+    <div className="grid">
+      {groups.map(([name, items]) => (
+        <section className="card" key={name as string}>
+          <h3>{name}</h3>
+          <ul
+            role="list"
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              padding: 0,
+              margin: 0,
+              listStyle: "none",
+            }}
+          >
+            {(items as string[]).map((i) => (
+              <li key={i} style={{ display: "flex" }}>
+                <span className="pill">{i}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
💡 What: Wrapped flat list of provider pills in a semantic `ul` element.
🎯 Why: Groups of inline elements lack collection semantics. A screen reader wouldn't announce how many items exist in a group, and they blend conceptually.
📸 Before/After: Visuals remain unchanged. Semantic structure added.
♿ Accessibility: Uses `ul role="list"` for better screen reader group announcements.

---
*PR created automatically by Jules for task [14175707568457964488](https://jules.google.com/task/14175707568457964488) started by @CodeHalwell*