### PR TITLE
🎨 Palette: Add semantic list grouping for ProviderMatrix pills

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -104,3 +104,7 @@
 ## 2026-06-01 - [ARIA Tablist for Interactive Switchers]
 **Learning:** When building interactive components that switch between content sections (like a journey map), standard buttons alone leave screen readers without context about the relationship between the controls and the content.
 **Action:** Always implement the ARIA tablist pattern (`role="tablist"`, `role="tab"`, `aria-selected`, `role="tabpanel"`) and ensure the tabpanel has `tabIndex={0}` so keyboard users can shift focus to the newly revealed content.
+
+## 2026-10-25 - [Semantic Grouping for Pill Badges]
+**Learning:** When displaying groups of inline visual badges or pills (like tags or categories), flat `<span>` or `<div>` elements cause screen readers to read them as an unstructured text block. By wrapping them in a semantic `<ul role="list">` and `<li>` structure, screen readers will properly announce the item count and boundaries.
+**Action:** Always wrap visual pill or tag groups in a `<ul role="list">` and apply CSS flexbox for wrapping to maintain visual layout while providing semantic meaning.

--- a/src/components/ProviderMatrix.tsx
+++ b/src/components/ProviderMatrix.tsx
@@ -3,4 +3,4 @@ const groups = [
  ['Frameworks', ['Microsoft Agent Framework', 'LangChain', 'LangGraph', 'LlamaIndex', 'CrewAI', 'AutoGen', 'Semantic Kernel', 'Google ADK', 'Pydantic AI', 'OpenAI Agents SDK', 'Smolagents', 'Haystack', 'Agno']],
  ['Protocols and storage', ['MCP server/client routing', 'A2A server/executor', 'LanceDB persistence', 'Qdrant / Chroma / pgvector adapters', 'Nomic / OpenAI / sentence-transformers embeddings', 'Cohere / cross-encoder rerankers']],
 ];
-export default function ProviderMatrix(){return <div className="grid">{groups.map(([name,items])=><section className="card" key={name as string}><h3>{name}</h3>{(items as string[]).map(i=><span className="pill" key={i}>{i}</span>)}</section>)}</div>}
+export default function ProviderMatrix(){return <div className="grid">{groups.map(([name,items])=><section className="card" key={name as string}><h3>{name}</h3><ul role="list" style={{ display: 'flex', flexWrap: 'wrap', padding: 0, margin: 0, listStyle: 'none' }}>{(items as string[]).map(i=><li key={i}><span className="pill">{i}</span></li>)}</ul></section>)}</div>}


### PR DESCRIPTION
💡 What: Wrapped the flat pill badges in ProviderMatrix with a semantic `<ul role="list">` and `<li>` structure.
🎯 Why: Without a list structure, screen readers announce inline groups of pills as a continuous run-on sentence without boundaries or item counts.
📸 Before/After: Visual layout remains unchanged (using inline flexbox styles on the semantic tags).
♿ Accessibility: Screen readers now correctly announce the number of providers in each category and allow users to navigate between individual pills.

---
*PR created automatically by Jules for task [6229148940177013263](https://jules.google.com/task/6229148940177013263) started by @CodeHalwell*