### PR TITLE
⚡ Bolt: Use LanceDB native queries for filtering/pagination

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -47,3 +47,6 @@
 ## 2026-06-23 - Optimize sliding window histories
 **Learning:** Using `list.pop(0)` for rolling histories incurs O(N) overhead because all subsequent elements must be shifted in memory. This creates a bottleneck in tight loops or long-running instances.
 **Action:** Use `collections.deque(maxlen=N)` for O(1) appending and automatic truncation from either end.
+## 2026-06-25 - Push LanceDB operations to database engine
+**Learning:** When querying LanceDB tables in Python, loading the entire table into memory via `table.to_arrow().to_pylist()` for filtering, counting, or pagination creates an O(N) memory bottleneck on large datasets.
+**Action:** Use LanceDB native query builders like `search().where(condition).limit(limit).offset(offset).to_list()` and `count_rows(condition)` instead of pulling the data into Python lists.

--- a/agent_gantry/adapters/vector_stores/lancedb_mixins.py
+++ b/agent_gantry/adapters/vector_stores/lancedb_mixins.py
@@ -342,16 +342,11 @@ class LanceDBToolsMixin:
             _validate_identifier(namespace, "namespace")
 
         try:
-            # Use to_arrow for listing (doesn't require pandas)
-            table = self._tools_table.to_arrow()  # type: ignore
-            records = table.to_pylist()
-
-            # Filter by namespace if specified
+            query = self._tools_table.search()  # type: ignore
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                query = query.where(f"namespace = '{_escape_sql_string(namespace)}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            records = query.limit(limit).offset(offset).to_list()
 
             return [
                 ToolDefinition.model_validate_json(r["tool_json"])
@@ -380,10 +375,9 @@ class LanceDBToolsMixin:
 
         try:
             if namespace:
-                # For namespace filtering, we need to scan records
-                table = self._tools_table.to_arrow()  # type: ignore
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                return int(
+                    self._tools_table.count_rows(f"namespace = '{_escape_sql_string(namespace)}'")
+                )  # type: ignore
             # Use count_rows() for efficient counting when no filter
             return int(self._tools_table.count_rows())  # type: ignore
         except Exception as e:
@@ -703,17 +697,17 @@ class LanceDBSkillsMixin:
             _validate_identifier(category, "category")
 
         try:
-            table = self._skills_table.to_arrow()  # type: ignore
-            records = table.to_pylist()
-
-            # Filter by namespace and category
+            query = self._skills_table.search()  # type: ignore
+            where_clauses = []
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                where_clauses.append(f"namespace = '{_escape_sql_string(namespace)}'")
             if category:
-                records = [r for r in records if r.get("category") == category]
+                where_clauses.append(f"category = '{_escape_sql_string(category)}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            if where_clauses:
+                query = query.where(" AND ".join(where_clauses))
+
+            records = query.limit(limit).offset(offset).to_list()
 
             return [
                 Skill.model_validate_json(r["skill_json"])
@@ -742,9 +736,9 @@ class LanceDBSkillsMixin:
 
         try:
             if namespace:
-                table = self._skills_table.to_arrow()  # type: ignore
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                return int(
+                    self._skills_table.count_rows(f"namespace = '{_escape_sql_string(namespace)}'")
+                )  # type: ignore
             return int(self._skills_table.count_rows())  # type: ignore
         except Exception as e:
             logger.warning(f"Error counting skills: {e}")


### PR DESCRIPTION
💡 What: Replace `to_pylist()` with native LanceDB `search().where().limit().offset()` and `count_rows()` in list/count operations.
🎯 Why: When querying LanceDB tables in Python, loading the entire table into memory via `table.to_pylist()` for filtering or pagination creates an O(N) memory bottleneck on large datasets.
📊 Impact: Reduces O(N) memory allocation to O(1) for paginated/filtered queries.
🔬 Measurement: Check memory profiling when listing/counting from large LanceDB tables.

---
*PR created automatically by Jules for task [2293894917458084789](https://jules.google.com/task/2293894917458084789) started by @CodeHalwell*