### PR TITLE
⚡ Bolt: Push LanceDB operations to database engine

### DIFF
--- a/agent_gantry/adapters/vector_stores/lancedb.py
+++ b/agent_gantry/adapters/vector_stores/lancedb.py
@@ -311,6 +311,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             ValueError: If tools and embeddings have different lengths or
                        if embedding dimensions don't match configured dimension
         """
+
         def to_record(tool: ToolDefinition, embedding: list[float], now: str) -> dict[str, Any]:
             return {
                 "id": f"{tool.namespace}.{tool.name}",
@@ -354,6 +355,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             ValueError: If skills and embeddings have different lengths or
                        if embedding dimensions don't match configured dimension
         """
+
         def to_record(skill: Skill, embedding: list[float], now: str) -> dict[str, Any]:
             return {
                 "id": f"{skill.namespace}.{skill.name}",
@@ -686,16 +688,11 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(namespace, "namespace")
 
         try:
-            # Use to_arrow for listing (doesn't require pandas)
-            table = self._tools_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace if specified
+            query = self._tools_table.search()
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                query = query.where(f"namespace = '{namespace}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            records = query.limit(limit).offset(offset).to_list()
 
             return [
                 ToolDefinition.model_validate_json(r["tool_json"])
@@ -734,17 +731,17 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(category, "category")
 
         try:
-            table = self._skills_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace and category
+            query = self._skills_table.search()
+            filters = []
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                filters.append(f"namespace = '{namespace}'")
             if category:
-                records = [r for r in records if r.get("category") == category]
+                filters.append(f"category = '{category}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            if filters:
+                query = query.where(" AND ".join(filters))
+
+            records = query.limit(limit).offset(offset).to_list()
 
             return [
                 Skill.model_validate_json(r["skill_json"])
@@ -773,11 +770,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                # For namespace filtering, we need to scan records
-                table = self._tools_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
-            # Use count_rows() for efficient counting when no filter
+                return int(self._tools_table.count_rows(f"namespace = '{namespace}'"))
             return int(self._tools_table.count_rows())
         except Exception as e:
             logger.warning(f"Error counting tools: {e}")
@@ -801,9 +794,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                table = self._skills_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                return int(self._skills_table.count_rows(f"namespace = '{namespace}'"))
             return int(self._skills_table.count_rows())
         except Exception as e:
             logger.warning(f"Error counting skills: {e}")
@@ -958,4 +949,3 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
     def dimension(self) -> int:
         """Return the vector dimension."""
         return self._dimension
-


### PR DESCRIPTION
💡 What: Replaced in-memory Python list comprehensions over full LanceDB tables with native `.search().where().limit().offset().to_list()` and `.count_rows(condition)` query builders in `agent_gantry/adapters/vector_stores/lancedb.py`.

🎯 Why: When calling `table.to_arrow().to_pylist()`, LanceDB pulls the entire table into memory before Python filters or paginates the results, creating an O(N) memory bottleneck for large vector databases. Pushing these operations down to LanceDB makes queries constant-time for pagination and avoids O(N) memory consumption.

📊 Impact: Eliminates O(N) memory overhead for tool listing, filtering, and counting, making database interactions significantly faster and vastly more memory efficient for large numbers of records.

🔬 Measurement: Validate functionality with `pytest tests/` and measure memory usage for queries against large tool namespaces.

---
*PR created automatically by Jules for task [13861157946489866894](https://jules.google.com/task/13861157946489866894) started by @CodeHalwell*