### PR TITLE
🎨 Palette: Improve navigation active state and focus visibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -108,3 +108,7 @@
 ## 2026-10-25 - [Semantic Grouping for Pill Badges]
 **Learning:** When displaying groups of inline visual badges or pills (like tags or categories), flat `<span>` or `<div>` elements cause screen readers to read them as an unstructured text block. By wrapping them in a semantic `<ul role="list">` and `<li>` structure, screen readers will properly announce the item count and boundaries.
 **Action:** Always wrap visual pill or tag groups in a `<ul role="list">` and apply CSS flexbox for wrapping to maintain visual layout while providing semantic meaning.
+
+## 2026-07-03 - [Active State Indication in Navigation]
+**Learning:** Users can lose their sense of location in documentation sites if the sidebar navigation does not visually indicate the currently active page. Even if the 'aria-current' attribute is set in the HTML for screen readers, visual users need a corresponding CSS style to benefit from the context.
+**Action:** Always provide a visual active state for navigation links matching the 'aria-current="page"' attribute (e.g., using a distinct background or text color) to maintain spatial context for sighted users.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,6 +35,11 @@ a {
 a:hover {
   text-decoration: underline;
 }
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .skip-link {
   position: absolute;
   top: -9999px;
@@ -107,6 +112,11 @@ a:hover {
   background: var(--panel2);
   color: var(--text);
   text-decoration: none;
+}
+.nav-section a[aria-current="page"] {
+  background: rgba(110, 231, 249, 0.1);
+  color: var(--accent);
+  font-weight: 600;
 }
 .main {
   min-width: 0;


### PR DESCRIPTION
💡 What: Added visual active states for sidebar navigation links and a global focus-visible outline for keyboard users.
🎯 Why: Users couldn't easily tell which documentation page they were currently on, and keyboard users lacked a consistent focus indicator across interactive elements.
📸 Before/After: Before, active links looked identical to inactive ones. Now, they have a subtle highlight. Before, keyboard focus was missing. Now, it has a clear accent-colored outline.
♿ Accessibility: Improves keyboard navigation visibility (WCAG 2.4.7 Focus Visible) and provides clearer structural context.

---
*PR created automatically by Jules for task [12424546743570014403](https://jules.google.com/task/12424546743570014403) started by @CodeHalwell*