### PR TITLE
🎨 Palette: Add global focus visible and active nav styles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -108,3 +108,11 @@
 ## 2026-10-25 - [Semantic Grouping for Pill Badges]
 **Learning:** When displaying groups of inline visual badges or pills (like tags or categories), flat `<span>` or `<div>` elements cause screen readers to read them as an unstructured text block. By wrapping them in a semantic `<ul role="list">` and `<li>` structure, screen readers will properly announce the item count and boundaries.
 **Action:** Always wrap visual pill or tag groups in a `<ul role="list">` and apply CSS flexbox for wrapping to maintain visual layout while providing semantic meaning.
+
+## 2026-07-04 - [Global Keyboard Focus Indicators]
+**Learning:** Relying only on default browser outlines or missing focus indicators makes keyboard navigation invisible, hurting accessibility.
+**Action:** Always implement a global `:focus-visible` CSS rule to provide a clear visual indicator during keyboard navigation.
+
+## 2026-07-04 - [Visual Active State for Navigation]
+**Learning:** When navigation links use the `aria-current="page"` attribute, assistive technology gets the active state but sighted users are left without spatial context if a visual style is missing.
+**Action:** Always ensure a corresponding CSS visual active state is defined for `[aria-current="page"]`, giving everyone equal spatial context.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,6 +35,12 @@ a {
 a:hover {
   text-decoration: underline;
 }
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 0.15rem;
+}
 .skip-link {
   position: absolute;
   top: -9999px;
@@ -107,6 +113,11 @@ a:hover {
   background: var(--panel2);
   color: var(--text);
   text-decoration: none;
+}
+.nav-section a[aria-current="page"] {
+  background: var(--panel2);
+  color: var(--accent);
+  font-weight: 600;
 }
 .main {
   min-width: 0;


### PR DESCRIPTION
💡 What: Added global `:focus-visible` outlines for all interactive elements and styled `aria-current='page'` for active navigation links.
🎯 Why: Enhances keyboard navigation visibility and provides spatial context for sighted users in the sidebar.
📸 Before/After: Navigation lacked visual active state and keyboard tabbing was invisible. Now, there are clear accents and focus outlines.
♿ Accessibility: Ensures WCAG focus visibility compliance and synchronizes visual state with ARIA semantic state.

---
*PR created automatically by Jules for task [4657836499533852743](https://jules.google.com/task/4657836499533852743) started by @CodeHalwell*