### PR TITLE
🎨 Palette: Add keyboard focus and active link states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -108,3 +108,7 @@
 ## 2026-10-25 - [Semantic Grouping for Pill Badges]
 **Learning:** When displaying groups of inline visual badges or pills (like tags or categories), flat `<span>` or `<div>` elements cause screen readers to read them as an unstructured text block. By wrapping them in a semantic `<ul role="list">` and `<li>` structure, screen readers will properly announce the item count and boundaries.
 **Action:** Always wrap visual pill or tag groups in a `<ul role="list">` and apply CSS flexbox for wrapping to maintain visual layout while providing semantic meaning.
+
+## 2026-07-05 - [Visual State for aria-current]
+**Learning:** When navigation links use the `aria-current="page"` attribute for screen readers, sighted users still require visual confirmation. Lacking an active style creates a confusing UX where users can't visually determine their current location.
+**Action:** Always pair semantic `aria-current="page"` attributes with a corresponding visual CSS state to provide spatial context for all users.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,6 +35,12 @@ a {
 a:hover {
   text-decoration: underline;
 }
+
+/* Global focus indicator for keyboard navigation */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .skip-link {
   position: absolute;
   top: -9999px;
@@ -107,6 +113,12 @@ a:hover {
   background: var(--panel2);
   color: var(--text);
   text-decoration: none;
+}
+
+.nav-section a[aria-current="page"] {
+  background: var(--panel2);
+  color: var(--accent);
+  font-weight: 600;
 }
 .main {
   min-width: 0;


### PR DESCRIPTION
💡 What: Added global `:focus-visible` outline and active visual state for `aria-current="page"` navigation links.
🎯 Why: Improves keyboard accessibility by making focus indicators clear and visible. Adds missing visual context for sighted users on the current page.
📸 Before/After: Interactive elements now clearly show focus, and sidebar active links are highlighted.
♿ Accessibility: Enhances WCAG compliance for focus indicators and ensures visual parity with semantic ARIA attributes.

---
*PR created automatically by Jules for task [4995313324040163798](https://jules.google.com/task/4995313324040163798) started by @CodeHalwell*