### PR TITLE
🎨 Palette: Add keyboard focus ring and active nav states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -108,3 +108,10 @@
 ## 2026-10-25 - [Semantic Grouping for Pill Badges]
 **Learning:** When displaying groups of inline visual badges or pills (like tags or categories), flat `<span>` or `<div>` elements cause screen readers to read them as an unstructured text block. By wrapping them in a semantic `<ul role="list">` and `<li>` structure, screen readers will properly announce the item count and boundaries.
 **Action:** Always wrap visual pill or tag groups in a `<ul role="list">` and apply CSS flexbox for wrapping to maintain visual layout while providing semantic meaning.
+## 2024-06-25 - [Navigation Active State Styles]
+**Learning:** When using `aria-current="page"` to semantically indicate the active navigation link to screen readers, it is crucial to ensure there is a corresponding visual CSS state (e.g., `.nav-section a[aria-current="page"] { color: var(--accent); }`) so that sighted users also receive clear spatial context about their current location.
+**Action:** Always write a corresponding CSS rule targeting `[aria-current="page"]` alongside the implementation of semantic active states in navigation.
+
+## 2024-06-25 - [Global Focus Visibility]
+**Learning:** Relying on default browser focus outlines or removing them without a replacement leaves keyboard navigators unable to see which element is currently active. A global `:focus-visible` rule provides a fallback outline for all interactive elements, ensuring base compliance and a better keyboard UX.
+**Action:** Always implement a global `:focus-visible` CSS rule (e.g., `outline: 2px solid var(--accent)`) at the root of the application's stylesheet to guarantee a clear visual indicator for keyboard navigation.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,6 +35,11 @@ a {
 a:hover {
   text-decoration: underline;
 }
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
 .skip-link {
   position: absolute;
   top: -9999px;
@@ -107,6 +112,11 @@ a:hover {
   background: var(--panel2);
   color: var(--text);
   text-decoration: none;
+}
+.nav-section a[aria-current="page"] {
+  background: var(--panel2);
+  color: var(--accent);
+  font-weight: 600;
 }
 .main {
   min-width: 0;


### PR DESCRIPTION
💡 What: Added a global `:focus-visible` rule and styled `[aria-current='page']` in the navigation sidebar.
🎯 Why: Keyboard users had no visible focus indicator making navigation difficult, and sighted users had no visual context of their current page in the sidebar.
📸 Before/After: Navigation now highlights the active page, and all interactive elements show a focus ring.
♿ Accessibility: Improves WCAG compliance for focus visibility (2.4.7) and location context (2.4.8).

---
*PR created automatically by Jules for task [12648590282389289678](https://jules.google.com/task/12648590282389289678) started by @CodeHalwell*