### PR TITLE
🎨 Palette: Enhance navigation accessibility and keyboard focus

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -108,3 +108,7 @@
 ## 2026-10-25 - [Semantic Grouping for Pill Badges]
 **Learning:** When displaying groups of inline visual badges or pills (like tags or categories), flat `<span>` or `<div>` elements cause screen readers to read them as an unstructured text block. By wrapping them in a semantic `<ul role="list">` and `<li>` structure, screen readers will properly announce the item count and boundaries.
 **Action:** Always wrap visual pill or tag groups in a `<ul role="list">` and apply CSS flexbox for wrapping to maintain visual layout while providing semantic meaning.
+
+## 2026-10-26 - [Visual Context for ARIA States and Focus]
+**Learning:** When using `aria-current="page"` to semantically indicate the active page in navigation, failing to pair it with a visual state leaves sighted users without spatial context. Additionally, relying solely on default browser focus outlines often results in poor visibility on dark themes, hindering keyboard accessibility.
+**Action:** Always ensure elements with `aria-current="page"` have a corresponding CSS visual active state, and define a clear, high-contrast `:focus-visible` rule globally to support keyboard navigation.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -108,6 +108,15 @@ a:hover {
   color: var(--text);
   text-decoration: none;
 }
+.nav-section a[aria-current="page"] {
+  background: var(--panel2);
+  color: var(--accent);
+  font-weight: 600;
+}
+*:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .main {
   min-width: 0;
 }


### PR DESCRIPTION
💡 What: Added global `:focus-visible` styles and visual active states for `aria-current="page"` navigation links.
🎯 Why: Improves spatial context for sighted users and guarantees a clear focus indicator for keyboard navigation.
📸 Before/After: Links now clearly show when they are the active page, and keyboard navigation is highlighted.
♿ Accessibility: Added global keyboard focus indicators and paired visual states with aria-current attributes.

---
*PR created automatically by Jules for task [16024906628430860284](https://jules.google.com/task/16024906628430860284) started by @CodeHalwell*