### PR TITLE
⚡ Bolt: Push LanceDB operations to database engine

### DIFF
--- a/agent_gantry/adapters/vector_stores/lancedb.py
+++ b/agent_gantry/adapters/vector_stores/lancedb.py
@@ -311,6 +311,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             ValueError: If tools and embeddings have different lengths or
                        if embedding dimensions don't match configured dimension
         """
+
         def to_record(tool: ToolDefinition, embedding: list[float], now: str) -> dict[str, Any]:
             return {
                 "id": f"{tool.namespace}.{tool.name}",
@@ -354,6 +355,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             ValueError: If skills and embeddings have different lengths or
                        if embedding dimensions don't match configured dimension
         """
+
         def to_record(skill: Skill, embedding: list[float], now: str) -> dict[str, Any]:
             return {
                 "id": f"{skill.namespace}.{skill.name}",
@@ -686,16 +688,11 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(namespace, "namespace")
 
         try:
-            # Use to_arrow for listing (doesn't require pandas)
-            table = self._tools_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace if specified
+            query = self._tools_table.search()
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                query = query.where(f"namespace = '{_escape_sql_string(namespace)}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            records = query.limit(limit).offset(offset).to_list()
 
             return [
                 ToolDefinition.model_validate_json(r["tool_json"])
@@ -734,17 +731,17 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(category, "category")
 
         try:
-            table = self._skills_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace and category
+            query = self._skills_table.search()
+            where_clauses = []
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                where_clauses.append(f"namespace = '{_escape_sql_string(namespace)}'")
             if category:
-                records = [r for r in records if r.get("category") == category]
+                where_clauses.append(f"category = '{_escape_sql_string(category)}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            if where_clauses:
+                query = query.where(" AND ".join(where_clauses))
+
+            records = query.limit(limit).offset(offset).to_list()
 
             return [
                 Skill.model_validate_json(r["skill_json"])
@@ -773,10 +770,9 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                # For namespace filtering, we need to scan records
-                table = self._tools_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                return int(
+                    self._tools_table.count_rows(f"namespace = '{_escape_sql_string(namespace)}'")
+                )
             # Use count_rows() for efficient counting when no filter
             return int(self._tools_table.count_rows())
         except Exception as e:
@@ -801,9 +797,9 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                table = self._skills_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                return int(
+                    self._skills_table.count_rows(f"namespace = '{_escape_sql_string(namespace)}'")
+                )
             return int(self._skills_table.count_rows())
         except Exception as e:
             logger.warning(f"Error counting skills: {e}")
@@ -958,4 +954,3 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
     def dimension(self) -> int:
         """Return the vector dimension."""
         return self._dimension
-


### PR DESCRIPTION
💡 What: Replaced in-memory Python list filtering and pagination (`table.to_arrow().to_pylist()`) with LanceDB's native query builders (`search().where().limit().offset().to_list()`) and `count_rows(condition)` in `agent_gantry/adapters/vector_stores/lancedb.py`.
🎯 Why: Loading the entire table into memory creates an O(N) memory bottleneck on large datasets. Pushing these operations to the database engine resolves this bottleneck.
📊 Impact: Significantly reduces memory footprint and latency for listing and counting operations on large vector stores.
🔬 Measurement: Verify memory usage and execution time during `list_all_tools`, `list_all_skills`, `count`, and `count_skills` on large LanceDB tables.

---
*PR created automatically by Jules for task [5966799543648240121](https://jules.google.com/task/5966799543648240121) started by @CodeHalwell*