### PR TITLE
🎨 Palette: Add focus-visible and active nav styles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -108,3 +108,7 @@
 ## 2026-10-25 - [Semantic Grouping for Pill Badges]
 **Learning:** When displaying groups of inline visual badges or pills (like tags or categories), flat `<span>` or `<div>` elements cause screen readers to read them as an unstructured text block. By wrapping them in a semantic `<ul role="list">` and `<li>` structure, screen readers will properly announce the item count and boundaries.
 **Action:** Always wrap visual pill or tag groups in a `<ul role="list">` and apply CSS flexbox for wrapping to maintain visual layout while providing semantic meaning.
+
+## 2026-06-05 - [Visual Consistency for Semantic State]
+**Learning:** When navigation links use the `aria-current="page"` attribute for screen reader context, relying only on standard link styles leaves sighted users without spatial context of their current location. Sighted users need equivalent visual feedback for semantic active states.
+**Action:** Always ensure a corresponding CSS visual active state (like a distinct background or font weight) is defined alongside `aria-current="page"` to maintain visual and semantic parity.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,6 +32,11 @@ a {
   color: var(--accent);
   text-decoration: none;
 }
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 a:hover {
   text-decoration: underline;
 }
@@ -102,6 +107,11 @@ a:hover {
   padding: 0.45rem 0.6rem;
   border-radius: 0.6rem;
   color: var(--muted);
+}
+.nav-section a[aria-current="page"] {
+  background: rgba(110, 231, 249, 0.08);
+  color: var(--accent);
+  font-weight: 600;
 }
 .nav-section a:hover {
   background: var(--panel2);


### PR DESCRIPTION
💡 What: Added global `:focus-visible` outlines for interactive elements and visual styling for `aria-current="page"` navigation links.
   🎯 Why: To improve keyboard navigation visibility and provide sighted users spatial context of their current page.
   📸 Before/After: Links now show a clear focus outline when navigating via keyboard, and the active sidebar link is highlighted.
   ♿ Accessibility: Ensures semantic state (aria-current) has equivalent visual styling and keyboard focus is perceivable.

---
*PR created automatically by Jules for task [3641477969118284452](https://jules.google.com/task/3641477969118284452) started by @CodeHalwell*