### PR TITLE
⚡ Bolt: Use native LanceDB queries instead of memory lists

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -50,3 +50,6 @@
 ## 2026-06-25 - Push LanceDB operations to database engine
 **Learning:** When querying LanceDB tables in Python, loading the entire table into memory via `table.to_arrow().to_pylist()` for filtering, counting, or pagination creates an O(N) memory bottleneck on large datasets.
 **Action:** Use LanceDB native query builders like `search().where(condition).limit(limit).offset(offset).to_list()` and `count_rows(condition)` instead of pulling the data into Python lists.
+## 2026-07-10 - Push LanceDB column selection to database engine
+**Learning:** When retrieving only specific columns from LanceDB tables in Python (e.g., just IDs and fingerprints in `get_stored_fingerprints`), loading the entire table row (which includes heavy JSON objects and large vector embeddings) creates unnecessary memory allocation and deserialization overhead.
+**Action:** Use LanceDB's native `.select(["col1", "col2"])` and `.limit(None)` in the query chain before calling `.to_arrow().to_pylist()` to restrict the returned columns at the database level, avoiding the overhead of serializing heavy unused data into Python.

--- a/agent_gantry/adapters/vector_stores/lancedb.py
+++ b/agent_gantry/adapters/vector_stores/lancedb.py
@@ -311,6 +311,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             ValueError: If tools and embeddings have different lengths or
                        if embedding dimensions don't match configured dimension
         """
+
         def to_record(tool: ToolDefinition, embedding: list[float], now: str) -> dict[str, Any]:
             return {
                 "id": f"{tool.namespace}.{tool.name}",
@@ -354,6 +355,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             ValueError: If skills and embeddings have different lengths or
                        if embedding dimensions don't match configured dimension
         """
+
         def to_record(skill: Skill, embedding: list[float], now: str) -> dict[str, Any]:
             return {
                 "id": f"{skill.namespace}.{skill.name}",
@@ -686,16 +688,11 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(namespace, "namespace")
 
         try:
-            # Use to_arrow for listing (doesn't require pandas)
-            table = self._tools_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace if specified
+            query = self._tools_table.search()
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                query = query.where(f"namespace = '{_escape_sql_string(namespace)}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            records = query.offset(offset).limit(limit).to_arrow().to_pylist()
 
             return [
                 ToolDefinition.model_validate_json(r["tool_json"])
@@ -734,17 +731,17 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(category, "category")
 
         try:
-            table = self._skills_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace and category
+            query = self._skills_table.search()
+            conditions = []
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                conditions.append(f"namespace = '{_escape_sql_string(namespace)}'")
             if category:
-                records = [r for r in records if r.get("category") == category]
+                conditions.append(f"category = '{_escape_sql_string(category)}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            if conditions:
+                query = query.where(" AND ".join(conditions))
+
+            records = query.offset(offset).limit(limit).to_arrow().to_pylist()
 
             return [
                 Skill.model_validate_json(r["skill_json"])
@@ -773,11 +770,9 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                # For namespace filtering, we need to scan records
-                table = self._tools_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
-            # Use count_rows() for efficient counting when no filter
+                return int(
+                    self._tools_table.count_rows(f"namespace = '{_escape_sql_string(namespace)}'")
+                )
             return int(self._tools_table.count_rows())
         except Exception as e:
             logger.warning(f"Error counting tools: {e}")
@@ -801,9 +796,9 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                table = self._skills_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                return int(
+                    self._skills_table.count_rows(f"namespace = '{_escape_sql_string(namespace)}'")
+                )
             return int(self._skills_table.count_rows())
         except Exception as e:
             logger.warning(f"Error counting skills: {e}")
@@ -958,4 +953,3 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
     def dimension(self) -> int:
         """Return the vector dimension."""
         return self._dimension
-

--- a/agent_gantry/adapters/vector_stores/lancedb_mixins.py
+++ b/agent_gantry/adapters/vector_stores/lancedb_mixins.py
@@ -816,8 +816,13 @@ class LanceDBMetadataMixin:
         await self._ensure_initialized()  # type: ignore
 
         try:
-            table = self._tools_table.to_arrow()  # type: ignore
-            records = table.to_pylist()
+            records = (
+                self._tools_table.search()
+                .select(["id", "fingerprint"])
+                .limit(None)
+                .to_arrow()
+                .to_pylist()
+            )  # type: ignore
             return {r["id"]: r.get("fingerprint", "") for r in records}
         except Exception as e:
             logger.debug(f"get_stored_fingerprints failed: {e}")


### PR DESCRIPTION
💡 What: Replaced in-memory Python list filtering and counting in `LanceDBVectorStore` with LanceDB's native `search().where(...)` and `count_rows(...)` query builders. Used `select()` to avoid loading entire vector data into memory when only IDs and fingerprints are needed.

🎯 Why: The previous implementation loaded all rows (including large vector embeddings) into memory via `.to_arrow().to_pylist()` before filtering or pagination. This was an O(N) memory bottleneck for large datasets.

📊 Impact: Significantly reduces memory usage during list/count/fingerprint operations by pushing filtering, counting, and column selection directly to the database engine. Transforms O(N) memory allocation into O(1) or proportional-to-page-size allocation.

🔬 Measurement: Can be verified by inserting a large number of rows (e.g. 100k) into LanceDB and running the unit tests for list/count operations, observing the memory usage and latency decrease dramatically compared to the old `to_pylist()` implementation.

---
*PR created automatically by Jules for task [14298325927893744743](https://jules.google.com/task/14298325927893744743) started by @CodeHalwell*