### PR TITLE
🎨 Palette: Add visual active states and focus outlines

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,6 +35,11 @@ a {
 a:hover {
   text-decoration: underline;
 }
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 0.15rem;
+}
 .skip-link {
   position: absolute;
   top: -9999px;
@@ -103,10 +108,15 @@ a:hover {
   border-radius: 0.6rem;
   color: var(--muted);
 }
-.nav-section a:hover {
+.nav-section a:hover,
+.nav-section a[aria-current="page"] {
   background: var(--panel2);
   color: var(--text);
   text-decoration: none;
+}
+.nav-section a[aria-current="page"] {
+  font-weight: 600;
+  color: #fff;
 }
 .main {
   min-width: 0;


### PR DESCRIPTION
💡 What: Added global `:focus-visible` outline and visual active states for sidebar navigation.

🎯 Why: Keyboard users had no clear visual indicator of focus, making navigation difficult. Sighted users had no spatial context for the currently active page in the sidebar.

📸 Before/After:
Before: No focus ring; active page looks identical to inactive pages.
After: Clear teal focus ring; active page highlighted with lighter background and bolder text.

♿ Accessibility: Added global `:focus-visible` to satisfy WCAG 2.4.7 Focus Visible. Styled `aria-current="page"` elements to align visual state with semantic state.

---
*PR created automatically by Jules for task [4691722251357316745](https://jules.google.com/task/4691722251357316745) started by @CodeHalwell*