### PR TITLE
🎨 Palette: Add focus visibility and active navigation styles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -108,3 +108,7 @@
 ## 2026-10-25 - [Semantic Grouping for Pill Badges]
 **Learning:** When displaying groups of inline visual badges or pills (like tags or categories), flat `<span>` or `<div>` elements cause screen readers to read them as an unstructured text block. By wrapping them in a semantic `<ul role="list">` and `<li>` structure, screen readers will properly announce the item count and boundaries.
 **Action:** Always wrap visual pill or tag groups in a `<ul role="list">` and apply CSS flexbox for wrapping to maintain visual layout while providing semantic meaning.
+
+## 2026-10-26 - [Global Focus Visibility and Active State Styling]
+**Learning:** Keyboard users rely entirely on visible focus outlines to navigate, but default browser outlines are often inconsistent or overridden by CSS resets. Additionally, screen reader users get context from `aria-current="page"`, but sighted users also need this state visually represented for spatial context in navigation.
+**Action:** Always implement a global `:focus-visible` rule using existing design tokens to ensure explicit keyboard focus indicators, and explicitly style semantic attributes like `[aria-current="page"]` to bridge the gap between semantic and visual active states.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,6 +14,11 @@
 * {
   box-sizing: border-box;
 }
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 body {
   margin: 0;
   font-family:
@@ -107,6 +112,12 @@ a:hover {
   background: var(--panel2);
   color: var(--text);
   text-decoration: none;
+}
+
+.nav-section a[aria-current="page"] {
+  background: rgba(110, 231, 249, 0.1);
+  color: var(--accent);
+  font-weight: 600;
 }
 .main {
   min-width: 0;


### PR DESCRIPTION
💡 What: Added global `:focus-visible` styles and visual active states for sidebar navigation links.
🎯 Why: To ensure keyboard users have clear visual focus indicators and sighted users have spatial context when navigating the documentation.
📸 Before/After: Visual focus rings now appear on interactive elements during keyboard navigation. Active sidebar links now have a distinct highlighted background.
♿ Accessibility: Improved keyboard navigation clarity and visual context for screen readers using `aria-current='page'`.

---
*PR created automatically by Jules for task [13773373112846240954](https://jules.google.com/task/13773373112846240954) started by @CodeHalwell*