### PR TITLE
⚡ Bolt: [performance improvement] push lancedb filter and pagination down to the engine

### DIFF
--- a/agent_gantry/adapters/vector_stores/lancedb.py
+++ b/agent_gantry/adapters/vector_stores/lancedb.py
@@ -686,16 +686,11 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(namespace, "namespace")
 
         try:
-            # Use to_arrow for listing (doesn't require pandas)
-            table = self._tools_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace if specified
+            query = self._tools_table.search().limit(limit).offset(offset)
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                query = query.where(f"namespace = '{_escape_sql_string(namespace)}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            records = query.to_arrow().to_pylist()
 
             return [
                 ToolDefinition.model_validate_json(r["tool_json"])
@@ -734,17 +729,18 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(category, "category")
 
         try:
-            table = self._skills_table.to_arrow()
-            records = table.to_pylist()
+            query = self._skills_table.search().limit(limit).offset(offset)
 
-            # Filter by namespace and category
+            where_clauses = []
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                where_clauses.append(f"namespace = '{_escape_sql_string(namespace)}'")
             if category:
-                records = [r for r in records if r.get("category") == category]
+                where_clauses.append(f"category = '{_escape_sql_string(category)}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            if where_clauses:
+                query = query.where(" AND ".join(where_clauses))
+
+            records = query.to_arrow().to_pylist()
 
             return [
                 Skill.model_validate_json(r["skill_json"])
@@ -773,10 +769,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                # For namespace filtering, we need to scan records
-                table = self._tools_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                return int(self._tools_table.count_rows(f"namespace = '{_escape_sql_string(namespace)}'"))
             # Use count_rows() for efficient counting when no filter
             return int(self._tools_table.count_rows())
         except Exception as e:
@@ -801,9 +794,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                table = self._skills_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                return int(self._skills_table.count_rows(f"namespace = '{_escape_sql_string(namespace)}'"))
             return int(self._skills_table.count_rows())
         except Exception as e:
             logger.warning(f"Error counting skills: {e}")


### PR DESCRIPTION
💡 What: Pushed down filtering and pagination logic to LanceDB native queries.
🎯 Why: Previous implementation loaded the entire table into Python memory via `to_arrow().to_pylist()` and performed pagination/filtering in python, which caused an O(N) memory and performance bottleneck.
📊 Impact: O(1) memory overhead and much faster retrieval for large datasets.
🔬 Measurement: Check the updated logic using native LanceDB query builders.

---
*PR created automatically by Jules for task [5620496267810763734](https://jules.google.com/task/5620496267810763734) started by @CodeHalwell*