### PR TITLE
⚡ Bolt: Push LanceDB filtering, counting, and pagination to the database engine

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -48,5 +48,5 @@
 **Learning:** Using `list.pop(0)` for rolling histories incurs O(N) overhead because all subsequent elements must be shifted in memory. This creates a bottleneck in tight loops or long-running instances.
 **Action:** Use `collections.deque(maxlen=N)` for O(1) appending and automatic truncation from either end.
 ## 2026-06-25 - Push LanceDB operations to database engine
-**Learning:** When querying LanceDB tables in Python, loading the entire table into memory via `table.to_arrow().to_pylist()` for filtering, counting, or pagination creates an O(N) memory bottleneck on large datasets.
-**Action:** Use LanceDB native query builders like `search().where(condition).limit(limit).offset(offset).to_list()` and `count_rows(condition)` instead of pulling the data into Python lists.
+**Learning:** When querying LanceDB tables in Python, loading the entire table into memory via `table.to_arrow().to_pylist()` for filtering, counting, or pagination creates an O(N) memory bottleneck on large datasets. Additionally, retrieving all columns when only specific ones are needed (like 'id' and 'fingerprint') increases the payload significantly.
+**Action:** Use LanceDB native query builders like `search().where(condition).limit(limit).offset(offset).to_list()`, `count_rows(condition)`, and `.select(["col1", "col2"])` instead of pulling the data into Python lists to process them.

--- a/agent_gantry/adapters/vector_stores/lancedb.py
+++ b/agent_gantry/adapters/vector_stores/lancedb.py
@@ -686,16 +686,10 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(namespace, "namespace")
 
         try:
-            # Use to_arrow for listing (doesn't require pandas)
-            table = self._tools_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace if specified
+            query = self._tools_table.search()
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
-
-            # Apply pagination
-            records = records[offset : offset + limit]
+                query = query.where(f"namespace = '{_escape_sql_string(namespace)}'")
+            records = query.limit(limit).offset(offset).to_list()
 
             return [
                 ToolDefinition.model_validate_json(r["tool_json"])
@@ -734,17 +728,17 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
             _validate_identifier(category, "category")
 
         try:
-            table = self._skills_table.to_arrow()
-            records = table.to_pylist()
-
-            # Filter by namespace and category
+            query = self._skills_table.search()
+            where_clauses = []
             if namespace:
-                records = [r for r in records if r.get("namespace") == namespace]
+                where_clauses.append(f"namespace = '{_escape_sql_string(namespace)}'")
             if category:
-                records = [r for r in records if r.get("category") == category]
+                where_clauses.append(f"category = '{_escape_sql_string(category)}'")
 
-            # Apply pagination
-            records = records[offset : offset + limit]
+            if where_clauses:
+                query = query.where(" AND ".join(where_clauses))
+
+            records = query.limit(limit).offset(offset).to_list()
 
             return [
                 Skill.model_validate_json(r["skill_json"])
@@ -773,10 +767,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                # For namespace filtering, we need to scan records
-                table = self._tools_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                return int(self._tools_table.count_rows(f"namespace = '{_escape_sql_string(namespace)}'"))
             # Use count_rows() for efficient counting when no filter
             return int(self._tools_table.count_rows())
         except Exception as e:
@@ -801,9 +792,7 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBSkillsMixin, LanceDBMetadataM
 
         try:
             if namespace:
-                table = self._skills_table.to_arrow()
-                records = table.to_pylist()
-                return len([r for r in records if r.get("namespace") == namespace])
+                return int(self._skills_table.count_rows(f"namespace = '{_escape_sql_string(namespace)}'"))
             return int(self._skills_table.count_rows())
         except Exception as e:
             logger.warning(f"Error counting skills: {e}")

--- a/agent_gantry/adapters/vector_stores/lancedb_mixins.py
+++ b/agent_gantry/adapters/vector_stores/lancedb_mixins.py
@@ -816,7 +816,7 @@ class LanceDBMetadataMixin:
         await self._ensure_initialized()  # type: ignore
 
         try:
-            table = self._tools_table.to_arrow()  # type: ignore
+            table = self._tools_table.search().select(["id", "fingerprint"]).limit(None).to_arrow()  # type: ignore
             records = table.to_pylist()
             return {r["id"]: r.get("fingerprint", "") for r in records}
         except Exception as e:


### PR DESCRIPTION
💡 What: Pushed table operations to LanceDB's native engine using `search().where(...).limit(...).offset(...).to_list()` and `count_rows(...)` instead of `table.to_arrow().to_pylist()` across the board. Also utilized `.select()` to avoid retrieving heavy payload columns.

🎯 Why: Loading the entire table into memory via `to_pylist()` for filtering, counting, or pagination creates an O(N) memory bottleneck on large datasets.

📊 Impact: O(1) memory instead of O(N) memory per query. Massive performance speedup as the database engine handles the filtering, selecting, and limit/offset in Rust rather than pulling massive datasets to Python.

🔬 Measurement: Check memory usage vs before using these methods when hitting endpoints fetching all items.

---
*PR created automatically by Jules for task [8787389445613303727](https://jules.google.com/task/8787389445613303727) started by @CodeHalwell*