### PR TITLE
Fix DoS via unbound string length in tool parameter validation

### DIFF
--- a/agent_gantry/core/executor.py
+++ b/agent_gantry/core/executor.py
@@ -507,6 +507,8 @@ class ExecutionEngine:
             elif expected_type == "string":
                 if not isinstance(value, str):
                     return False, f"Parameter '{path}' must be a string"
+                if len(value) > 1_000_000:
+                    return False, f"Parameter '{path}' exceeds maximum allowed length of 1000000 characters"
             elif expected_type == "array":
                 if not isinstance(value, list):
                     return False, f"Parameter '{path}' must be an array"


### PR DESCRIPTION
## Summary

- Adds a hard 1,000,000-character cap on string arguments validated by `ExecutionEngine._validate_value`
- Without this limit, callers (or adversarial agents) can pass arbitrarily large string payloads, causing memory exhaustion and potential DoS
- The fix is two lines in `agent_gantry/core/executor.py`; no API or schema changes

## Details

`_validate_value` checked that string arguments were `isinstance(value, str)` but imposed no upper bound on length. A single tool call carrying a multi-megabyte string would allocate that memory unconditionally before any business logic ran.

The 1 MB character cap is the same threshold used in PR #297 (which was closed because it had CI failures against an older base). This PR applies the identical fix cleanly against current `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqhkyyCXfUPbqQk7VaC3Qx)_