### PR TITLE
🎨 Palette: Add global :focus-visible for keyboard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -108,3 +108,8 @@
 ## 2026-10-25 - [Semantic Grouping for Pill Badges]
 **Learning:** When displaying groups of inline visual badges or pills (like tags or categories), flat `<span>` or `<div>` elements cause screen readers to read them as an unstructured text block. By wrapping them in a semantic `<ul role="list">` and `<li>` structure, screen readers will properly announce the item count and boundaries.
 **Action:** Always wrap visual pill or tag groups in a `<ul role="list">` and apply CSS flexbox for wrapping to maintain visual layout while providing semantic meaning.
+
+
+## 2026-07-21 - [Global Focus Outline Overriding Native Radii]
+**Learning:** Applying `border-radius` directly within a global `:focus-visible` rule overrides the element's native border radius on focus, turning rounded pill buttons into squares. Modern browsers automatically curve the `outline` property to match the element's `border-radius` anyway.
+**Action:** Never apply `border-radius` inside global focus-visible rules. Only apply `outline` and `outline-offset` to ensure the visual indicator conforms to the element's existing geometry.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,6 +35,10 @@ a {
 a:hover {
   text-decoration: underline;
 }
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .skip-link {
   position: absolute;
   top: -9999px;


### PR DESCRIPTION
💡 What: Added a global `:focus-visible` CSS rule to provide a clear visual indicator for keyboard navigation.
🎯 Why: Interactive elements without focus indicators make it impossible for keyboard-only sighted users to navigate the application.
📸 Before/After: Links and buttons now show a 2px accent outline when focused via keyboard.
♿ Accessibility: Greatly improves keyboard navigability and complies with WCAG focus visibility standards.

---
*PR created automatically by Jules for task [10704262286958423741](https://jules.google.com/task/10704262286958423741) started by @CodeHalwell*