### PR TITLE
🎨 Palette: Add global focus-visible outline

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,6 +35,10 @@ a {
 a:hover {
   text-decoration: underline;
 }
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .skip-link {
   position: absolute;
   top: -9999px;


### PR DESCRIPTION
💡 What: Added a global `:focus-visible` rule to `global.css` to provide a clear outline indicator.
🎯 Why: Interactive elements lacked a visual focus state, making keyboard navigation difficult or impossible for users to track their location on the page.
📸 Before/After: Before, tabbing through links provided no visual feedback. After, an accent-colored outline appears.
♿ Accessibility: Greatly improves WCAG compliance for Focus Visible (2.4.7) and ensures keyboard navigators have spatial context.

---
*PR created automatically by Jules for task [11555831369535364889](https://jules.google.com/task/11555831369535364889) started by @CodeHalwell*