### PR TITLE
🎨 Palette: Add global focus-visible styles

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,6 +35,10 @@ a {
 a:hover {
   text-decoration: underline;
 }
+:focus-visible {
+  outline: 2px solid var(--accent, currentColor);
+  outline-offset: 2px;
+}
 .skip-link {
   position: absolute;
   top: -9999px;


### PR DESCRIPTION
💡 What: Added a global :focus-visible CSS rule using the theme's accent color.
🎯 Why: Ensure keyboard navigation has a clear, consistent visual indicator, as default browser focus outlines are often invisible against dark themes.
📸 Before/After: Links and interactive elements now show a distinct 2px offset outline when focused via keyboard.
♿ Accessibility: Improves visibility of focus states for sighted keyboard users.

---
*PR created automatically by Jules for task [6387824936711876511](https://jules.google.com/task/6387824936711876511) started by @CodeHalwell*