### PR TITLE
🎨 Palette: Add aria-hidden to decorative logo element

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -108,3 +108,7 @@
 ## 2026-10-25 - [Semantic Grouping for Pill Badges]
 **Learning:** When displaying groups of inline visual badges or pills (like tags or categories), flat `<span>` or `<div>` elements cause screen readers to read them as an unstructured text block. By wrapping them in a semantic `<ul role="list">` and `<li>` structure, screen readers will properly announce the item count and boundaries.
 **Action:** Always wrap visual pill or tag groups in a `<ul role="list">` and apply CSS flexbox for wrapping to maintain visual layout while providing semantic meaning.
+
+## 2024-07-24 - [Decorative Elements ARIA]
+**Learning:** When using empty inline elements (like `<span>` or `<div>`) purely for CSS-driven decorative graphics (e.g., gradients or shapes acting as logos), screen readers can sometimes pause or announce them unpredictably depending on the browser/AT combination if they lack semantic meaning.
+**Action:** Always apply `aria-hidden="true"` to purely decorative, empty structural elements to ensure assistive technologies smoothly bypass them and focus on the adjacent meaningful text.

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -40,7 +40,7 @@ const nav: Section[] = [
 ];
 ---
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/><meta name="description" content={description}/><title>{title}</title></head>
-<body><a href="#main-content" class="skip-link">Skip to main content</a><div class="shell"><aside class="sidebar"><a class="brand" href="/Agent-Gantry/"><span class="logo"></span><span><h1>Agent-Gantry</h1><p>v0.8.0 docs</p></span></a><nav aria-label="Sidebar navigation">
+<body><a href="#main-content" class="skip-link">Skip to main content</a><div class="shell"><aside class="sidebar"><a class="brand" href="/Agent-Gantry/"><span class="logo" aria-hidden="true"></span><span><h1>Agent-Gantry</h1><p>v0.8.0 docs</p></span></a><nav aria-label="Sidebar navigation">
         {nav.map(({section,links})=>{
           const sectionId = `nav-${section.toLowerCase().replace(/\s+/g, '-')}`;
           return (


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to the empty, decorative logo `<span>` in the sidebar navigation.
🎯 Why: Prevents screen readers from unpredictably announcing or pausing on the empty, CSS-driven decorative element, ensuring a smoother reading experience for the adjacent brand text.
📸 Before/After: N/A (Non-visual semantic change)
♿ Accessibility: Improves screen reader flow for the primary navigation brand link.

---
*PR created automatically by Jules for task [16693445745768703419](https://jules.google.com/task/16693445745768703419) started by @CodeHalwell*