### PR TITLE
🛡️ Sentinel: [HIGH] Fix newline injection in config models

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -89,3 +89,8 @@
 **Vulnerability:** The `AgentSkill` and `AgentCard` models lacked identifier validation for `id` and `name` fields, making them vulnerable to newline injection. This could lead to downstream log injection or command injection.
 **Learning:** Security validations for common schema patterns (like identifier sanitation) must be universally applied across all analogous models within a system (e.g., tools, MCP servers, skills, and A2A agents).
 **Prevention:** Always implement explicit string character checks (using `reject_newlines`) with `@field_validator` on all identifier fields across all Pydantic models. Ensure `model_config = ConfigDict(validate_assignment=True)` is set so these constraints cannot be bypassed after object instantiation.
+
+## 2026-06-08 - [HIGH] Fix regex bypass via newline injection in Config models
+**Vulnerability:** The `MCPServerConfig` and `A2AAgentConfig` models lacked identifier validation for `name` and `namespace` fields, making them vulnerable to newline injection. This could lead to downstream log injection or command injection.
+**Learning:** Security validations for common schema patterns (like identifier sanitation) must be universally applied across all analogous models within a system, including configuration models that act as the source of truth.
+**Prevention:** Always implement explicit string character checks (using `reject_newlines`) with `@field_validator` on all identifier fields across all Pydantic models, including configuration objects. Ensure `model_config = ConfigDict(validate_assignment=True)` is set so these constraints cannot be bypassed after object instantiation.

--- a/agent_gantry/schema/config.py
+++ b/agent_gantry/schema/config.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from agent_gantry.schema.base import reject_newlines
 
 
 class VectorStoreConfig(BaseModel):
@@ -130,6 +132,10 @@ class MCPServerConfig(BaseModel):
     env: dict[str, str] = Field(default_factory=dict)
     namespace: str = "default"
 
+    model_config = ConfigDict(validate_assignment=True)
+
+    _reject_newline_identifiers = field_validator("name", "namespace")(reject_newlines)
+
 
 class MCPConfig(BaseModel):
     """Configuration for MCP integration."""
@@ -145,6 +151,10 @@ class A2AAgentConfig(BaseModel):
     name: str
     url: str
     namespace: str = "default"
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    _reject_newline_identifiers = field_validator("name", "namespace")(reject_newlines)
 
 
 class A2AConfig(BaseModel):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `MCPServerConfig` and `A2AAgentConfig` models in `agent_gantry/schema/config.py` lacked the `reject_newlines` validator, making them vulnerable to newline injection in identifier fields (`name`, `namespace`).
🎯 Impact: This could allow an attacker to inject newline characters into logs or bypass downstream security validations, potentially leading to command injection or log spoofing.
🔧 Fix: Imported and applied the `reject_newlines` validator from `agent_gantry.schema.base` to both models, along with setting `validate_assignment=True`.
✅ Verification: Attempting to instantiate these models with newline characters in their names or namespaces will now raise a ValueError, matching the security invariant of other schema models.

---
*PR created automatically by Jules for task [12338379063676155291](https://jules.google.com/task/12338379063676155291) started by @CodeHalwell*