### PR TITLE
🎨 Palette: [a11y] Hide decorative logo from screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -108,3 +108,7 @@
 ## 2026-10-25 - [Semantic Grouping for Pill Badges]
 **Learning:** When displaying groups of inline visual badges or pills (like tags or categories), flat `<span>` or `<div>` elements cause screen readers to read them as an unstructured text block. By wrapping them in a semantic `<ul role="list">` and `<li>` structure, screen readers will properly announce the item count and boundaries.
 **Action:** Always wrap visual pill or tag groups in a `<ul role="list">` and apply CSS flexbox for wrapping to maintain visual layout while providing semantic meaning.
+
+## 2026-07-26 - [Decorative Logo Screen Reader Accessibility]
+**Learning:** For accessibility, when using empty inline elements (like `<span>` or `<div>`) purely for CSS-driven decorative graphics (such as visual shapes or logos), always apply `aria-hidden="true"` to ensure assistive technologies smoothly bypass them without announcing unpredictable content.
+**Action:** When inspecting empty layout elements designed purely for visual CSS backgrounds, explicitly append `aria-hidden="true"` to prevent screen reader clutter.

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -40,7 +40,7 @@ const nav: Section[] = [
 ];
 ---
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/><meta name="description" content={description}/><title>{title}</title></head>
-<body><a href="#main-content" class="skip-link">Skip to main content</a><div class="shell"><aside class="sidebar"><a class="brand" href="/Agent-Gantry/"><span class="logo"></span><span><h1>Agent-Gantry</h1><p>v0.8.0 docs</p></span></a><nav aria-label="Sidebar navigation">
+<body><a href="#main-content" class="skip-link">Skip to main content</a><div class="shell"><aside class="sidebar"><a class="brand" href="/Agent-Gantry/"><span class="logo" aria-hidden="true"></span><span><h1>Agent-Gantry</h1><p>v0.8.0 docs</p></span></a><nav aria-label="Sidebar navigation">
         {nav.map(({section,links})=>{
           const sectionId = `nav-${section.toLowerCase().replace(/\s+/g, '-')}`;
           return (


### PR DESCRIPTION
💡 What: Added aria-hidden="true" to the purely decorative, empty logo span in DocsLayout.astro.
🎯 Why: To ensure assistive technologies like screen readers smoothly bypass the element instead of attempting to announce empty, unpredictable content.
📸 Before/After: Visual layout remains unchanged.
♿ Accessibility: Improves the signal-to-noise ratio for screen reader users by removing a non-semantic layout node from the accessibility tree.

---
*PR created automatically by Jules for task [6312012273605997912](https://jules.google.com/task/6312012273605997912) started by @CodeHalwell*