### PR TITLE
🎨 Palette: Add aria-hidden to decorative logo

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -40,7 +40,7 @@ const nav: Section[] = [
 ];
 ---
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/><meta name="description" content={description}/><title>{title}</title></head>
-<body><a href="#main-content" class="skip-link">Skip to main content</a><div class="shell"><aside class="sidebar"><a class="brand" href="/Agent-Gantry/"><span class="logo"></span><span><h1>Agent-Gantry</h1><p>v0.8.0 docs</p></span></a><nav aria-label="Sidebar navigation">
+<body><a href="#main-content" class="skip-link">Skip to main content</a><div class="shell"><aside class="sidebar"><a class="brand" href="/Agent-Gantry/"><span class="logo" aria-hidden="true"></span><span><h1>Agent-Gantry</h1><p>v0.8.0 docs</p></span></a><nav aria-label="Sidebar navigation">
         {nav.map(({section,links})=>{
           const sectionId = `nav-${section.toLowerCase().replace(/\s+/g, '-')}`;
           return (


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to the empty `<span class="logo">` element used for the CSS-driven background logo in the sidebar.
🎯 Why: To ensure screen readers and assistive technologies gracefully bypass the empty element rather than potentially announcing confusing or unpredictable content.
📸 Before/After: Visuals remain unchanged (no CSS changes).
♿ Accessibility: Improves screen reader navigation by hiding purely decorative visual elements.

---
*PR created automatically by Jules for task [16285463886022358651](https://jules.google.com/task/16285463886022358651) started by @CodeHalwell*