### PR TITLE
🛡️ Sentinel: [HIGH] Map RateLimitExceeded to PERMISSION_DENIED status

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -89,3 +89,8 @@
 **Vulnerability:** The `AgentSkill` and `AgentCard` models lacked identifier validation for `id` and `name` fields, making them vulnerable to newline injection. This could lead to downstream log injection or command injection.
 **Learning:** Security validations for common schema patterns (like identifier sanitation) must be universally applied across all analogous models within a system (e.g., tools, MCP servers, skills, and A2A agents).
 **Prevention:** Always implement explicit string character checks (using `reject_newlines`) with `@field_validator` on all identifier fields across all Pydantic models. Ensure `model_config = ConfigDict(validate_assignment=True)` is set so these constraints cannot be bypassed after object instantiation.
+
+## 2026-07-28 - [HIGH] Fix Rate Limit Error Status Mapping
+**Vulnerability:** Rate limit exceptions (RateLimitExceeded) in `ExecutionEngine._check_rate_limit` were incorrectly mapped to the generic `ExecutionStatus.FAILURE`. This obscured the security context of the failure in execution logs and could allow authorization/rate-limit events to be improperly categorized or retried downstream.
+**Learning:** Security policy exceptions (like authorization, permission, and rate limit errors) must consistently map to explicit security-related statuses (e.g., `ExecutionStatus.PERMISSION_DENIED`) when converted into structured API or execution responses (like `ToolResult`). Generic failure statuses weaken observability and security auditing.
+**Prevention:** When mapping authorization, permission, or rate limiting errors to structured execution responses in Agent-Gantry, always use `ExecutionStatus.PERMISSION_DENIED` instead of generic failure statuses to ensure accurate downstream security logging.

--- a/agent_gantry/core/executor.py
+++ b/agent_gantry/core/executor.py
@@ -408,7 +408,7 @@ class ExecutionEngine:
             except RateLimitExceeded as e:
                 result = ToolResult(
                     tool_name=call.tool_name,
-                    status=ExecutionStatus.FAILURE,
+                    status=ExecutionStatus.PERMISSION_DENIED,
                     error=str(e),
                     error_type="RateLimitExceeded",
                     queued_at=queued_at,

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -107,6 +107,7 @@ async def test_rate_limiter_blocks_execution() -> None:
 
     # Second call should be rate-limited
     result2 = await engine.execute(ToolCall(tool_name="test_tool", arguments={}))
+    assert result2.status.value == "permission_denied"
     assert result2.error_type == "RateLimitExceeded"
 
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Rate limit exceptions were mapped to generic ExecutionStatus.FAILURE instead of PERMISSION_DENIED.
🎯 Impact: Security logs lack clarity and downstream systems could improperly handle or retry rate limited requests.
🔧 Fix: Updated \`ExecutionEngine._check_rate_limit\` to return \`ExecutionStatus.PERMISSION_DENIED\` on RateLimitExceeded.
✅ Verification: Ran \`pytest -n auto\` and all tests passed.

---
*PR created automatically by Jules for task [8285145804074070096](https://jules.google.com/task/8285145804074070096) started by @CodeHalwell*