### PR TITLE
🎨 Palette: Add semantic pill groups and hide decorative logo

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -40,7 +40,7 @@ const nav: Section[] = [
 ];
 ---
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/><meta name="description" content={description}/><title>{title}</title></head>
-<body><a href="#main-content" class="skip-link">Skip to main content</a><div class="shell"><aside class="sidebar"><a class="brand" href="/Agent-Gantry/"><span class="logo"></span><span><h1>Agent-Gantry</h1><p>v0.8.0 docs</p></span></a><nav aria-label="Sidebar navigation">
+<body><a href="#main-content" class="skip-link">Skip to main content</a><div class="shell"><aside class="sidebar"><a class="brand" href="/Agent-Gantry/"><span class="logo" aria-hidden="true"></span><span><h1>Agent-Gantry</h1><p>v0.8.0 docs</p></span></a><nav aria-label="Sidebar navigation">
         {nav.map(({section,links})=>{
           const sectionId = `nav-${section.toLowerCase().replace(/\s+/g, '-')}`;
           return (
@@ -66,4 +66,4 @@ const nav: Section[] = [
             <li><a href="/Agent-Gantry/docs/quick-reference/" aria-current={Astro.url.pathname === '/Agent-Gantry/docs/quick-reference/' ? 'page' : undefined} style={Astro.url.pathname === '/Agent-Gantry/docs/quick-reference/' ? 'color: var(--text); font-weight: 600;' : undefined}>Quick reference</a></li>
           </ul>
         </div>
-        </nav></aside><main class="main" id="main-content" tabindex="-1"><div class="topbar"><span>Context is precious. Execution is sacred. Trust is earned.</span><span class="pill">Python 3.10–3.13</span></div><div class="content"><slot /></div><footer class="footer">Built with Astro, React, and TypeScript. Documentation reflects Agent-Gantry 0.8.0.</footer></main></div></body></html>
+        </nav></aside><main class="main" id="main-content" tabindex="-1"><div class="topbar"><span>Context is precious. Execution is sacred. Trust is earned.</span><ul role="list" style="display: flex; padding: 0; margin: 0; list-style: none;"><li><span class="pill">Python 3.10–3.13</span></li></ul></div><div class="content"><slot /></div><footer class="footer">Built with Astro, React, and TypeScript. Documentation reflects Agent-Gantry 0.8.0.</footer></main></div></body></html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,11 +11,11 @@ const stages = await buildHighlightedJourneyStages();
     <p class="eyebrow">Universal Tool Orchestration Platform</p>
     <h1>Give every agent the right tools at the right moment.</h1>
     <p class="lead">Agent-Gantry is a Python 0.8.0 library for semantic tool routing, secure execution, provider schema conversion, MCP/A2A interoperability, and framework adapters. It replaces prompt-stuffing hundreds of tools with a governed retrieval-and-execution layer.</p>
-    <p>
-      <a class="pill" href="/Agent-Gantry/docs/getting-started/">Start the journey →</a>
-      <a class="pill" href="/Agent-Gantry/docs/api/">API reference</a>
-      <a class="pill" href="/Agent-Gantry/docs/frameworks/agent-framework/">Microsoft Agent Framework →</a>
-    </p>
+    <ul role="list" style="display: flex; flex-wrap: wrap; padding: 0; margin: 0; list-style: none; gap: 0.5rem;">
+      <li><a class="pill" href="/Agent-Gantry/docs/getting-started/">Start the journey →</a></li>
+      <li><a class="pill" href="/Agent-Gantry/docs/api/">API reference</a></li>
+      <li><a class="pill" href="/Agent-Gantry/docs/frameworks/agent-framework/">Microsoft Agent Framework →</a></li>
+    </ul>
   </section>
   <section class="grid">
     <div class="card"><div class="kpi">~79–90%</div><h3>Less tool context</h3><p>Retrieve top-k tools instead of injecting the entire registry into every model call.</p></div>


### PR DESCRIPTION
💡 What: Wrapped pill link groups in semantic lists and hid decorative logo from screen readers.
🎯 Why: Grouping items in a list allows screen readers to announce item count and boundaries, and hiding decorative elements reduces noise for assistive tech users.
📸 Before/After: N/A
♿ Accessibility: Uses `<ul role="list">` for semantic grouping and `aria-hidden="true"` for decorative logo.

---
*PR created automatically by Jules for task [747552901903792614](https://jules.google.com/task/747552901903792614) started by @CodeHalwell*