### PR TITLE
🎨 Palette: Add aria-hidden to decorative logo

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -40,7 +40,7 @@ const nav: Section[] = [
 ];
 ---
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/><meta name="description" content={description}/><title>{title}</title></head>
-<body><a href="#main-content" class="skip-link">Skip to main content</a><div class="shell"><aside class="sidebar"><a class="brand" href="/Agent-Gantry/"><span class="logo"></span><span><h1>Agent-Gantry</h1><p>v0.8.0 docs</p></span></a><nav aria-label="Sidebar navigation">
+<body><a href="#main-content" class="skip-link">Skip to main content</a><div class="shell"><aside class="sidebar"><a class="brand" href="/Agent-Gantry/"><span class="logo" aria-hidden="true"></span><span><h1>Agent-Gantry</h1><p>v0.8.0 docs</p></span></a><nav aria-label="Sidebar navigation">
         {nav.map(({section,links})=>{
           const sectionId = `nav-${section.toLowerCase().replace(/\s+/g, '-')}`;
           return (


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to the empty `<span class="logo">`.
🎯 Why: Empty inline elements used purely for CSS-driven graphics can cause screen readers to announce unpredictable content.
📸 Before/After: N/A (Visuals unchanged, purely semantic).
♿ Accessibility: Screen readers will now smoothly bypass the decorative logo icon.

---
*PR created automatically by Jules for task [12817942058462549836](https://jules.google.com/task/12817942058462549836) started by @CodeHalwell*