### PR TITLE
🛡️ Sentinel: [HIGH] Fix CRLF injection in execution models

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -89,3 +89,8 @@
 **Vulnerability:** The `AgentSkill` and `AgentCard` models lacked identifier validation for `id` and `name` fields, making them vulnerable to newline injection. This could lead to downstream log injection or command injection.
 **Learning:** Security validations for common schema patterns (like identifier sanitation) must be universally applied across all analogous models within a system (e.g., tools, MCP servers, skills, and A2A agents).
 **Prevention:** Always implement explicit string character checks (using `reject_newlines`) with `@field_validator` on all identifier fields across all Pydantic models. Ensure `model_config = ConfigDict(validate_assignment=True)` is set so these constraints cannot be bypassed after object instantiation.
+
+## 2026-08-01 - [HIGH] Fix Log Injection via Newlines in Execution Models
+**Vulnerability:** Execution trace and tool models lacked identifier validation, making them vulnerable to newline injection.
+**Learning:** Pydantic models handling tool names, span IDs, and trace IDs must reject newlines.
+**Prevention:** Apply `reject_newlines` with `ConfigDict(validate_assignment=True)` on all identifier fields.

--- a/agent_gantry/schema/execution.py
+++ b/agent_gantry/schema/execution.py
@@ -11,7 +11,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from agent_gantry.schema.base import reject_newlines
 
 
 class ExecutionStatus(str, Enum):
@@ -39,6 +41,11 @@ class ToolCall(BaseModel):
     trace_id: str | None = None
     parent_span_id: str | None = None
 
+    model_config = ConfigDict(validate_assignment=True)
+    _reject_newline_identifiers = field_validator("tool_name", "trace_id", "parent_span_id")(
+        reject_newlines
+    )
+
 
 class ToolResult(BaseModel):
     """Result of a tool execution."""
@@ -58,6 +65,11 @@ class ToolResult(BaseModel):
 
     trace_id: str
     span_id: str
+
+    model_config = ConfigDict(validate_assignment=True)
+    _reject_newline_identifiers = field_validator("tool_name", "trace_id", "span_id")(
+        reject_newlines
+    )
 
     @property
     def latency_ms(self) -> float:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Execution models lacked newline rejection on identifier fields, allowing log/CRLF injection.
🎯 Impact: Attackers could inject newlines into trace IDs or tool names to spoof logs or exploit downstream parsing.
🔧 Fix: Added reject_newlines field validator and validate_assignment config to ToolCall and ToolResult.
✅ Verification: Verified via added test script and main test suite.

---
*PR created automatically by Jules for task [17423521932000237542](https://jules.google.com/task/17423521932000237542) started by @CodeHalwell*