### PR TITLE
Release v0.10.0: semantic skills, Qdrant quantization, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Semantic skill selection.** The `Skill` schema (procedural memory:
+  guidance retrieved by meaning and injected into prompts, never executed)
+  now has a facade API — `add_skill`/`add_skills`, `retrieve_skills`,
+  `retrieve_skills_as_prompt` (pre-formatted system-prompt block),
+  `delete_skill`, `list_skills`, `count_skills` — using the same embedder
+  and vector store as tools. The default `InMemoryVectorStore` gained full
+  skill support (add/search/get/delete/list/count with namespace/category
+  filters and per-dimension matrices), joining LanceDB, which already
+  persisted skills; stores without skill support raise a clear
+  `NotImplementedError`. `Skill`, `SkillCategory`, and `SkillSearchResult`
+  are exported from the top-level package. Example:
+  `examples/basics/skills_example.py`.
+- **Qdrant quantized vector search.** `QdrantVectorStore(quantization=...)`
+  enables int8 scalar quantization (`"scalar"`: ~4x smaller vectors kept in
+  RAM, minimal recall loss) or binary quantization (`"binary"`: ~32x
+  smaller, best for high-dimensional embeddings) at collection creation.
+  Searches oversample and rescore candidates against the original vectors,
+  so returned scores stay exact. Existing collections are not migrated —
+  recreate the collection to change quantization.
+
 - **mcp 1.x and 2.x are both supported** — the `mcp` dependency range widened
   from the emergency `<2.0.0` cap to `>=1.27.2,<3`. mcp 2.0.0 kept the entire
   v1 client surface (`ClientSession` / `StdioServerParameters` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -423,16 +423,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `pydantic_ai.models.test.TestModel`, and the others gate their live
   agent/model run behind `OPENAI_API_KEY`. `examples/agent_frameworks/
   README.md` documents all five.
- 2026-06-16
-
-### Removed
-
-- **BREAKING — `ToolDefinition.to_openai_schema()`, `to_anthropic_schema()`, and
-  `to_gemini_schema()` removed.** These were thin deprecated shims over
-  `to_dialect()` with no internal or example callers. Use
-  `ToolDefinition.to_dialect("openai" | "anthropic" | "gemini", ...)` instead.
-  (`Skill` / `SkillRegistry.to_anthropic_schema` is a separate, actively-used
-  method and is unchanged.)
 
 ### Fixed
 
@@ -458,17 +448,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   row), which also removes the router's re-embed fallback for MMR.
 - `MCPManager.add_server` returned a `(count, tools)` tuple while annotated
   `-> int`; the annotation now matches the return value.
-- **MCP initialisation no longer masks real failures.** `AgentGantry` now
-  separates the *import* guard from the *construction* guard: an expected-absent
-  MCP install is logged at DEBUG and degrades silently to no-MCP, while an
-  unexpected construction failure (e.g. a broken/partial `mcp` install) is logged
-  at WARNING with a traceback instead of being swallowed at DEBUG. Either way
-  `AgentGantry()` still constructs successfully.
-- **`GantryContextProvider` is a class again.** It is now a thin class whose
-  `__new__` delegates to a cached implementation class, so it remains valid in
-  type annotations and `isinstance()` checks return `False` rather than raising
-  `TypeError`. The `score_threshold` property is now typed `float | str` to match
-  the config (relative-threshold strings are valid).
 - **BREAKING (bugfix) — a broken `gantry.retrieve()` mid-conversation no
   longer crashes six of the eight per-turn live providers.**
   `integrations/frameworks/{autogen_live,langgraph_live,llamaindex_live,
@@ -490,6 +469,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Callers who relied on a selection failure raising out of one of these six
   providers (e.g. to abort a run) must now check the `WARNING` log or wrap
   `gantry.retrieve()`/the vector store itself instead.
+
+## [0.9.0] - 2026-06-16
+
+### Removed
+
+- **BREAKING — `ToolDefinition.to_openai_schema()`, `to_anthropic_schema()`, and
+  `to_gemini_schema()` removed.** These were thin deprecated shims over
+  `to_dialect()` with no internal or example callers. Use
+  `ToolDefinition.to_dialect("openai" | "anthropic" | "gemini", ...)` instead.
+  (`Skill` / `SkillRegistry.to_anthropic_schema` is a separate, actively-used
+  method and is unchanged.)
+
+### Fixed
+
+- **MCP initialisation no longer masks real failures.** `AgentGantry` now
+  separates the *import* guard from the *construction* guard: an expected-absent
+  MCP install is logged at DEBUG and degrades silently to no-MCP, while an
+  unexpected construction failure (e.g. a broken/partial `mcp` install) is logged
+  at WARNING with a traceback instead of being swallowed at DEBUG. Either way
+  `AgentGantry()` still constructs successfully.
+- **`GantryContextProvider` is a class again.** It is now a thin class whose
+  `__new__` delegates to a cached implementation class, so it remains valid in
+  type annotations and `isinstance()` checks return `False` rather than raising
+  `TypeError`. The `score_threshold` property is now typed `float | str` to match
+  the config (relative-threshold strings are valid).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-07
+
 ### Added
 
 - **Semantic skill selection.** The `Skill` schema (procedural memory:
@@ -1736,7 +1738,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LLM SDK compatibility guide
 - Architecture diagrams
 
-[Unreleased]: https://github.com/CodeHalwell/Agent-Gantry/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/CodeHalwell/Agent-Gantry/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/CodeHalwell/Agent-Gantry/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/CodeHalwell/Agent-Gantry/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/CodeHalwell/Agent-Gantry/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/CodeHalwell/Agent-Gantry/compare/v0.6.0...v0.7.0

--- a/agent_gantry/__init__.py
+++ b/agent_gantry/__init__.py
@@ -66,7 +66,7 @@ def disable_af_instrumentation() -> bool:
     return _impl()
 
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 __all__ = [
     "AgentGantry",
     "GantryContextProvider",

--- a/agent_gantry/__init__.py
+++ b/agent_gantry/__init__.py
@@ -24,6 +24,7 @@ from agent_gantry.integrations.semantic_tools import (
 from agent_gantry.observability.console import enable_console_logging
 from agent_gantry.schema.execution import ToolCall, ToolCallEvent, ToolResult
 from agent_gantry.schema.query import ConversationContext, ToolQuery
+from agent_gantry.schema.skill import Skill, SkillCategory, SkillSearchResult
 from agent_gantry.schema.tool import (
     ToolCapability,
     ToolCost,
@@ -83,6 +84,9 @@ __all__ = [
     "ToolResult",
     "ToolQuery",
     "ConversationContext",
+    "Skill",
+    "SkillCategory",
+    "SkillSearchResult",
     "ToolCapability",
     "ToolCost",
     "ToolDefinition",

--- a/agent_gantry/adapters/vector_stores/README.md
+++ b/agent_gantry/adapters/vector_stores/README.md
@@ -34,4 +34,17 @@ await gantry.sync()  # pushes tool embeddings into the chosen store
 ```
 
 Adding a new backend is as simple as implementing `VectorStoreAdapter`; the router will consume it
-without further changes.*** End Patch" serializer error? Actually apply_patch expects raw string not JSON. Let's re-run plain.
+without further changes.
+
+## Skills
+
+`InMemoryVectorStore` and `LanceDBVectorStore` also store **skills** (procedural memory retrieved
+semantically and injected into prompts — see `gantry.add_skills()` / `gantry.retrieve_skills()`).
+Stores without skill support raise `NotImplementedError` from the facade's skill methods.
+
+## Qdrant quantized search
+
+`QdrantVectorStore(quantization="scalar")` enables int8 scalar quantization (~4x smaller vectors,
+kept in RAM, minimal recall loss); `quantization="binary"` compresses ~32x and suits
+high-dimensional embeddings. Searches oversample and rescore against the original vectors, so
+returned scores stay exact. Applied at collection creation — recreate the collection to change it.

--- a/agent_gantry/adapters/vector_stores/README.md
+++ b/agent_gantry/adapters/vector_stores/README.md
@@ -42,6 +42,12 @@ without further changes.
 semantically and injected into prompts — see `gantry.add_skills()` / `gantry.retrieve_skills()`).
 Stores without skill support raise `NotImplementedError` from the facade's skill methods.
 
+Notes: skill content is injected into prompts verbatim, so register skills only from trusted
+sources. Switching embedding models re-embeds stored skills automatically when the dimension is
+unchanged; a dimension change cannot be migrated in place on fixed-schema stores (LanceDB) —
+recreate the store. Concurrent gantry instances with *different* embedders sharing one store are
+unsupported (each would re-migrate the other's vectors).
+
 ## Qdrant quantized search
 
 `QdrantVectorStore(quantization="scalar")` enables int8 scalar quantization (~4x smaller vectors,

--- a/agent_gantry/adapters/vector_stores/README.md
+++ b/agent_gantry/adapters/vector_stores/README.md
@@ -46,7 +46,10 @@ Notes: skill content is injected into prompts verbatim, so register skills only 
 sources. Switching embedding models re-embeds stored skills automatically when the dimension is
 unchanged; a dimension change cannot be migrated in place on fixed-schema stores (LanceDB) —
 recreate the store. Concurrent gantry instances with *different* embedders sharing one store are
-unsupported (each would re-migrate the other's vectors).
+unsupported (each would re-migrate the other's vectors). Multiple worker processes sharing one
+embedded store path follow the backend's multi-writer semantics — LanceDB's upsert is a
+non-atomic delete-then-add — so let one worker warm the store after a model switch before the
+others start (an atomic `merge_insert`-based upsert is a planned follow-up).
 
 ## Qdrant quantized search
 

--- a/agent_gantry/adapters/vector_stores/lancedb.py
+++ b/agent_gantry/adapters/vector_stores/lancedb.py
@@ -418,6 +418,9 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBMetadataMixin):
             ns_filter = filters["namespace"]
             if isinstance(ns_filter, (list, tuple, set)):
                 ns_list = list(ns_filter)
+                if not ns_list:
+                    # Empty list matches nothing; "IN ()" is invalid SQL
+                    return []
                 if len(ns_list) == 1:
                     escaped_ns = _escape_sql_string(ns_list[0])
                     search = search.where(f"namespace = '{escaped_ns}'")
@@ -508,6 +511,10 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBMetadataMixin):
             ns_filter = filters["namespace"]
             if isinstance(ns_filter, (list, tuple, set)):
                 ns_list = list(ns_filter)
+                if not ns_list:
+                    # An empty namespace list matches nothing (mirrors the
+                    # in-memory store); "IN ()" is invalid SQL in LanceDB
+                    return []
                 if len(ns_list) == 1:
                     escaped_ns = _escape_sql_string(ns_list[0])
                     where_clauses.append(f"namespace = '{escaped_ns}'")

--- a/agent_gantry/adapters/vector_stores/lancedb.py
+++ b/agent_gantry/adapters/vector_stores/lancedb.py
@@ -732,27 +732,32 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBMetadataMixin):
         if category is not None:
             _validate_identifier(category, "category")
 
-        try:
-            query = self._skills_table.search()
-            where_clauses = []
-            if namespace:
-                where_clauses.append(f"namespace = '{_escape_sql_string(namespace)}'")
-            if category:
-                where_clauses.append(f"category = '{_escape_sql_string(category)}'")
+        # Table-level errors propagate: swallowing them into an empty list is
+        # indistinguishable from "no skills stored", which let callers (e.g.
+        # the facade's embedder-migration check) record success after having
+        # listed nothing. Only malformed individual rows are skipped.
+        query = self._skills_table.search()
+        where_clauses = []
+        if namespace:
+            where_clauses.append(f"namespace = '{_escape_sql_string(namespace)}'")
+        if category:
+            where_clauses.append(f"category = '{_escape_sql_string(category)}'")
 
-            if where_clauses:
-                query = query.where(" AND ".join(where_clauses))
+        if where_clauses:
+            query = query.where(" AND ".join(where_clauses))
 
-            records = await asyncio.to_thread(query.limit(limit).offset(offset).to_list)
+        records = await asyncio.to_thread(query.limit(limit).offset(offset).to_list)
 
-            return [
-                Skill.model_validate_json(r["skill_json"])
-                for r in records
-                if r.get("skill_json")  # Skip records with missing skill_json
-            ]
-        except Exception as e:
-            logger.warning(f"Error listing skills: {e}")
-            return []
+        skills: list[Skill] = []
+        for record in records:
+            raw = record.get("skill_json")
+            if not raw:
+                continue
+            try:
+                skills.append(Skill.model_validate_json(raw))
+            except Exception as e:
+                logger.warning(f"Skipping malformed skill record: {e}")
+        return skills
 
     async def count(self, namespace: str | None = None) -> int:
         """

--- a/agent_gantry/adapters/vector_stores/lancedb.py
+++ b/agent_gantry/adapters/vector_stores/lancedb.py
@@ -500,25 +500,28 @@ class LanceDBVectorStore(LanceDBToolsMixin, LanceDBMetadataMixin):
 
         search = self._skills_table.search(query_vector).limit(limit * 2)
 
-        # Apply namespace filter (escape for SQL safety)
+        # Build ONE combined predicate: LanceDB's .where() is a setter, not
+        # an accumulator — a second call replaces the first, which silently
+        # dropped the namespace constraint when both filters were supplied.
+        where_clauses: list[str] = []
         if filters and "namespace" in filters:
             ns_filter = filters["namespace"]
             if isinstance(ns_filter, (list, tuple, set)):
                 ns_list = list(ns_filter)
                 if len(ns_list) == 1:
                     escaped_ns = _escape_sql_string(ns_list[0])
-                    search = search.where(f"namespace = '{escaped_ns}'")
+                    where_clauses.append(f"namespace = '{escaped_ns}'")
                 else:
                     escaped_values = ", ".join(f"'{_escape_sql_string(ns)}'" for ns in ns_list)
-                    search = search.where(f"namespace IN ({escaped_values})")
+                    where_clauses.append(f"namespace IN ({escaped_values})")
             else:
                 escaped_ns = _escape_sql_string(ns_filter)
-                search = search.where(f"namespace = '{escaped_ns}'")
-
-        # Apply category filter (escape for SQL safety)
+                where_clauses.append(f"namespace = '{escaped_ns}'")
         if filters and "category" in filters:
             escaped_cat = _escape_sql_string(filters["category"])
-            search = search.where(f"category = '{escaped_cat}'")
+            where_clauses.append(f"category = '{escaped_cat}'")
+        if where_clauses:
+            search = search.where(" AND ".join(where_clauses))
 
         results = await asyncio.to_thread(search.to_list)
 

--- a/agent_gantry/adapters/vector_stores/memory.py
+++ b/agent_gantry/adapters/vector_stores/memory.py
@@ -237,9 +237,14 @@ class InMemoryVectorStore:
         upsert: bool = True,
     ) -> int:
         """Add skills with their embeddings."""
+        # Validate BEFORE mutating: a strict zip alone would store the
+        # matching prefix and then raise, leaving a partial skill set behind
+        # a failed call. A length mismatch means an upstream embed failure.
+        if len(skills) != len(embeddings):
+            raise ValueError(
+                f"skills/embeddings length mismatch: {len(skills)} != {len(embeddings)}"
+            )
         count = 0
-        # strict: a length mismatch means an upstream embed failure — fail
-        # loudly instead of silently storing a partial skill set
         for skill, embedding in zip(skills, embeddings, strict=True):
             key = f"{skill.namespace}.{skill.name}"
             if key not in self._skills or upsert:

--- a/agent_gantry/adapters/vector_stores/memory.py
+++ b/agent_gantry/adapters/vector_stores/memory.py
@@ -238,7 +238,9 @@ class InMemoryVectorStore:
     ) -> int:
         """Add skills with their embeddings."""
         count = 0
-        for skill, embedding in zip(skills, embeddings):
+        # strict: a length mismatch means an upstream embed failure — fail
+        # loudly instead of silently storing a partial skill set
+        for skill, embedding in zip(skills, embeddings, strict=True):
             key = f"{skill.namespace}.{skill.name}"
             if key not in self._skills or upsert:
                 self._skills[key] = skill

--- a/agent_gantry/adapters/vector_stores/memory.py
+++ b/agent_gantry/adapters/vector_stores/memory.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import numpy as np
 
+from agent_gantry.schema.skill import Skill
 from agent_gantry.schema.tool import ToolDefinition
 from agent_gantry.utils.fingerprint import compute_tool_fingerprint
 
@@ -34,6 +35,9 @@ class InMemoryVectorStore:
         self._embeddings: dict[str, list[float]] = {}
         self._fingerprints: dict[str, str] = {}
         self._metadata: dict[str, str] = {}
+        self._skills: dict[str, Skill] = {}
+        self._skill_embeddings: dict[str, list[float]] = {}
+        self._skill_matrices: dict[int, tuple[np.ndarray, list[str]]] = {}
         self._dimension = dimension
         # Vectorized search cache: L2-normalized (n, d) matrices plus row
         # ordering, kept per dimension — mixed dimensions legitimately coexist
@@ -219,6 +223,131 @@ class InMemoryVectorStore:
     async def health_check(self) -> bool:
         """Check health (always healthy for in-memory)."""
         return True
+
+    # ------------------------------------------------------------------
+    # Skills — procedural-memory records retrieved semantically and
+    # injected into prompts (never executed). Mirrors the LanceDB store's
+    # skill API so the facade works against the default backend.
+    # ------------------------------------------------------------------
+
+    async def add_skills(
+        self,
+        skills: list[Skill],
+        embeddings: list[list[float]],
+        upsert: bool = True,
+    ) -> int:
+        """Add skills with their embeddings."""
+        count = 0
+        for skill, embedding in zip(skills, embeddings):
+            key = f"{skill.namespace}.{skill.name}"
+            if key not in self._skills or upsert:
+                self._skills[key] = skill
+                self._skill_embeddings[key] = embedding
+                count += 1
+        if count:
+            self._skill_matrices.clear()
+        return count
+
+    async def search_skills(
+        self,
+        query_vector: list[float],
+        limit: int,
+        filters: dict[str, Any] | None = None,
+        score_threshold: float | None = None,
+    ) -> list[tuple[Skill, float]]:
+        """Search for skills similar to the query vector.
+
+        Filters: ``namespace`` (str or collection) and ``category`` (str).
+        """
+        q = np.asarray(query_vector, dtype=np.float32)
+        if q.ndim != 1:
+            return []
+        matrix, keys = self._skill_matrix_for(q.shape[0])
+        if matrix.shape[0] == 0:
+            return []
+
+        q_norm = float(np.linalg.norm(q))
+        if q_norm == 0.0:
+            scores = np.zeros(matrix.shape[0], dtype=np.float32)
+        else:
+            scores = matrix @ (q / q_norm)
+
+        ns_filter = filters.get("namespace") if filters else None
+        category = filters.get("category") if filters else None
+
+        results: list[tuple[Skill, float]] = []
+        for idx, key in enumerate(keys):
+            skill = self._skills.get(key)
+            if skill is None:
+                continue
+            if ns_filter is not None:
+                if isinstance(ns_filter, (list, tuple, set)):
+                    if skill.namespace not in ns_filter:
+                        continue
+                elif skill.namespace != ns_filter:
+                    continue
+            if category is not None and skill.category.value != category:
+                continue
+            score = float(scores[idx])
+            if score_threshold is not None and score < score_threshold:
+                continue
+            results.append((skill, score))
+
+        results.sort(key=lambda x: x[1], reverse=True)
+        return results[:limit]
+
+    async def get_skill_by_name(self, name: str, namespace: str = "default") -> Skill | None:
+        """Get a skill by name."""
+        return self._skills.get(f"{namespace}.{name}")
+
+    async def delete_skill(self, name: str, namespace: str = "default") -> bool:
+        """Delete a skill."""
+        key = f"{namespace}.{name}"
+        if key in self._skills:
+            del self._skills[key]
+            self._skill_embeddings.pop(key, None)
+            self._skill_matrices.clear()
+            return True
+        return False
+
+    async def list_all_skills(
+        self,
+        namespace: str | None = None,
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> list[Skill]:
+        """List all skills."""
+        skills = list(self._skills.values())
+        if namespace:
+            skills = [s for s in skills if s.namespace == namespace]
+        return skills[offset : offset + limit]
+
+    async def count_skills(self, namespace: str | None = None) -> int:
+        """Count skills."""
+        if namespace:
+            return sum(1 for s in self._skills.values() if s.namespace == namespace)
+        return len(self._skills)
+
+    def _skill_matrix_for(self, dim: int) -> tuple[np.ndarray, list[str]]:
+        """Return (matrix, keys) of normalized skill embeddings of this dimension."""
+        cached = self._skill_matrices.get(dim)
+        if cached is not None:
+            return cached
+        keys = [
+            k
+            for k in self._skills
+            if (emb := self._skill_embeddings.get(k)) is not None and len(emb) == dim
+        ]
+        if not keys:
+            empty: tuple[np.ndarray, list[str]] = (np.zeros((0, dim), dtype=np.float32), [])
+            self._skill_matrices[dim] = empty
+            return empty
+        mat = np.asarray([self._skill_embeddings[k] for k in keys], dtype=np.float32)
+        norms = np.linalg.norm(mat, axis=1, keepdims=True)
+        norms[norms == 0.0] = 1.0
+        result = (mat / norms, keys)
+        self._skill_matrices[dim] = result
+        return result
 
     @property
     def supports_metadata(self) -> bool:

--- a/agent_gantry/adapters/vector_stores/remote.py
+++ b/agent_gantry/adapters/vector_stores/remote.py
@@ -58,6 +58,7 @@ class QdrantVectorStore:
         dimension: int = 1536,
         distance: str = "Cosine",
         prefer_grpc: bool = False,
+        quantization: str | None = None,
     ) -> None:
         """
         Initialize the Qdrant vector store.
@@ -69,6 +70,14 @@ class QdrantVectorStore:
             dimension: Vector dimension
             distance: Distance metric (Cosine, Euclid, Dot)
             prefer_grpc: Use gRPC if available
+            quantization: Optional quantized-search mode for the collection:
+                ``"scalar"`` (int8 scalar quantization — ~4x smaller vectors,
+                kept in RAM, minimal recall loss) or ``"binary"`` (~32x
+                smaller, fastest, best for high-dimensional embeddings such
+                as OpenAI's). Applied at collection creation; searches
+                rescore candidates against the original vectors so returned
+                scores stay exact. Existing collections are not migrated —
+                recreate the collection to change quantization.
         """
         try:
             from qdrant_client import AsyncQdrantClient
@@ -82,8 +91,14 @@ class QdrantVectorStore:
         self._url = url
         self._api_key = api_key
         self._collection_name = collection_name
+        if quantization not in (None, "scalar", "binary"):
+            raise ValueError(
+                f"Unsupported quantization mode: {quantization!r} "
+                f"(expected 'scalar', 'binary', or None)"
+            )
         self._dimension = dimension
         self._prefer_grpc = prefer_grpc
+        self._quantization = quantization
         self._initialized = False
 
         # Map distance string to Qdrant Distance enum
@@ -108,6 +123,39 @@ class QdrantVectorStore:
         """Return the vector dimension."""
         return self._dimension
 
+    def _build_quantization_config(self) -> Any:
+        """Translate the configured quantization mode to Qdrant config.
+
+        Returns None (no quantization) when unset. int8 scalar quantization
+        keeps the compressed vectors in RAM (that's where the speed win
+        comes from); binary quantization compresses 32x and suits
+        high-dimensional embeddings where sign bits retain enough signal.
+        """
+        if not self._quantization:
+            return None
+        from qdrant_client.models import (
+            BinaryQuantization,
+            BinaryQuantizationConfig,
+            ScalarQuantization,
+            ScalarQuantizationConfig,
+            ScalarType,
+        )
+
+        if self._quantization == "scalar":
+            return ScalarQuantization(
+                scalar=ScalarQuantizationConfig(
+                    type=ScalarType.INT8,
+                    quantile=0.99,
+                    always_ram=True,
+                )
+            )
+        if self._quantization == "binary":
+            return BinaryQuantization(binary=BinaryQuantizationConfig(always_ram=True))
+        raise ValueError(
+            f"Unsupported quantization mode: {self._quantization!r} "
+            f"(expected 'scalar', 'binary', or None)"
+        )
+
     async def initialize(self) -> None:
         """Initialize the collection, creating it if needed."""
         if self._initialized:
@@ -128,8 +176,12 @@ class QdrantVectorStore:
                         size=self._dimension,
                         distance=self._distance,
                     ),
+                    quantization_config=self._build_quantization_config(),
                 )
-                logger.info(f"Created Qdrant collection: {self._collection_name}")
+                logger.info(
+                    f"Created Qdrant collection: {self._collection_name}"
+                    + (f" (quantization={self._quantization})" if self._quantization else "")
+                )
 
             self._initialized = True
         except Exception as e:
@@ -208,7 +260,16 @@ class QdrantVectorStore:
                 ]
             )
 
-        # Search with optional vector retrieval
+        # Search with optional vector retrieval. On a quantized collection,
+        # oversample candidates from the compressed index and rescore them
+        # against the original vectors so returned scores stay exact.
+        search_params = None
+        if self._quantization:
+            from qdrant_client.models import QuantizationSearchParams, SearchParams
+
+            search_params = SearchParams(
+                quantization=QuantizationSearchParams(rescore=True, oversampling=2.0)
+            )
         results = await self._client.search(
             collection_name=self._collection_name,
             query_vector=query_vector,
@@ -216,6 +277,7 @@ class QdrantVectorStore:
             query_filter=query_filter,
             score_threshold=score_threshold,
             with_vectors=include_embeddings,  # Request vectors if needed
+            search_params=search_params,
         )
 
         # Convert results to tools

--- a/agent_gantry/adapters/vector_stores/remote.py
+++ b/agent_gantry/adapters/vector_stores/remote.py
@@ -133,15 +133,22 @@ class QdrantVectorStore:
         """
         if not self._quantization:
             return None
-        from qdrant_client.models import (
-            BinaryQuantization,
-            BinaryQuantizationConfig,
-            ScalarQuantization,
-            ScalarQuantizationConfig,
-            ScalarType,
-        )
-
+        # Import per mode: the binary-quantization models postdate older
+        # qdrant-client releases the extras still permit, so importing them
+        # unconditionally would break scalar mode (or plain construction) on
+        # clients that support everything scalar needs.
         if self._quantization == "scalar":
+            try:
+                from qdrant_client.models import (
+                    ScalarQuantization,
+                    ScalarQuantizationConfig,
+                    ScalarType,
+                )
+            except ImportError as exc:
+                raise ImportError(
+                    "quantization='scalar' requires a qdrant-client version with "
+                    "scalar quantization support; upgrade qdrant-client."
+                ) from exc
             return ScalarQuantization(
                 scalar=ScalarQuantizationConfig(
                     type=ScalarType.INT8,
@@ -149,12 +156,14 @@ class QdrantVectorStore:
                     always_ram=True,
                 )
             )
-        if self._quantization == "binary":
-            return BinaryQuantization(binary=BinaryQuantizationConfig(always_ram=True))
-        raise ValueError(
-            f"Unsupported quantization mode: {self._quantization!r} "
-            f"(expected 'scalar', 'binary', or None)"
-        )
+        try:
+            from qdrant_client.models import BinaryQuantization, BinaryQuantizationConfig
+        except ImportError as exc:
+            raise ImportError(
+                "quantization='binary' requires a qdrant-client version with "
+                "binary quantization support; upgrade qdrant-client."
+            ) from exc
+        return BinaryQuantization(binary=BinaryQuantizationConfig(always_ram=True))
 
     async def initialize(self) -> None:
         """Initialize the collection, creating it if needed."""
@@ -265,11 +274,17 @@ class QdrantVectorStore:
         # against the original vectors so returned scores stay exact.
         search_params = None
         if self._quantization:
-            from qdrant_client.models import QuantizationSearchParams, SearchParams
+            try:
+                from qdrant_client.models import QuantizationSearchParams, SearchParams
 
-            search_params = SearchParams(
-                quantization=QuantizationSearchParams(rescore=True, oversampling=2.0)
-            )
+                search_params = SearchParams(
+                    quantization=QuantizationSearchParams(rescore=True, oversampling=2.0)
+                )
+            except ImportError:
+                # A client old enough to lack these couldn't have created the
+                # quantized collection either, but degrade gracefully: the
+                # server still searches, just with its default rescoring.
+                logger.debug("qdrant-client lacks QuantizationSearchParams; using defaults")
         results = await self._client.search(
             collection_name=self._collection_name,
             query_vector=query_vector,

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -216,6 +216,9 @@ class AgentGantry:
         not loaded here because import + embedding is async.
         """
         self._pending_tools: list[ToolDefinition] = []
+        # One-shot guard for _ensure_skill_vectors_current (embedder is fixed
+        # for this instance's lifetime)
+        self._skill_vectors_checked = False
         self._pending_mcp_servers: list[MCPServerDefinition] = []
         self._tool_handlers: dict[str, Callable[..., Any]] = {}
         # MCP clients created by add_mcp_server (immediate discovery), kept so
@@ -1855,6 +1858,41 @@ class AgentGantry:
         """
         await self.add_skills([skill])
 
+    async def _ensure_skill_vectors_current(self, store: Any) -> None:
+        """Re-embed persisted skills if they were made by a different embedder.
+
+        Tools get this via SyncManager's fingerprint/embedder-id machinery;
+        skills need the equivalent or reopening a persistent store with a new
+        embedding model silently searches the old model's vectors (or fails
+        outright on a dimension change). Runs once per gantry instance — the
+        embedder is fixed for the instance's lifetime. Stores without the
+        metadata API skip the check (nothing to compare against).
+        """
+        if self._skill_vectors_checked:
+            return
+        self._skill_vectors_checked = True
+        get_meta = getattr(store, "get_metadata", None)
+        set_meta = getattr(store, "set_metadata", None)
+        if get_meta is None or set_meta is None:
+            return
+        current = self._sync_manager.get_embedder_id()
+        stored = await get_meta("skills_embedder_id")
+        if stored == current:
+            return
+        # Unknown or different embedder: re-embed whatever is stored (covers
+        # both a model switch and pre-existing skills with no recorded id)
+        skills = await store.list_all_skills(limit=1_000_000)
+        if skills:
+            embeddings = await self._embedder.embed_batch(
+                [skill.to_embedding_text() for skill in skills]
+            )
+            await store.add_skills(skills, embeddings, upsert=True)
+            logger.info(
+                f"Re-embedded {len(skills)} skill(s): stored embedder id "
+                f"{stored!r} != current {current!r}"
+            )
+        await set_meta("skills_embedder_id", current)
+
     async def add_skills(self, skills: list[Skill]) -> int:
         """
         Embed and store skills for semantic retrieval.
@@ -1869,6 +1907,7 @@ class AgentGantry:
             return 0
         store = self._skills_store()
         await self._ensure_initialized()
+        await self._ensure_skill_vectors_current(store)
         embeddings = await self._embedder.embed_batch(
             [skill.to_embedding_text() for skill in skills]
         )
@@ -1898,6 +1937,7 @@ class AgentGantry:
         """
         store = self._skills_store()
         await self._ensure_initialized()
+        await self._ensure_skill_vectors_current(store)
         query_embedding = await self._embedder.embed_text(query)
         filters: dict[str, Any] = {}
         if namespace is not None:

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -1872,9 +1872,15 @@ class AgentGantry:
         Limitations: switching to an embedder of a *different dimension*
         cannot be migrated in place on fixed-schema stores (LanceDB tables
         have a fixed vector width) — recreate the store instead; the failure
-        is surfaced with that guidance. And concurrent gantry instances using
+        is surfaced with that guidance. Concurrent gantry instances using
         *different* embedders against one shared store are unsupported: each
         would re-migrate to its own vector space, thrashing the other's.
+        And the lock here serializes tasks within this process only —
+        multiple worker *processes* sharing one embedded store path follow
+        the backend's multi-writer semantics (LanceDB's upsert is a
+        non-atomic delete-then-add), so serialize the first post-model-switch
+        access externally when running multiple workers, or let one worker
+        warm the store before the others start.
         """
         if self._skill_vectors_checked:
             return
@@ -1893,7 +1899,11 @@ class AgentGantry:
                 # Scope the marker to the skills table where the store names
                 # one: multiple configured skills tables can share a single
                 # metadata table (LanceDB), and an unscoped key would let one
-                # table's migration mark the others as migrated too.
+                # table's migration mark the others as migrated too. Adapter
+                # contract: stores whose metadata table is shared across
+                # differently-configured skills tables should expose
+                # _skills_table_name; stores without it get a store-wide
+                # marker, which is correct when metadata is per-store.
                 table_id = getattr(store, "_skills_table_name", None)
                 marker_key = (
                     f"skills_embedder_id:{table_id}" if table_id else "skills_embedder_id"

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -37,6 +37,7 @@ from agent_gantry.schema.config import (
 from agent_gantry.schema.introspection import build_parameters_schema
 from agent_gantry.schema.mcp import MCPServerDefinition
 from agent_gantry.schema.query import RetrievalResult, ScoredTool, ToolQuery
+from agent_gantry.schema.skill import Skill, SkillSearchResult
 from agent_gantry.schema.tool import ToolCapability, ToolDefinition
 from agent_gantry.utils.fingerprint import compute_tool_fingerprint
 
@@ -1812,6 +1813,135 @@ class AgentGantry:
                 result.append(tool)
 
         return result
+
+    # ------------------------------------------------------------------
+    # Skills — semantic procedural memory alongside tools: registered
+    # once, retrieved by meaning per prompt, and injected as context
+    # (never executed). Same embedder and vector store as tools.
+    # ------------------------------------------------------------------
+
+    def _skills_store(self) -> Any:
+        """Return the vector store if it supports skills, else raise."""
+        store = self._vector_store
+        if not hasattr(store, "add_skills"):
+            raise NotImplementedError(
+                f"{type(store).__name__} does not support skills. "
+                f"InMemoryVectorStore (default) and LanceDBVectorStore do."
+            )
+        return store
+
+    async def add_skill(self, skill: Skill) -> None:
+        """
+        Add a single skill. See :meth:`add_skills`.
+
+        Args:
+            skill: The skill to add
+        """
+        await self.add_skills([skill])
+
+    async def add_skills(self, skills: list[Skill]) -> int:
+        """
+        Embed and store skills for semantic retrieval.
+
+        Args:
+            skills: Skills to add (upserted by ``namespace.name``)
+
+        Returns:
+            Number of skills stored
+        """
+        if not skills:
+            return 0
+        store = self._skills_store()
+        await self._ensure_initialized()
+        embeddings = await self._embedder.embed_batch(
+            [skill.to_embedding_text() for skill in skills]
+        )
+        return int(await store.add_skills(skills, embeddings, upsert=True))
+
+    async def retrieve_skills(
+        self,
+        query: str,
+        limit: int = 3,
+        namespace: str | list[str] | None = None,
+        category: str | None = None,
+        score_threshold: float | None = None,
+    ) -> list[SkillSearchResult]:
+        """
+        Retrieve the skills most relevant to a query.
+
+        Args:
+            query: Natural-language query (typically the user prompt)
+            limit: Maximum number of skills to return
+            namespace: Optional namespace (or list of namespaces) filter
+            category: Optional ``SkillCategory`` value filter
+            score_threshold: Minimum similarity score (0-1)
+
+        Returns:
+            Scored skills, most relevant first
+        """
+        store = self._skills_store()
+        await self._ensure_initialized()
+        query_embedding = await self._embedder.embed_text(query)
+        filters: dict[str, Any] = {}
+        if namespace is not None:
+            filters["namespace"] = namespace
+        if category is not None:
+            filters["category"] = category
+        matches = await store.search_skills(
+            query_vector=query_embedding,
+            limit=limit,
+            filters=filters or None,
+            score_threshold=score_threshold,
+        )
+        # Clamp: float32 cosine can exceed 1.0 by rounding error, and the
+        # schema bounds score to [0, 1].
+        return [
+            SkillSearchResult(skill=skill, score=min(1.0, max(0.0, float(score))))
+            for skill, score in matches
+        ]
+
+    async def retrieve_skills_as_prompt(
+        self,
+        query: str,
+        limit: int = 3,
+        namespace: str | list[str] | None = None,
+        category: str | None = None,
+        score_threshold: float | None = None,
+    ) -> str:
+        """
+        Retrieve relevant skills formatted for system-prompt injection.
+
+        Returns an empty string when nothing matches, so the result can be
+        appended to a prompt unconditionally.
+        """
+        results = await self.retrieve_skills(
+            query,
+            limit=limit,
+            namespace=namespace,
+            category=category,
+            score_threshold=score_threshold,
+        )
+        return "\n\n".join(result.skill.to_prompt_text() for result in results)
+
+    async def delete_skill(self, name: str, namespace: str = "default") -> bool:
+        """Delete a skill by name."""
+        store = self._skills_store()
+        await self._ensure_initialized()
+        return bool(await store.delete_skill(name, namespace))
+
+    async def list_skills(
+        self, namespace: str | None = None, limit: int = 1000, offset: int = 0
+    ) -> list[Skill]:
+        """List stored skills."""
+        store = self._skills_store()
+        await self._ensure_initialized()
+        return list(await store.list_all_skills(namespace=namespace, limit=limit, offset=offset))
+
+    async def count_skills(self, namespace: str | None = None) -> int:
+        """Count stored skills."""
+        store = self._skills_store()
+        await self._ensure_initialized()
+        return int(await store.count_skills(namespace=namespace))
 
     async def delete_tool(self, name: str, namespace: str = "default") -> bool:
         """

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -1890,8 +1890,16 @@ class AgentGantry:
             get_meta = getattr(store, "get_metadata", None)
             set_meta = getattr(store, "set_metadata", None)
             if get_meta is not None and set_meta is not None:
+                # Scope the marker to the skills table where the store names
+                # one: multiple configured skills tables can share a single
+                # metadata table (LanceDB), and an unscoped key would let one
+                # table's migration mark the others as migrated too.
+                table_id = getattr(store, "_skills_table_name", None)
+                marker_key = (
+                    f"skills_embedder_id:{table_id}" if table_id else "skills_embedder_id"
+                )
                 current = self._sync_manager.get_embedder_id()
-                stored = await get_meta("skills_embedder_id")
+                stored = await get_meta(marker_key)
                 if stored != current:
                     # Unknown or different embedder: re-embed whatever is
                     # stored (covers both a model switch and pre-existing
@@ -1915,7 +1923,7 @@ class AgentGantry:
                             f"Re-embedded {len(skills)} skill(s): stored embedder id "
                             f"{stored!r} != current {current!r}"
                         )
-                    await set_meta("skills_embedder_id", current)
+                    await set_meta(marker_key, current)
             self._skill_vectors_checked = True
 
     async def add_skills(self, skills: list[Skill]) -> int:

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -217,8 +217,9 @@ class AgentGantry:
         """
         self._pending_tools: list[ToolDefinition] = []
         # One-shot guard for _ensure_skill_vectors_current (embedder is fixed
-        # for this instance's lifetime)
+        # for this instance's lifetime); lock created lazily on first use
         self._skill_vectors_checked = False
+        self._skill_vectors_lock: asyncio.Lock | None = None
         self._pending_mcp_servers: list[MCPServerDefinition] = []
         self._tool_handlers: dict[str, Callable[..., Any]] = {}
         # MCP clients created by add_mcp_server (immediate discovery), kept so
@@ -1870,28 +1871,36 @@ class AgentGantry:
         """
         if self._skill_vectors_checked:
             return
-        self._skill_vectors_checked = True
-        get_meta = getattr(store, "get_metadata", None)
-        set_meta = getattr(store, "set_metadata", None)
-        if get_meta is None or set_meta is None:
-            return
-        current = self._sync_manager.get_embedder_id()
-        stored = await get_meta("skills_embedder_id")
-        if stored == current:
-            return
-        # Unknown or different embedder: re-embed whatever is stored (covers
-        # both a model switch and pre-existing skills with no recorded id)
-        skills = await store.list_all_skills(limit=1_000_000)
-        if skills:
-            embeddings = await self._embedder.embed_batch(
-                [skill.to_embedding_text() for skill in skills]
-            )
-            await store.add_skills(skills, embeddings, upsert=True)
-            logger.info(
-                f"Re-embedded {len(skills)} skill(s): stored embedder id "
-                f"{stored!r} != current {current!r}"
-            )
-        await set_meta("skills_embedder_id", current)
+        # Serialize: concurrent first calls must not skip past an in-flight
+        # migration and search stale vectors, and the flag is only set after
+        # full success so a transient failure gets retried instead of
+        # permanently bypassing migration.
+        if self._skill_vectors_lock is None:
+            self._skill_vectors_lock = asyncio.Lock()
+        async with self._skill_vectors_lock:
+            if self._skill_vectors_checked:
+                return
+            get_meta = getattr(store, "get_metadata", None)
+            set_meta = getattr(store, "set_metadata", None)
+            if get_meta is not None and set_meta is not None:
+                current = self._sync_manager.get_embedder_id()
+                stored = await get_meta("skills_embedder_id")
+                if stored != current:
+                    # Unknown or different embedder: re-embed whatever is
+                    # stored (covers both a model switch and pre-existing
+                    # skills with no recorded id)
+                    skills = await store.list_all_skills(limit=1_000_000)
+                    if skills:
+                        embeddings = await self._embedder.embed_batch(
+                            [skill.to_embedding_text() for skill in skills]
+                        )
+                        await store.add_skills(skills, embeddings, upsert=True)
+                        logger.info(
+                            f"Re-embedded {len(skills)} skill(s): stored embedder id "
+                            f"{stored!r} != current {current!r}"
+                        )
+                    await set_meta("skills_embedder_id", current)
+            self._skill_vectors_checked = True
 
     async def add_skills(self, skills: list[Skill]) -> int:
         """

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -1864,10 +1864,17 @@ class AgentGantry:
 
         Tools get this via SyncManager's fingerprint/embedder-id machinery;
         skills need the equivalent or reopening a persistent store with a new
-        embedding model silently searches the old model's vectors (or fails
-        outright on a dimension change). Runs once per gantry instance — the
-        embedder is fixed for the instance's lifetime. Stores without the
-        metadata API skip the check (nothing to compare against).
+        embedding model silently searches the old model's vectors. Runs once
+        per gantry instance — the embedder is fixed for the instance's
+        lifetime. Stores without the metadata API skip the check (nothing to
+        compare against).
+
+        Limitations: switching to an embedder of a *different dimension*
+        cannot be migrated in place on fixed-schema stores (LanceDB tables
+        have a fixed vector width) — recreate the store instead; the failure
+        is surfaced with that guidance. And concurrent gantry instances using
+        *different* embedders against one shared store are unsupported: each
+        would re-migrate to its own vector space, thrashing the other's.
         """
         if self._skill_vectors_checked:
             return
@@ -1894,7 +1901,16 @@ class AgentGantry:
                         embeddings = await self._embedder.embed_batch(
                             [skill.to_embedding_text() for skill in skills]
                         )
-                        await store.add_skills(skills, embeddings, upsert=True)
+                        try:
+                            await store.add_skills(skills, embeddings, upsert=True)
+                        except Exception as exc:
+                            raise RuntimeError(
+                                f"Failed to re-embed stored skills for the current "
+                                f"embedder ({current!r}). If the new embedder has a "
+                                f"different dimension, fixed-schema stores (e.g. "
+                                f"LanceDB) cannot be migrated in place — recreate the "
+                                f"store, or use a same-dimension model."
+                            ) from exc
                         logger.info(
                             f"Re-embedded {len(skills)} skill(s): stored embedder id "
                             f"{stored!r} != current {current!r}"
@@ -1979,6 +1995,9 @@ class AgentGantry:
 
         Returns an empty string when nothing matches, so the result can be
         appended to a prompt unconditionally.
+
+        Skill content is injected into the prompt verbatim — register skills
+        only from sources you trust, exactly as you would tool descriptions.
         """
         results = await self.retrieve_skills(
             query,

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -1820,12 +1820,28 @@ class AgentGantry:
     # (never executed). Same embedder and vector store as tools.
     # ------------------------------------------------------------------
 
+    _SKILL_STORE_METHODS = (
+        "add_skills",
+        "search_skills",
+        "get_skill_by_name",
+        "delete_skill",
+        "list_all_skills",
+        "count_skills",
+    )
+
     def _skills_store(self) -> Any:
-        """Return the vector store if it supports skills, else raise."""
+        """Return the vector store if it supports skills, else raise.
+
+        Checks the full skill API surface up front so a partially
+        implemented adapter fails with this clear message instead of an
+        AttributeError from deep inside a later call.
+        """
         store = self._vector_store
-        if not hasattr(store, "add_skills"):
+        missing = [m for m in self._SKILL_STORE_METHODS if not hasattr(store, m)]
+        if missing:
             raise NotImplementedError(
-                f"{type(store).__name__} does not support skills. "
+                f"{type(store).__name__} does not support skills "
+                f"(missing: {', '.join(missing)}). "
                 f"InMemoryVectorStore (default) and LanceDBVectorStore do."
             )
         return store
@@ -1873,7 +1889,8 @@ class AgentGantry:
             query: Natural-language query (typically the user prompt)
             limit: Maximum number of skills to return
             namespace: Optional namespace (or list of namespaces) filter
-            category: Optional ``SkillCategory`` value filter
+            category: Optional category filter as its string value, e.g.
+                ``"how_to"`` or ``SkillCategory.PATTERN.value``
             score_threshold: Minimum similarity score (0-1)
 
         Returns:

--- a/agent_gantry/core/gantry.py
+++ b/agent_gantry/core/gantry.py
@@ -1978,6 +1978,11 @@ class AgentGantry:
         Returns:
             Scored skills, most relevant first
         """
+        # A blank query has no semantic signal: it embeds to a zero vector,
+        # every skill ties at 0.0, and with no threshold the first `limit`
+        # skills would be returned (and prompt-injected) arbitrarily.
+        if not query.strip():
+            return []
         store = self._skills_store()
         await self._ensure_initialized()
         await self._ensure_skill_vectors_current(store)

--- a/examples/basics/skills_example.py
+++ b/examples/basics/skills_example.py
@@ -1,0 +1,64 @@
+"""
+Semantic skill selection: procedural memory alongside tools.
+
+Skills are registered once, retrieved by meaning per prompt, and injected
+into the system prompt as contextual guidance — they are never executed.
+Works out of the box with the default in-memory store (LanceDB also
+supports skills for persistence).
+
+Run: python examples/basics/skills_example.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from agent_gantry import AgentGantry, Skill, SkillCategory
+
+
+async def main() -> None:
+    gantry = AgentGantry()
+
+    await gantry.add_skills(
+        [
+            Skill(
+                name="api_pagination",
+                description="How to implement cursor-based pagination for API endpoints",
+                content=(
+                    "Use cursor-based pagination rather than offset/limit: return an "
+                    "opaque cursor with each page and accept it on the next request. "
+                    "Offsets skew under concurrent writes; cursors do not."
+                ),
+                category=SkillCategory.HOW_TO,
+                tags=["api", "pagination", "rest"],
+                related_tools=["fetch_page"],
+            ),
+            Skill(
+                name="retry_backoff",
+                description="Pattern for retrying flaky network calls with exponential backoff",
+                content=(
+                    "Retry transient failures with exponential backoff plus jitter "
+                    "(e.g. 1s, 2s, 4s, 8s). Never retry non-idempotent operations "
+                    "without a dedupe key."
+                ),
+                category=SkillCategory.PATTERN,
+                tags=["network", "retry", "resilience"],
+            ),
+        ]
+    )
+
+    # Retrieve the most relevant skills for a prompt...
+    results = await gantry.retrieve_skills("my HTTP requests keep timing out", limit=1)
+    for result in results:
+        print(f"[{result.score:.2f}] {result.skill.qualified_name}")
+
+    # ...or get them pre-formatted for system-prompt injection
+    prompt_block = await gantry.retrieve_skills_as_prompt(
+        "my HTTP requests keep timing out", limit=1
+    )
+    print()
+    print(prompt_block)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-gantry"
-version = "0.9.0"
+version = "0.10.0"
 description = "Universal Tool Orchestration Platform - Intelligent, secure tool orchestration for LLM-based agent systems"
 readme = "README.md"
 license = "MIT"

--- a/tests/integration/test_vector_stores.py
+++ b/tests/integration/test_vector_stores.py
@@ -207,3 +207,30 @@ def test_qdrant_quantization_mode_validated() -> None:
 
     with pytest.raises(ValueError, match="Unsupported quantization mode"):
         QdrantVectorStore(url="http://localhost:6333", quantization="turbo")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_qdrant_binary_quantized_search(qdrant_url: str) -> None:
+    """Binary-quantized collections search correctly with exact rescoring."""
+    pytest.importorskip("qdrant_client")
+
+    from agent_gantry.adapters.vector_stores.remote import QdrantVectorStore
+
+    store = QdrantVectorStore(
+        url=qdrant_url,
+        collection_name="test_quantized_binary",
+        dimension=128,
+        quantization="binary",
+    )
+    embedder = SimpleEmbedder()
+    await store.initialize()
+
+    tools = _make_tools(5)
+    embeddings = await embedder.embed_batch([t.to_searchable_text() for t in tools])
+    assert await store.add_tools(tools, embeddings, upsert=True) == 5
+
+    query = await embedder.embed_text(tools[2].to_searchable_text())
+    results = await store.search(query_vector=query, limit=3)
+    assert results
+    assert results[0][0].name == tools[2].name

--- a/tests/integration/test_vector_stores.py
+++ b/tests/integration/test_vector_stores.py
@@ -169,3 +169,41 @@ async def test_pgvector_fingerprint_keys_align_with_sync_manager(pgvector_url: s
     stored = await store.get_stored_fingerprints()
     expected = {f"{t.namespace}.{t.name}": compute_tool_fingerprint(t) for t in tools}
     assert stored == expected
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_qdrant_quantized_search(qdrant_url: str) -> None:
+    """Scalar-quantized collections search correctly with exact rescoring."""
+    pytest.importorskip("qdrant_client")
+
+    from agent_gantry.adapters.vector_stores.remote import QdrantVectorStore
+
+    store = QdrantVectorStore(
+        url=qdrant_url,
+        collection_name="test_quantized",
+        dimension=128,
+        quantization="scalar",
+    )
+    embedder = SimpleEmbedder()
+    await store.initialize()
+
+    tools = _make_tools(5)
+    embeddings = await embedder.embed_batch([t.to_searchable_text() for t in tools])
+    assert await store.add_tools(tools, embeddings, upsert=True) == 5
+
+    query = await embedder.embed_text(tools[1].to_searchable_text())
+    results = await store.search(query_vector=query, limit=3)
+    assert results
+    # Rescoring against original vectors keeps the exact match on top
+    assert results[0][0].name == tools[1].name
+
+
+def test_qdrant_quantization_mode_validated() -> None:
+    """Bad quantization modes fail fast at construction."""
+    pytest.importorskip("qdrant_client")
+
+    from agent_gantry.adapters.vector_stores.remote import QdrantVectorStore
+
+    with pytest.raises(ValueError, match="Unsupported quantization mode"):
+        QdrantVectorStore(url="http://localhost:6333", quantization="turbo")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -173,3 +173,42 @@ async def test_gantry_add_skill_singular():
     gantry = AgentGantry()
     await gantry.add_skill(_make_skills()[0])
     assert await gantry.count_skills() == 1
+
+
+@pytest.mark.asyncio
+async def test_skills_reembedded_after_embedder_change():
+    """Reopening a store with a different embedder must re-embed persisted
+    skills — otherwise queries embed with the new model but search the old
+    model's vectors, silently returning wrong guidance."""
+    from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+    class ShiftedEmbedder(SimpleEmbedder):
+        """Same dimension, different vector space and identity."""
+
+        @property
+        def model_name(self) -> str:
+            return "shifted-model"
+
+        def get_embedder_id(self) -> str:
+            return f"shifted:{self.dimension}"
+
+        async def embed_text(self, text: str) -> list[float]:
+            base = await super().embed_text(text)
+            return list(reversed(base))
+
+        async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+            return [await self.embed_text(t) for t in texts]
+
+    store = InMemoryVectorStore()
+    skills = _make_skills()
+
+    gantry_a = AgentGantry(vector_store=store)
+    await gantry_a.add_skills(skills)
+
+    # Same store, different embedder: retrieval must self-heal by
+    # re-embedding, so an exact-text query still ranks its skill first with
+    # a perfect score
+    gantry_b = AgentGantry(vector_store=store, embedder=ShiftedEmbedder())
+    results = await gantry_b.retrieve_skills(skills[0].to_embedding_text(), limit=1)
+    assert results and results[0].skill.name == "api_pagination"
+    assert results[0].score == pytest.approx(1.0, abs=1e-5)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -147,3 +147,29 @@ async def test_gantry_skills_unsupported_store_raises():
     gantry = AgentGantry(vector_store=NoSkillsStore())  # type: ignore[arg-type]
     with pytest.raises(NotImplementedError, match="does not support skills"):
         await gantry.add_skills(_make_skills())
+
+
+@pytest.mark.asyncio
+async def test_memory_store_skill_upsert_false_skips_existing():
+    store = InMemoryVectorStore()
+    skill = _make_skills()[0]
+    await store.add_skills([skill], [[1.0, 0.0]])
+
+    updated = skill.model_copy(update={"content": "changed content"})
+    assert await store.add_skills([updated], [[0.0, 1.0]], upsert=False) == 0
+    stored = await store.get_skill_by_name("api_pagination")
+    assert stored is not None and stored.content != "changed content"
+
+
+@pytest.mark.asyncio
+async def test_memory_store_add_skills_length_mismatch_raises():
+    store = InMemoryVectorStore()
+    with pytest.raises(ValueError):
+        await store.add_skills(_make_skills()[:2], [[1.0, 0.0]])
+
+
+@pytest.mark.asyncio
+async def test_gantry_add_skill_singular():
+    gantry = AgentGantry()
+    await gantry.add_skill(_make_skills()[0])
+    assert await gantry.count_skills() == 1

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -447,3 +447,14 @@ async def test_lancedb_empty_namespace_list_matches_nothing(tmp_path):
     query = await embedder.embed_text("anything")
     assert await store.search_skills(query, limit=5, filters={"namespace": []}) == []
     assert await store.search(query, limit=5, filters={"namespace": []}) == []
+
+
+@pytest.mark.asyncio
+async def test_blank_query_retrieves_nothing():
+    """A blank query embeds to a zero vector where every skill ties at 0.0 —
+    it must return nothing rather than prompt-inject arbitrary guidance."""
+    gantry = AgentGantry()
+    await gantry.add_skills(_make_skills())
+    assert await gantry.retrieve_skills("") == []
+    assert await gantry.retrieve_skills("   ") == []
+    assert await gantry.retrieve_skills_as_prompt("") == ""

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -294,3 +294,24 @@ async def test_skill_migration_retries_after_transient_failure():
     results = await gantry_b.retrieve_skills(query, limit=1)
     assert results and results[0].skill.name == "api_pagination"
     assert results[0].score == pytest.approx(1.0, abs=1e-5)
+
+
+@pytest.mark.asyncio
+async def test_lancedb_list_all_skills_propagates_table_errors(tmp_path):
+    """Table-level listing errors must propagate — returning [] on failure is
+    indistinguishable from an empty store, which let the embedder-migration
+    check record success after listing nothing."""
+    pytest.importorskip("lancedb")
+
+    from agent_gantry.adapters.vector_stores.lancedb import LanceDBVectorStore
+
+    store = LanceDBVectorStore(db_path=str(tmp_path / "db"), dimension=8)
+    await store.initialize()
+
+    class BrokenTable:
+        def search(self):
+            raise RuntimeError("table exploded")
+
+    store._skills_table = BrokenTable()
+    with pytest.raises(RuntimeError, match="table exploded"):
+        await store.list_all_skills()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -212,3 +212,85 @@ async def test_skills_reembedded_after_embedder_change():
     results = await gantry_b.retrieve_skills(skills[0].to_embedding_text(), limit=1)
     assert results and results[0].skill.name == "api_pagination"
     assert results[0].score == pytest.approx(1.0, abs=1e-5)
+
+
+def _shifted_embedder_cls():
+    from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+
+    class ShiftedEmbedder(SimpleEmbedder):
+        @property
+        def model_name(self) -> str:
+            return "shifted-model"
+
+        def get_embedder_id(self) -> str:
+            return f"shifted:{self.dimension}"
+
+        async def embed_text(self, text: str) -> list[float]:
+            return list(reversed(await super().embed_text(text)))
+
+        async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+            return [await self.embed_text(t) for t in texts]
+
+    return ShiftedEmbedder
+
+
+@pytest.mark.asyncio
+async def test_concurrent_retrievals_wait_for_skill_migration():
+    """Concurrent first calls must not skip past an in-flight re-embed and
+    search stale vectors."""
+    import asyncio
+
+    store = InMemoryVectorStore()
+    skills = _make_skills()
+    gantry_a = AgentGantry(vector_store=store)
+    await gantry_a.add_skills(skills)
+
+    # Slow the migration's skill listing so a second caller overlaps it
+    original_list = store.list_all_skills
+
+    async def slow_list(*args, **kwargs):
+        await asyncio.sleep(0.05)
+        return await original_list(*args, **kwargs)
+
+    store.list_all_skills = slow_list  # type: ignore[method-assign]
+
+    gantry_b = AgentGantry(vector_store=store, embedder=_shifted_embedder_cls()())
+    query = skills[0].to_embedding_text()
+    first, second = await asyncio.gather(
+        gantry_b.retrieve_skills(query, limit=1),
+        gantry_b.retrieve_skills(query, limit=1),
+    )
+    for results in (first, second):
+        assert results and results[0].skill.name == "api_pagination"
+        assert results[0].score == pytest.approx(1.0, abs=1e-5)
+
+
+@pytest.mark.asyncio
+async def test_skill_migration_retries_after_transient_failure():
+    """A transient failure mid-migration must not permanently mark the
+    migration complete — the next call retries it."""
+    store = InMemoryVectorStore()
+    skills = _make_skills()
+    gantry_a = AgentGantry(vector_store=store)
+    await gantry_a.add_skills(skills)
+
+    original_get = store.get_metadata
+    calls = {"n": 0}
+
+    async def flaky_get(key: str):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient metadata outage")
+        return await original_get(key)
+
+    store.get_metadata = flaky_get  # type: ignore[method-assign]
+
+    gantry_b = AgentGantry(vector_store=store, embedder=_shifted_embedder_cls()())
+    query = skills[0].to_embedding_text()
+    with pytest.raises(RuntimeError, match="transient metadata outage"):
+        await gantry_b.retrieve_skills(query, limit=1)
+
+    # Retry migrates and succeeds
+    results = await gantry_b.retrieve_skills(query, limit=1)
+    assert results and results[0].skill.name == "api_pagination"
+    assert results[0].score == pytest.approx(1.0, abs=1e-5)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,149 @@
+"""
+Tests for semantic skill selection: the in-memory store's skill support and
+the AgentGantry facade API (add/retrieve/prompt-injection/delete/list/count).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_gantry import AgentGantry, Skill, SkillCategory
+from agent_gantry.adapters.vector_stores.memory import InMemoryVectorStore
+
+
+def _make_skills() -> list[Skill]:
+    return [
+        Skill(
+            name="api_pagination",
+            description="How to implement cursor-based pagination for API endpoints",
+            content="Use cursor-based pagination: return an opaque cursor per page...",
+            category=SkillCategory.HOW_TO,
+            tags=["api", "pagination"],
+            related_tools=["fetch_page"],
+        ),
+        Skill(
+            name="retry_backoff",
+            description="Pattern for retrying flaky network calls with exponential backoff",
+            content="Retry with exponential backoff and jitter: 1s, 2s, 4s...",
+            category=SkillCategory.PATTERN,
+            tags=["network", "retry"],
+        ),
+        Skill(
+            name="db_migration",
+            description="Procedure for running database schema migrations safely",
+            content="Always back up before migrating. Apply migrations in a transaction...",
+            category=SkillCategory.PROCEDURE,
+            namespace="ops",
+            tags=["database"],
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# InMemoryVectorStore skill support
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_store_skill_crud():
+    store = InMemoryVectorStore()
+    skills = _make_skills()
+    embeddings = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+
+    assert await store.add_skills(skills, embeddings) == 3
+    assert await store.count_skills() == 3
+    assert await store.count_skills(namespace="ops") == 1
+
+    fetched = await store.get_skill_by_name("api_pagination")
+    assert fetched is not None and fetched.category == SkillCategory.HOW_TO
+
+    listed = await store.list_all_skills(namespace="default")
+    assert {s.name for s in listed} == {"api_pagination", "retry_backoff"}
+
+    assert await store.delete_skill("db_migration", namespace="ops") is True
+    assert await store.count_skills() == 2
+    assert await store.delete_skill("db_migration", namespace="ops") is False
+
+
+@pytest.mark.asyncio
+async def test_memory_store_skill_search_and_filters():
+    store = InMemoryVectorStore()
+    skills = _make_skills()
+    embeddings = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    await store.add_skills(skills, embeddings)
+
+    results = await store.search_skills(query_vector=[1.0, 0.0, 0.0], limit=2)
+    assert results[0][0].name == "api_pagination"
+    assert results[0][1] == pytest.approx(1.0)
+
+    # Category filter
+    results = await store.search_skills(
+        query_vector=[1.0, 0.0, 0.0], limit=5, filters={"category": "pattern"}
+    )
+    assert {s.name for s, _ in results} == {"retry_backoff"}
+
+    # Namespace filter
+    results = await store.search_skills(
+        query_vector=[1.0, 0.0, 0.0], limit=5, filters={"namespace": "ops"}
+    )
+    assert {s.name for s, _ in results} == {"db_migration"}
+
+    # Score threshold prunes orthogonal matches
+    results = await store.search_skills(
+        query_vector=[1.0, 0.0, 0.0], limit=5, score_threshold=0.5
+    )
+    assert {s.name for s, _ in results} == {"api_pagination"}
+
+    # Mismatched query dimension degrades gracefully
+    assert await store.search_skills(query_vector=[1.0, 0.0], limit=5) == []
+
+
+# ---------------------------------------------------------------------------
+# AgentGantry facade
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gantry_skill_roundtrip():
+    gantry = AgentGantry()
+    skills = _make_skills()
+    assert await gantry.add_skills(skills) == 3
+    assert await gantry.count_skills() == 3
+
+    # Identical text embeds to the identical vector, so querying with a
+    # skill's own embedding text must rank that skill first regardless of
+    # which embedder backs the store.
+    results = await gantry.retrieve_skills(skills[0].to_embedding_text(), limit=2)
+    assert results and results[0].skill.name == "api_pagination"
+    assert results[0].score == pytest.approx(1.0, abs=1e-5)
+
+    prompt = await gantry.retrieve_skills_as_prompt(skills[0].to_embedding_text(), limit=1)
+    assert "Api Pagination" in prompt
+    assert "cursor-based pagination" in prompt
+    assert "Related tools: fetch_page" in prompt
+
+    # Namespace + category filters pass through
+    ops_only = await gantry.retrieve_skills(
+        skills[2].to_embedding_text(), limit=5, namespace="ops"
+    )
+    assert {r.skill.name for r in ops_only} == {"db_migration"}
+
+    assert await gantry.delete_skill("retry_backoff") is True
+    assert await gantry.count_skills() == 2
+    assert {s.name for s in await gantry.list_skills()} == {"api_pagination", "db_migration"}
+
+
+@pytest.mark.asyncio
+async def test_gantry_skill_prompt_empty_when_no_match():
+    gantry = AgentGantry()
+    assert await gantry.retrieve_skills_as_prompt("anything") == ""
+
+
+@pytest.mark.asyncio
+async def test_gantry_skills_unsupported_store_raises():
+    class NoSkillsStore:
+        async def initialize(self) -> None: ...
+
+    gantry = AgentGantry(vector_store=NoSkillsStore())  # type: ignore[arg-type]
+    with pytest.raises(NotImplementedError, match="does not support skills"):
+        await gantry.add_skills(_make_skills())

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -373,3 +373,46 @@ async def test_gantry_skill_roundtrip_lancedb(tmp_path):
     assert await gantry.delete_skill("retry_backoff") is True
     assert await gantry.count_skills() == 2
     assert {s.name for s in await gantry.list_skills()} == {"api_pagination", "db_migration"}
+
+
+@pytest.mark.asyncio
+async def test_lancedb_search_skills_combines_namespace_and_category(tmp_path):
+    """LanceDB's .where() is a setter — a second call replaces the first
+    predicate, so namespace+category must be combined into one clause or the
+    namespace constraint is silently dropped."""
+    pytest.importorskip("lancedb")
+
+    from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+    from agent_gantry.adapters.vector_stores.lancedb import LanceDBVectorStore
+
+    embedder = SimpleEmbedder()
+    store = LanceDBVectorStore(db_path=str(tmp_path / "db"), dimension=embedder.dimension)
+    await store.initialize()
+
+    skills = [
+        Skill(
+            name="how_a",
+            namespace="ns_a",
+            description="how-to skill living in namespace a",
+            content="a",
+            category=SkillCategory.HOW_TO,
+        ),
+        Skill(
+            name="how_b",
+            namespace="ns_b",
+            description="how-to skill living in namespace b",
+            content="b",
+            category=SkillCategory.HOW_TO,
+        ),
+    ]
+    embeddings = await embedder.embed_batch([s.to_embedding_text() for s in skills])
+    await store.add_skills(skills, embeddings)
+
+    query = await embedder.embed_text(skills[1].to_embedding_text())
+    results = await store.search_skills(
+        query_vector=query,
+        limit=10,
+        filters={"namespace": "ns_a", "category": "how_to"},
+    )
+    names = {s.name for s, _ in results}
+    assert names == {"how_a"}, f"namespace filter dropped: got {names}"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -348,3 +348,28 @@ async def test_skill_embedder_marker_scoped_per_table():
     results = await gantry_b.retrieve_skills(query, limit=1)
     assert results and results[0].skill.name == "api_pagination"
     assert results[0].score == pytest.approx(1.0, abs=1e-5)
+
+
+@pytest.mark.asyncio
+async def test_gantry_skill_roundtrip_lancedb(tmp_path):
+    """Full facade round trip against the other skill-capable store."""
+    pytest.importorskip("lancedb")
+
+    from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+    from agent_gantry.adapters.vector_stores.lancedb import LanceDBVectorStore
+
+    embedder = SimpleEmbedder()
+    store = LanceDBVectorStore(db_path=str(tmp_path / "db"), dimension=embedder.dimension)
+    gantry = AgentGantry(vector_store=store, embedder=embedder)
+
+    skills = _make_skills()
+    assert await gantry.add_skills(skills) == 3
+    assert await gantry.count_skills() == 3
+
+    results = await gantry.retrieve_skills(skills[0].to_embedding_text(), limit=2)
+    assert results and results[0].skill.name == "api_pagination"
+    assert results[0].score == pytest.approx(1.0, abs=1e-2)
+
+    assert await gantry.delete_skill("retry_backoff") is True
+    assert await gantry.count_skills() == 2
+    assert {s.name for s in await gantry.list_skills()} == {"api_pagination", "db_migration"}

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -416,3 +416,34 @@ async def test_lancedb_search_skills_combines_namespace_and_category(tmp_path):
     )
     names = {s.name for s, _ in results}
     assert names == {"how_a"}, f"namespace filter dropped: got {names}"
+
+
+@pytest.mark.asyncio
+async def test_memory_add_skills_mismatch_mutates_nothing():
+    """A length mismatch must fail before any mutation — a strict zip alone
+    stores the matching prefix behind the failed call."""
+    store = InMemoryVectorStore()
+    with pytest.raises(ValueError):
+        await store.add_skills(_make_skills()[:2], [[1.0, 0.0]])
+    assert await store.count_skills() == 0
+
+
+@pytest.mark.asyncio
+async def test_lancedb_empty_namespace_list_matches_nothing(tmp_path):
+    """namespace=[] must return no matches, not build invalid 'IN ()' SQL."""
+    pytest.importorskip("lancedb")
+
+    from agent_gantry.adapters.embedders.simple import SimpleEmbedder
+    from agent_gantry.adapters.vector_stores.lancedb import LanceDBVectorStore
+
+    embedder = SimpleEmbedder()
+    store = LanceDBVectorStore(db_path=str(tmp_path / "db"), dimension=embedder.dimension)
+    await store.initialize()
+
+    skills = _make_skills()
+    embeddings = await embedder.embed_batch([s.to_embedding_text() for s in skills])
+    await store.add_skills(skills, embeddings)
+
+    query = await embedder.embed_text("anything")
+    assert await store.search_skills(query, limit=5, filters={"namespace": []}) == []
+    assert await store.search(query, limit=5, filters={"namespace": []}) == []

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -315,3 +315,36 @@ async def test_lancedb_list_all_skills_propagates_table_errors(tmp_path):
     store._skills_table = BrokenTable()
     with pytest.raises(RuntimeError, match="table exploded"):
         await store.list_all_skills()
+
+
+@pytest.mark.asyncio
+async def test_skill_embedder_marker_scoped_per_table():
+    """One store path can host multiple named skills tables sharing a single
+    metadata table (LanceDB): migrating one table must not mark the others
+    as migrated."""
+    shared_meta: dict[str, str] = {}
+
+    class NamedTableStore(InMemoryVectorStore):
+        def __init__(self, name: str) -> None:
+            super().__init__()
+            self._skills_table_name = name
+            self._metadata = shared_meta  # simulate the shared metadata table
+
+    store_a = NamedTableStore("skills_a")
+    store_b = NamedTableStore("skills_b")
+    skills = _make_skills()
+
+    # Both tables hold vectors from the default embedder
+    await AgentGantry(vector_store=store_a).add_skills(skills)
+    await AgentGantry(vector_store=store_b).add_skills(skills)
+
+    shifted = _shifted_embedder_cls()
+    # Migrate table A to the shifted embedder
+    await AgentGantry(vector_store=store_a, embedder=shifted()).retrieve_skills("q")
+
+    # Table B must still migrate for its own gantry — A's marker is not B's
+    gantry_b = AgentGantry(vector_store=store_b, embedder=shifted())
+    query = skills[0].to_embedding_text()
+    results = await gantry_b.retrieve_skills(query, limit=1)
+    assert results and results[0].skill.name == "api_pagination"
+    assert results[0].score == pytest.approx(1.0, abs=1e-5)

--- a/uv.lock
+++ b/uv.lock
@@ -473,7 +473,7 @@ wheels = [
 
 [[package]]
 name = "agent-gantry"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Summary

Cuts the **v0.10.0** release. This PR carries two commits:

1. **Semantic skill selection + Qdrant quantized vector search** (rebased from the post-merge tail of #336):
   - `AgentGantry` gains a skill facade — `add_skill(s)`, `retrieve_skills`, `retrieve_skills_as_prompt` (pre-formatted system-prompt block), `delete_skill`, `list_skills`, `count_skills` — sharing the tools' embedder and vector store. The default `InMemoryVectorStore` implements the full skill API (namespace/category filters, per-dimension matrices), joining LanceDB which already persisted skills; unsupported stores raise a clear `NotImplementedError`. `Skill`/`SkillCategory`/`SkillSearchResult` exported top-level, runnable example under `examples/basics/`, dedicated test suite.
   - `QdrantVectorStore(quantization="scalar"|"binary")`: int8 scalar (~4x smaller vectors, in-RAM, minimal recall loss) or binary (~32x) quantization at collection creation, with searches oversampling and rescoring against original vectors so scores stay exact. Mode validated at construction; service-gated integration tests.
   - Also removes stray patch-tool garbage previously committed at the tail of `adapters/vector_stores/README.md`.

2. **Release prep** per RELEASING.md: version bumped to `0.10.0` in both sources of record (`pyproject.toml`, `agent_gantry.__version__`), CHANGELOG section dated 2026-08-07 with compare links updated.

Version rationale: the release contains documented **BREAKING** changes (notably the `LLMConfig.model` default moving to `gpt-5.4-mini`), so a 0.x minor bump per semver's pre-1.0 allowances.

## Verification

- Full suite: 925 passed, 72 skipped locally; MCP suites additionally verified against mcp 2.0 in a separate venv
- `ruff check` clean; `tests/test_version_consistency.py` passes
- `uv build` produces `agent_gantry-0.10.0` sdist + wheel

## After merge

Run **Actions → Publish to PyPI → Run workflow** on `main` with target `pypi` — that publishes, tags `v0.10.0`, and creates the GitHub Release in one run (per RELEASING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbsgc65S64Bfe7Jnv1S7wc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rbsgc65S64Bfe7Jnv1S7wc)_