### PR TITLE
🛡️ Sentinel: [HIGH] Fix CRLF injection in execution and event models

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -89,3 +89,8 @@
 **Vulnerability:** The `AgentSkill` and `AgentCard` models lacked identifier validation for `id` and `name` fields, making them vulnerable to newline injection. This could lead to downstream log injection or command injection.
 **Learning:** Security validations for common schema patterns (like identifier sanitation) must be universally applied across all analogous models within a system (e.g., tools, MCP servers, skills, and A2A agents).
 **Prevention:** Always implement explicit string character checks (using `reject_newlines`) with `@field_validator` on all identifier fields across all Pydantic models. Ensure `model_config = ConfigDict(validate_assignment=True)` is set so these constraints cannot be bypassed after object instantiation.
+
+## 2026-08-09 - Fix CRLF injection in execution and event models
+**Vulnerability:** Execution and event models lack newline validation on identifier fields.
+**Learning:** Identifier sanitization needs to be universally applied to all schema models to avoid CRLF injection.
+**Prevention:** Implement reject_newlines field_validator and validate_assignment=True on all schemas.

--- a/agent_gantry/schema/config.py
+++ b/agent_gantry/schema/config.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from agent_gantry.schema.base import reject_newlines
 
 
 class VectorStoreConfig(BaseModel):
@@ -131,6 +133,10 @@ class MCPServerConfig(BaseModel):
     env: dict[str, str] = Field(default_factory=dict)
     namespace: str = "default"
 
+    model_config = ConfigDict(validate_assignment=True)
+
+    _reject_newline_identifiers = field_validator("name", "namespace")(reject_newlines)
+
 
 class MCPConfig(BaseModel):
     """Configuration for MCP integration."""
@@ -146,6 +152,10 @@ class A2AAgentConfig(BaseModel):
     name: str
     url: str
     namespace: str = "default"
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    _reject_newline_identifiers = field_validator("name", "namespace")(reject_newlines)
 
 
 class A2AConfig(BaseModel):

--- a/agent_gantry/schema/events.py
+++ b/agent_gantry/schema/events.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from agent_gantry.schema.base import reject_newlines
 from agent_gantry.schema.tool import ToolHealth
 
 
@@ -27,6 +28,10 @@ class RetrievalEvent(BaseModel):
     scores: list[float]
     filters_applied: dict[str, Any] = Field(default_factory=dict)
 
+    model_config = ConfigDict(validate_assignment=True)
+
+    _reject_newline_identifiers = field_validator("trace_id")(reject_newlines)
+
 
 class ExecutionEvent(BaseModel):
     """Event emitted after a tool execution."""
@@ -41,6 +46,12 @@ class ExecutionEvent(BaseModel):
     error: str | None = None
     error_type: str | None = None
 
+    model_config = ConfigDict(validate_assignment=True)
+
+    _reject_newline_identifiers = field_validator("trace_id", "span_id", "tool_name")(
+        reject_newlines
+    )
+
 
 class HealthChangeEvent(BaseModel):
     """Event emitted when a tool's health status changes."""
@@ -50,6 +61,10 @@ class HealthChangeEvent(BaseModel):
     old_health: ToolHealth
     new_health: ToolHealth
     reason: str
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    _reject_newline_identifiers = field_validator("tool_name")(reject_newlines)
 
 
 class TokenUsageEvent(BaseModel):
@@ -66,3 +81,7 @@ class TokenUsageEvent(BaseModel):
     saved_prompt_tokens: int | None = None
     savings_pct: float | None = None
     trace_id: str | None = None
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    _reject_newline_identifiers = field_validator("trace_id")(reject_newlines)

--- a/agent_gantry/schema/execution.py
+++ b/agent_gantry/schema/execution.py
@@ -11,7 +11,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from agent_gantry.schema.base import reject_newlines
 
 
 class ExecutionStatus(str, Enum):
@@ -39,6 +41,12 @@ class ToolCall(BaseModel):
     trace_id: str | None = None
     parent_span_id: str | None = None
 
+    model_config = ConfigDict(validate_assignment=True)
+
+    _reject_newline_identifiers = field_validator("tool_name", "trace_id", "parent_span_id")(
+        reject_newlines
+    )
+
 
 class ToolResult(BaseModel):
     """Result of a tool execution."""
@@ -58,6 +66,12 @@ class ToolResult(BaseModel):
 
     trace_id: str
     span_id: str
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    _reject_newline_identifiers = field_validator("tool_name", "trace_id", "span_id")(
+        reject_newlines
+    )
 
     @property
     def latency_ms(self) -> float:

--- a/agent_gantry/schema/query.py
+++ b/agent_gantry/schema/query.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from agent_gantry.schema.base import reject_newlines
 from agent_gantry.schema.tool import ToolCapability, ToolDefinition, ToolSource
 
 
@@ -109,6 +110,10 @@ class RetrievalResult(BaseModel):
     filtered_count: int
 
     trace_id: str
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    _reject_newline_identifiers = field_validator("trace_id")(reject_newlines)
 
     def to_openai_tools(self) -> list[dict[str, Any]]:
         """


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Execution and event models lacked newline validation on identifier fields, which could allow log injection and CRLF injection vulnerabilities via trailing newlines.
🎯 Impact: Attackers could inject arbitrary log entries or HTTP headers through malformed tool identifiers or trace IDs.
🔧 Fix: Applied `reject_newlines` `@field_validator` across all remaining schema models including `ToolCall`, `ToolResult`, `Events`, `Config`, and `RetrievalResult`, alongside `validate_assignment=True`.
✅ Verification: Ran `pytest` tests to verify behavior and ran `ruff` to format.

---
*PR created automatically by Jules for task [16674739821240824942](https://jules.google.com/task/16674739821240824942) started by @CodeHalwell*